### PR TITLE
FB 873: Image Grid widget URL field not working

### DIFF
--- a/widgets/so-image-grid-widget/so-image-grid-widget.php
+++ b/widgets/so-image-grid-widget/so-image-grid-widget.php
@@ -38,8 +38,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 							'label' => __('Image title', 'so-widgets-bundle')
 						),
 						'url' => array(
-							'type' => 'text',
-							'sanitize' => 'url',
+							'type' => 'link',
 							'label' => __('URL', 'so-widgets-bundle')
 						),
 					)

--- a/widgets/so-image-grid-widget/tpl/default.php
+++ b/widgets/so-image-grid-widget/tpl/default.php
@@ -6,9 +6,11 @@
 		<?php
 		foreach( $instance['images'] as $image ) {
 			echo '<div class="sow-image-grid-image">';
+			if ( ! empty( $image['url'] ) ) echo '<a href="' . sow_esc_url( $image['url'] ) . '">';
 			echo wp_get_attachment_image( $image['image'], $image['display']['image_size'], false, array(
 				'title' => $image['title']
 			) );
+			if ( ! empty( $image['url'] ) ) echo '</a>';
 			echo '</div>';
 		}
 		?>


### PR DESCRIPTION
Changed the url input field type to 'link' to and added missing `<a>` tag to template.