### PR TITLE
Updating wysiwyg editor images to be responsive

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -67,6 +67,9 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 		if( !empty($GLOBALS['wp_embed']) ) {
 			$instance['text'] = $GLOBALS['wp_embed']->autoembed( $instance['text'] );
 		}
+		if (function_exists('wp_make_content_images_responsive')) {
+			$instance['text'] = wp_make_content_images_responsive( $instance['text'] );
+		}
 		if( $instance['autop'] ) {
 			$instance['text'] = wpautop( $instance['text'] );
 		}


### PR DESCRIPTION
Related to #43, I realized images from the editor widget weren't getting srcset attributes either. This PR fixes that for WP 4.4 while being backward compatible.