### PR TITLE
Default to no background color for slider frame instead of arbitrary gray

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -103,7 +103,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 		);
 
 		return array(
-			'color' => !empty( $frame['background_color'] ) ? $frame['background_color'] : '#a0a0a0',
+			'color' => !empty( $frame['background_color'] ) ? $frame['background_color'] : false,
 			'image' => !empty( $background_image ) ? $background_image[0] : false,
 			'opacity' => 1,
 			'image-sizing' => 'cover',


### PR DESCRIPTION
I was trying to use PNGs with transparent rounded corners and kept seeing a gray color behind them...this removes that color as default and instead doesn't pass a `background-color` attr to the frame element.