### PR TITLE
apply filter to capability of admin page

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -214,7 +214,7 @@ class SiteOrigin_Widgets_Bundle {
 	 */
 	function admin_ajax_manage_handler(){
 		if(!wp_verify_nonce($_GET['_wpnonce'], 'manage_so_widget')) exit();
-		if(!current_user_can('install_plugins')) exit();
+		if(!current_user_can(apply_filters('siteorigin_widgets_admin_menu_capability', 'install_plugins'))) exit();
 		if(empty($_GET['widget'])) exit();
 
 		if( $_POST['active'] == 'true' ) $this->activate_widget($_GET['widget']);

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -235,7 +235,7 @@ class SiteOrigin_Widgets_Bundle {
 		add_plugins_page(
 			__('SiteOrigin Widgets', 'siteorigin-widgets'),
 			__('SiteOrigin Widgets', 'siteorigin-widgets'),
-			'install_plugins',
+			apply_filters('siteorigin_widgets_admin_menu_capability', 'install_plugins'),
 			'so-widgets-plugins',
 			array($this, 'admin_page')
 		);


### PR DESCRIPTION
I want to filter the capability of the admin page. At the moment it is not possible to access the page if DISALLOW_FILE_MODS is set to true. Would be nice to see it in the next release.