### PR TITLE
Fix wp-cli "wp_is_mobile()" fatal error when installing themes

### DIFF
--- a/widgets/so-slider-widget/so-slider-widget.php
+++ b/widgets/so-slider-widget/so-slider-widget.php
@@ -165,7 +165,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget {
 			array( 'jquery' ),
 			SOW_BUNDLE_VERSION
 		);
-		if( wp_is_mobile() ) {
+		if( function_exists( 'wp_is_mobile' ) && wp_is_mobile() ) {
 			$frontend_scripts[] = array(
 				'sow-slider-slider-cycle2-swipe',
 				siteorigin_widget_get_plugin_dir_url( 'slider' ) . 'js/jquery.cycle.swipe' . SOW_BUNDLE_JS_SUFFIX . '.js',


### PR DESCRIPTION
When using [wp-cli](http://wp-cli.org)'s `wp theme install` command with the so-widgets-bundle plugin activated, I would get a Fatal Error on the line that called `wp_is_mobile()`. This error is corrected if I check for the existence of `wp_is_mobile()` first.

I suspect that wp-cli isn't loading all of WP's functionality to do its job.