### PR TITLE
Add support for srcset to Image widget

### DIFF
--- a/widgets/image/tpl/base.php
+++ b/widgets/image/tpl/base.php
@@ -13,6 +13,9 @@ if( !empty($src) ) {
 
 	if(!empty($src[1])) $attr['width'] = $src[1];
 	if(!empty($src[2])) $attr['height'] = $src[2];
+	if (function_exists('wp_get_attachment_image_srcset')) {
+		$attr['srcset'] = esc_attr(wp_get_attachment_image_srcset($instance['image'], $instance['size']));
+ 	}
 }
 
 $styles = array();

--- a/widgets/image/tpl/base.php
+++ b/widgets/image/tpl/base.php
@@ -14,7 +14,7 @@ if( !empty($src) ) {
 	if(!empty($src[1])) $attr['width'] = $src[1];
 	if(!empty($src[2])) $attr['height'] = $src[2];
 	if (function_exists('wp_get_attachment_image_srcset')) {
-		$attr['srcset'] = esc_attr(wp_get_attachment_image_srcset($instance['image'], $instance['size']));
+		$attr['srcset'] = wp_get_attachment_image_srcset($instance['image'], $instance['size']);
  	}
 }
 


### PR DESCRIPTION
Wordpress 4.4 adds support for responsive images via srcset to images added through the visual editor. However, these changes don't get applied to the Site Origin Image Widget. This change uses the new Wordpress wp_get_attachment_image_srcset function to add the required attributes to the widget.