### PR TITLE
OR relation for multiple taxonomy terms

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -53,7 +53,7 @@ function siteorigin_widget_post_selector_process_query($query){
 		$tax_queries = explode(',', $query['tax_query']);
 
 		$query['tax_query'] = array();
-        $query['tax_query']['relation'] = 'OR';
+		$query['tax_query']['relation'] = 'OR';
 		foreach($tax_queries as $tq) {
 			list($tax, $term) = explode(':', $tq);
 

--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -53,6 +53,7 @@ function siteorigin_widget_post_selector_process_query($query){
 		$tax_queries = explode(',', $query['tax_query']);
 
 		$query['tax_query'] = array();
+        $query['tax_query']['relation'] = 'OR';
 		foreach($tax_queries as $tq) {
 			list($tax, $term) = explode(':', $tq);
 


### PR DESCRIPTION
When multiple taxonomy terms are specified for a query, wordpress defaults to relation AND but my experience says the users mostly mean OR when they include multiple taxonomy terms. The use case of someone wanting to see all posts belonging to either category/term X or Y is much more common than someone wanting to create a query for a post which belongs to both category/terms X and Y, IMO. Pls review and merge if this seems right. 