### PR TITLE
Use set_url_scheme() when enqueueing css

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -189,7 +189,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 						if ( ! wp_style_is( $css_name ) ) {
 							wp_enqueue_style(
 								$css_name,
-								$upload_dir['baseurl'] . '/siteorigin-widgets/' . $css_name .'.css'
+								set_url_scheme($upload_dir['baseurl'] . '/siteorigin-widgets/' . $css_name .'.css')
 							);
 						}
 					}


### PR DESCRIPTION
Fixes #14 

I've wrapped the enqueued widget css url in set_url_scheme() as it will check if SSL is being used and correct the url to https if it is.