### PR TITLE
Prefix function name in Google Map widget

### DIFF
--- a/widgets/so-google-map-widget/js/js-map.js
+++ b/widgets/so-google-map-widget/js/js-map.js
@@ -154,7 +154,7 @@ function loadMap($) {
 function loadApi($) {
     var apiKey = $('.sow-google-map-canvas').data('api-key');
 
-    var apiUrl = 'https://maps.googleapis.com/maps/api/js?v=3.exp&callback=initialize';
+    var apiUrl = 'https://maps.googleapis.com/maps/api/js?v=3.exp&callback=soGoogleMapInitialize';
     if(apiKey) {
         apiUrl += '&key=' + apiKey;
     }
@@ -162,7 +162,7 @@ function loadApi($) {
     $('body').append(script);
 }
 
-function initialize() {
+function soGoogleMapInitialize() {
     loadMap(window.jQuery);
 }
 


### PR DESCRIPTION
Hello.

We ran into an issue where the Google Map widget sometimes wouldn't appear. This turned out to be loadApi() which loads the required script and gives it the callback initialize() function. What would happen is that, depending on execution order, the initialize() function could be overwritten before the script the google script finished running and then the wrong function would be called.

The conflicting function with the same name initialize() was in the "UDG Tagging & Testing Extension" plugin, and this would get called instead of the intended one here. Therefore the map widgets would never appear.

My suggestion is to just rename the function to something more obscure and less likely to conflict. It's less of an issue with other function names as JavaScript scoping rules normally capture the correct function. However, in the case of the google api callback this does not happen.

Of course, alternatively I could just ask the other plugin to change the function name. But they're German speaking (only) and haven't applied another bug fix I sent them in the past. So it would be really great if you could accept this pull request to avoid this conflict. I suspect a similar thing might happen with other plugins and theme code also.

Kind regards and all the best,
Shanee Vanstone.