### PR TITLE
Fix issue where margin units were doubling causing broken margin rule in Headline Widget.

### DIFF
--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -222,11 +222,11 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			}
 
 			if ( !empty( $divider_styles['top_margin'] ) && !empty( $divider_styles['top_margin_unit'] ) ) {
-				$less_vars['divider_top_margin'] = $divider_styles['top_margin'] . $divider_styles['top_margin_unit'];
+				$less_vars['divider_top_margin'] = $divider_styles['top_margin'];
 			}
 
 			if ( !empty( $divider_styles['side_margin'] ) && !empty( $divider_styles['side_margin_unit'] ) ) {
-				$less_vars['divider_side_margin'] = $divider_styles['side_margin'] . $divider_styles['side_margin_unit'];
+				$less_vars['divider_side_margin'] = $divider_styles['side_margin'];
 			}
 
 


### PR DESCRIPTION
Adding the margin unit here causes the units to double up and thereby
breaking the CSS rule for the margin around the divider for the Headline
widget.