### PR TITLE
Alter the default caps

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -294,7 +294,7 @@ class SiteOrigin_Widgets_Bundle {
 	 */
 	function admin_ajax_manage_handler(){
 		if( !wp_verify_nonce($_GET['_wpnonce'], 'manage_so_widget') ) exit();
-		if( !current_user_can( apply_filters('siteorigin_widgets_admin_menu_capability', 'install_plugins') ) ) exit();
+		if( !current_user_can( apply_filters('siteorigin_widgets_admin_menu_capability', 'manage_options') ) ) exit();
 		if( empty($_POST['widget']) ) exit();
 
 		if( !empty($_POST['active']) ) $this->activate_widget($_POST['widget']);

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -294,7 +294,7 @@ class SiteOrigin_Widgets_Bundle {
 	 */
 	function admin_ajax_manage_handler(){
 		if( !wp_verify_nonce($_GET['_wpnonce'], 'manage_so_widget') ) exit();
-		if( !current_user_can( apply_filters('siteorigin_widgets_admin_menu_capability', 'manage_options') ) ) exit();
+		if( ! current_user_can( apply_filters( 'siteorigin_widgets_admin_menu_capability', 'manage_options' ) ) ) exit();
 		if( empty($_POST['widget']) ) exit();
 
 		if( !empty($_POST['active']) ) $this->activate_widget($_POST['widget']);


### PR DESCRIPTION
Hey folks!

Firstly, thanks for your great plugin!

I was creating a new widget this afternoon on a site and I hit a bug where activating a widget wouldn't actually save the activation. I noticed in the console that I was getting anything returned when I clicked activate so I started hunting down the issue and it turned out to be the default caps.

For our sites we have `define( 'DISALLOW_FILE_MODS', true );` set in `wp-config.php` so that clients can't update plugins however they can still alter settings. In that scenario they can get to the Plugins->SiteOrigin Widgets can they can click Activate and the plugin looks like it activated but when you hit refresh it's not.

To get around this `manage_options` is a more sensible capability to check for. It's an edge case but I think it's worth handling.

I have hooked into the filter to change the caps in my plugin in case you're not a fan of this PR.

Thanks again!