### PR TITLE
Allow LatLong input for Google Maps widget center and markers.

### DIFF
--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -225,8 +225,8 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 
 	public function sanitize_instance( $instance ) {
 		$selected_editor_name = $this->get_selected_editor_field_name( $this->base_name );
-		$selected_editor = $instance[ $selected_editor_name ];
-		if( ! empty( $selected_editor ) ) {
+		if( ! empty( $instance[ $selected_editor_name ] ) ) {
+			$selected_editor = $instance[ $selected_editor_name ];
 			$instance[ $selected_editor_name ] = in_array( $selected_editor, array( 'tinymce', 'tmce', 'html' ) ) ? $selected_editor : $this->default_editor;
 		}
 		return $instance;
@@ -236,7 +236,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		$v_name = $base_name;
 		if( strpos($v_name, '][') !== false ) {
 			// Remove this splitter
-			$v_name = substr( $v_name, strpos($v_name, '][') + 2 );
+			$v_name = substr( $v_name, strrpos($v_name, '][') + 2 );
 		}
 		return $v_name . '_selected_editor';
 	}

--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -409,34 +409,36 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 			);
 		} else {
 			$markers         = $instance['markers'];
-			$directions_json = '';
+			$directions = '';
 			if ( ! empty( $instance['directions']['origin'] ) && ! empty( $instance['directions']['destination'] ) ) {
 				if ( empty( $instance['directions']['waypoints'] ) ) {
 					unset( $instance['directions']['waypoints'] );
 				}
-				$directions_json = json_encode( siteorigin_widgets_underscores_to_camel_case( $instance['directions'] ) );
+				$directions = siteorigin_widgets_underscores_to_camel_case( $instance['directions'] );
 			}
+
+			$map_data = siteorigin_widgets_underscores_to_camel_case( array(
+				'address'           => $instance['map_center'],
+				'zoom'              => $settings['zoom'],
+				'scroll_zoom'       => $settings['scroll_zoom'],
+				'draggable'         => $settings['draggable'],
+				'disable_ui'        => $settings['disable_default_ui'],
+				'keep_centered'     => $settings['keep_centered'],
+				'marker_icon'       => ! empty( $mrkr_src ) ? $mrkr_src[0] : '',
+				'markers_draggable' => isset( $markers['markers_draggable'] ) ? $markers['markers_draggable'] : '',
+				'marker_at_center'  => !empty( $markers['marker_at_center'] ),
+				'marker_info_display' => $markers['info_display'],
+				'marker_positions'  => isset( $markers['marker_positions'] ) ? $markers['marker_positions'] : '',
+				'map_name'          => ! empty( $styles ) ? $styles['map_name'] : '',
+				'map_styles'        => ! empty( $styles ) ? $styles['styles'] : '',
+				'directions'        => $directions,
+				'api_key'           => $instance['api_key_section']['api_key']
+			));
 
 			return array(
 				'map_id'   => md5( $instance['map_center'] ),
 				'height'   => $settings['height'],
-				'map_data' => array(
-					'address'           => $instance['map_center'],
-					'zoom'              => $settings['zoom'],
-					'scroll-zoom'       => $settings['scroll_zoom'],
-					'draggable'         => $settings['draggable'],
-					'disable-ui'        => $settings['disable_default_ui'],
-					'keep-centered'     => $settings['keep_centered'],
-					'marker-icon'       => ! empty( $mrkr_src ) ? $mrkr_src[0] : '',
-					'markers-draggable' => isset( $markers['markers_draggable'] ) ? $markers['markers_draggable'] : '',
-					'marker-at-center'  => !empty( $markers['marker_at_center'] ),
-					'marker-info-display' => $markers['info_display'],
-					'marker-positions'  => isset( $markers['marker_positions'] ) ? json_encode( $markers['marker_positions'] ) : '',
-					'map-name'          => ! empty( $styles ) ? $styles['map_name'] : '',
-					'map-styles'        => ! empty( $styles ) ? json_encode( $styles['styles'] ) : '',
-					'directions'        => $directions_json,
-					'api-key'           => $instance['api_key_section']['api_key']
-				)
+				'map_data' => $map_data,
 			);
 		}
 	}

--- a/widgets/google-map/js/js-map.js
+++ b/widgets/google-map/js/js-map.js
@@ -2,164 +2,197 @@
  * (c) SiteOrigin, freely distributable under the terms of the GPL 2.0 license.
  */
 
-var SiteOriginGoogleMap = {
-    loadMap: function($) {
-        $('.sow-google-map-canvas').each(function () {
-            var $$ = $(this);
-            var mapCenter = $$.data('address');
-            if(!mapCenter) {
-                var markers = $$.data('marker-positions');
-                if(markers && markers.length) {
-                    mapCenter = markers[0].place;
-                }
-            }
-            // We use the geocoder
-            var geocoder = new google.maps.Geocoder();
-            geocoder.geocode({'address': mapCenter}, function (results, status) {
-                if (status == google.maps.GeocoderStatus.OK) {
-                    var zoom = Number($$.data('zoom'));
-                    if ( !zoom ) zoom = 14;
+var SiteOriginGoogleMap = function($) {
+	return {
+		showMap: function(element, location, options) {
+			var zoom = Number(options.zoom);
+			if ( !zoom ) zoom = 14;
 
-                    var userMapTypeId = 'user_map_style';
+			var userMapTypeId = 'user_map_style';
 
-                    var mapOptions = {
-                        zoom: zoom,
-                        scrollwheel: Boolean( $$.data('scroll-zoom') ),
-                        draggable: Boolean( $$.data('draggable') ),
-                        disableDefaultUI: Boolean( $$.data('disable-ui') ),
-                        center: results[0].geometry.location,
-                        mapTypeControlOptions: {
-                            mapTypeIds: [google.maps.MapTypeId.ROADMAP, userMapTypeId]
-                        }
-                    };
+			var mapOptions = {
+				zoom: zoom,
+				scrollwheel: options.scrollZoom,
+				draggable: options.draggable,
+				disableDefaultUI: options.disableUi,
+				center: location,
+				mapTypeControlOptions: {
+					mapTypeIds: [google.maps.MapTypeId.ROADMAP, userMapTypeId]
+				}
+			};
 
-                    var map = new google.maps.Map($$.get(0), mapOptions);
+			var map = new google.maps.Map(element, mapOptions);
 
-                    var userMapOptions = {
-                        name: $$.data('map-name')
-                    };
+			var userMapOptions = {
+				name: options.mapName
+			};
 
-                    var userMapStyles = $$.data('map-styles');
+			var userMapStyles = options.mapStyles;
 
-                    if ( userMapStyles ) {
-                        var userMapType = new google.maps.StyledMapType(userMapStyles, userMapOptions);
+			if ( userMapStyles ) {
+				var userMapType = new google.maps.StyledMapType(userMapStyles, userMapOptions);
 
-                        map.mapTypes.set(userMapTypeId, userMapType);
-                        map.setMapTypeId(userMapTypeId);
-                    }
+				map.mapTypes.set(userMapTypeId, userMapType);
+				map.setMapTypeId(userMapTypeId);
+			}
 
-                    if ( Boolean( $$.data('marker-at-center' ) ) ) {
+			if (options.markerAtCenter) {
+				new google.maps.Marker({
+					position: location,
+					map: map,
+					draggable: options.markersDraggable,
+					icon: options.markerIcon,
+					title: ''
+				});
+			}
 
-                        new google.maps.Marker({
-                            position: results[0].geometry.location,
-                            map: map,
-                            draggable: Boolean( $$.data('markers-draggable') ),
-                            icon: $$.data('marker-icon'),
-                            title: ''
-                        });
-                    }
-                    var markerPositions = $$.data('marker-positions');
-                    if ( markerPositions && markerPositions.length ) {
-                        markerPositions.forEach(
-                            function(mrkr) {
-                                var geocodeMarker = function () {
-                                    geocoder.geocode({'address': mrkr.place}, function (res, status) {
-                                        if (status == google.maps.GeocoderStatus.OK) {
+			if(options.keepCentered) {
+				var center;
+				google.maps.event.addDomListener(map, 'idle', function () {
+					center = map.getCenter();
+				});
+				google.maps.event.addDomListener(window, 'resize', function () {
+					map.setCenter(center);
+				});
+			}
 
-                                            var marker = new google.maps.Marker({
-                                                position: res[0].geometry.location,
-                                                map: map,
-                                                draggable: Boolean($$.data('markers-draggable')),
-                                                icon: $$.data('marker-icon'),
-                                                title: ''
-                                            });
+			this.showMarkers(options.markerPositions, map, options);
+			this.showDirections(options.directions, map, options);
+		},
+		showMarkers: function(markerPositions, map, options) {
+			if ( markerPositions && markerPositions.length ) {
+				var geocoder = new google.maps.Geocoder();
+				markerPositions.forEach(
+					function (mrkr) {
+						var geocodeMarker = function () {
+							geocoder.geocode({'address': mrkr.place}, function (res, status) {
+								if (status == google.maps.GeocoderStatus.OK) {
 
-                                            if(mrkr.hasOwnProperty('info') && mrkr.info) {
-                                                var infoWindowOptions = { content: mrkr.info };
+									var marker = new google.maps.Marker({
+										position: res[0].geometry.location,
+										map: map,
+										draggable: options.markersDraggable,
+										icon: options.markerIcon,
+										title: ''
+									});
 
-                                                if(mrkr.hasOwnProperty('info_max_width') && mrkr.info_max_width) {
-                                                    infoWindowOptions.maxWidth = mrkr.info_max_width;
-                                                }
+									if (mrkr.hasOwnProperty('info') && mrkr.info) {
+										var infoWindowOptions = {content: mrkr.info};
 
-                                                var infoDisplay = $$.data('marker-info-display');
-                                                infoWindowOptions.disableAutoPan = infoDisplay == 'always';
-                                                var infoWindow = new google.maps.InfoWindow(infoWindowOptions);
-                                                if( infoDisplay == 'always') {
-                                                    infoWindow.open(map, marker);
-                                                } else {
-                                                    marker.addListener(infoDisplay, function() {
-                                                        infoWindow.open(map, marker);
-                                                    });
-                                                }
-                                            }
-                                        } else if (status == google.maps.GeocoderStatus.OVER_QUERY_LIMIT) {
-                                            //try again please
-                                            setTimeout(geocodeMarker, Math.random() * 1000, mrkr);
-                                        }
-                                    });
-                                };
-                                //set random delays of 0 - 1 seconds when geocoding markers to try avoid hitting the query limit
-                                setTimeout(geocodeMarker, Math.random() * 1000, mrkr);
-                            }
-                        );
-                    }
+										if (mrkr.hasOwnProperty('info_max_width') && mrkr.info_max_width) {
+											infoWindowOptions.maxWidth = mrkr.info_max_width;
+										}
 
-                    var directions = $$.data('directions');
-                    if ( directions ) {
+										var infoDisplay = options.markerInfoDisplay;
+										infoWindowOptions.disableAutoPan = infoDisplay == 'always';
+										var infoWindow = new google.maps.InfoWindow(infoWindowOptions);
+										if (infoDisplay == 'always') {
+											infoWindow.open(map, marker);
+										} else {
+											marker.addListener(infoDisplay, function () {
+												infoWindow.open(map, marker);
+											});
+										}
+									}
+								} else if (status == google.maps.GeocoderStatus.OVER_QUERY_LIMIT) {
+									//try again please
+									setTimeout(geocodeMarker, Math.random() * 1000, mrkr);
+								}
+							});
+						};
+						//set random delays of 0 - 1 seconds when geocoding markers to try avoid hitting the query limit
+						setTimeout(geocodeMarker, Math.random() * 1000, mrkr);
+					}
+				);
+			}
+		},
+		showDirections: function(directions, map) {
+			if ( directions ) {
+				if ( directions.waypoints && directions.waypoints.length ) {
+					directions.waypoints.map(
+						function (wypt) {
+							wypt.stopover = Boolean(wypt.stopover);
+						}
+					);
+				}
 
-                        if ( directions.waypoints && directions.waypoints.length ) {
-                            directions.waypoints.map(
-                                function (wypt) {
-                                    wypt.stopover = Boolean(wypt.stopover);
-                                }
-                            );
-                        }
+				var directionsRenderer = new google.maps.DirectionsRenderer();
+				directionsRenderer.setMap(map);
 
-                        var directionsRenderer = new google.maps.DirectionsRenderer();
-                        directionsRenderer.setMap(map);
+				var directionsService = new google.maps.DirectionsService();
+				directionsService.route({
+						origin: directions.origin,
+						destination: directions.destination,
+						travelMode: directions.travelMode.toUpperCase(),
+						avoidHighways: directions.avoidHighways,
+						avoidTolls: directions.avoidTolls,
+						waypoints: directions.waypoints,
+						optimizeWaypoints: directions.optimizeWaypoints,
+					},
+					function(result, status) {
+						if (status == google.maps.DirectionsStatus.OK) {
+							directionsRenderer.setDirections(result);
+						}
+					});
+			}
+		},
+		loadMaps: function() {
+			$('.sow-google-map-canvas').each(function (index, element) {
+				var $$ = $(element);
 
-                        var directionsService = new google.maps.DirectionsService();
-                        directionsService.route({
-                                origin: directions.origin,
-                                destination: directions.destination,
-                                travelMode: directions.travelMode.toUpperCase(),
-                                avoidHighways: Boolean( directions.avoidHighways ),
-                                avoidTolls: Boolean( directions.avoidTolls ),
-                                waypoints: directions.waypoints,
-                                optimizeWaypoints: Boolean( directions.optimizeWaypoints )
-                            },
-                            function(result, status) {
-                                if (status == google.maps.DirectionsStatus.OK) {
-                                    directionsRenderer.setDirections(result);
-                                }
-                            });
-                    }
+				var options = $$.data('options');
+				var address = options.address;
+				// If no address was specified, but we have markers, use the first marker as the map center.
+				if(!address) {
+					var markers = options.markerPositions;
+					if(markers && markers.length) {
+						address = markers[0].place;
+					}
+				}
+				var args = {'address': address};
 
-                    if(Boolean( $$.data('keep-centered') )) {
-                        var center;
-                        google.maps.event.addDomListener(map, 'idle', function () {
-                            center = map.getCenter();
-                        });
-                        google.maps.event.addDomListener(window, 'resize', function () {
-                            map.setCenter(center);
-                        });
-                    }
-                }
-                else if (status == google.maps.GeocoderStatus.ZERO_RESULTS) {
-                    $$.append('<div><p><strong>There were no results for the place you entered. Please try another.</strong></p></div>');
-                }
-            });
-        });
-    }
+				//check if address is actually a valid latlng
+				var latLng;
+				if(address && address.indexOf(',') > -1) {
+					var vals = address.split(',');
+					// A latlng value should be of the format 'lat,lng'
+					if(vals && vals.length == 2) {
+						latLng = new google.maps.LatLng(vals[0], vals[1]);
+						// If we have a valid latlng
+						if(!(isNaN(latLng.lat()) || isNaN(latLng.lng()))) {
+							args = {'location': {lat:latLng.lat(), lng:latLng.lng()}};
+						}
+					}
+				}
+
+				// We're using entered latlng coordinates directly
+				if(args.hasOwnProperty('location')) {
+					this.showMap(element, args.location, options);
+				} else if(args.hasOwnProperty('address')) {
+					// User entered an address so use the geocoder.
+					var geocoder = new google.maps.Geocoder();
+					geocoder.geocode(args, function (results, status) {
+						if (status == google.maps.GeocoderStatus.OK) {
+							this.showMap(element, results[0].geometry.location, options);
+						}
+						else if (status == google.maps.GeocoderStatus.ZERO_RESULTS) {
+							$$.append('<div><p><strong>There were no results for the place you entered. Please try another.</strong></p></div>');
+						}
+					}.bind(this));
+				}
+
+			}.bind(this));
+		}
+	};
 };
 
 function soGoogleMapInitialize() {
-    SiteOriginGoogleMap.loadMap(window.jQuery);
+    new SiteOriginGoogleMap(window.jQuery).loadMaps();
 }
 
 jQuery(function ($) {
     if (window.google && window.google.maps) {
-        SiteOriginGoogleMap.loadMap($);
+        new SiteOriginGoogleMap($).loadMaps();
     } else {
         var apiKey = $('.sow-google-map-canvas').data('api-key');
 

--- a/widgets/google-map/tpl/js-map.php
+++ b/widgets/google-map/tpl/js-map.php
@@ -1,10 +1,6 @@
 <div
 	class="sow-google-map-canvas"
 	style="height:<?php echo intval($height) ?>px;"
-	id="map-canvas-<?php echo esc_attr($map_id) ?>"
-<?php foreach( $map_data as $key => $val ) : ?>
-	<?php if ( ! empty( $val ) ) : ?>
-	data-<?php echo $key . '="' . esc_attr( $val ) . '"'?>
-	<?php endif ?>
-<?php endforeach; ?>
+	id="map-canvas-<?php echo esc_attr( $map_id ) ?>"
+	data-options="<?php echo esc_attr( json_encode( $map_data ) ) ?>"
 ></div>


### PR DESCRIPTION
To resolve issue #44 
Some refactoring to send map configuration options as single data attribute and separate markers and directions functions.
Fix for bug when using TinyMCE field in directions waypoints.