### PR TITLE
Adding fault tolerance to swipe method invocation

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -13,8 +13,12 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.txt
 */
 
 define('SOW_BUNDLE_VERSION', 'dev');
-define('SOW_BUNDLE_JS_SUFFIX', '');
 define('SOW_BUNDLE_BASE_FILE', __FILE__);
+
+// Allow JS suffix to be pre-set
+if( !defined( 'SOW_BUNDLE_JS_SUFFIX' ) ) {
+	define('SOW_BUNDLE_JS_SUFFIX', '');
+}
 
 if( !function_exists('siteorigin_widget_get_plugin_path') ) {
 	include plugin_dir_path(__FILE__).'base/inc.php';

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -73,57 +73,63 @@ jQuery( function($){
         var prevTime = 0;
         var posInterval;
         var negativeDirection = isRTL ? 'right' : 'left';
-        $$.swipe( {
-            excludedElements: "",
-            triggerOnTouchEnd: true,
-            threshold: 75,
-            swipeStatus: function (event, phase, direction, distance, duration, fingerCount, fingerData) {
-                if ( phase == "start" ) {
-                    startPosition = -( itemWidth * position);
-                    prevTime = new Date().getTime();
-                    clearInterval(posInterval);
-                }
-                else if ( phase == "move" ) {
-                    if( direction == negativeDirection ) distance *= -1;
-                    setNewPosition(startPosition + distance);
-                    var newTime = new Date().getTime();
-                    var timeDelta = (newTime - prevTime) / 1000;
-                    velocity = (distance - prevDistance) / timeDelta;
-                    prevTime = newTime;
-                    prevDistance = distance;
-                }
-                else if ( phase == "end" ) {
-                    validSwipe = true;
-                    if( direction == negativeDirection ) distance *= -1;
-                    if(Math.abs(velocity) > 400) {
-                        velocity *= 0.1;
-                        var startTime = new Date().getTime();
-                        var cumulativeDistance = 0;
-                        posInterval = setInterval(function () {
-                            var time = (new Date().getTime() - startTime) / 1000;
-                            cumulativeDistance += velocity * time;
-                            var newPos = startPosition + distance + cumulativeDistance;
-                            var decel = 30;
-                            var end = (Math.abs(velocity) - decel) < 0;
-                            if(direction == negativeDirection) {
-                                velocity += decel;
-                            } else {
-                                velocity -= decel;
-                            }
-                            if(end || !setNewPosition(newPos)) {
-                                clearInterval(posInterval);
-                                setFinalPosition();
-                            }
-                        }, 20);
-                    } else {
-                        setFinalPosition();
-                    }
-                }
-                else if( phase == "cancel") {
-                    updatePosition();
-                }
-            }
-        } );
+        
+        // Verify "swipe" method exists prior to invoking it.
+        if( 'function' === typeof $$.swipe ) {
+        	$$.swipe( {
+	            excludedElements: "",
+	            triggerOnTouchEnd: true,
+	            threshold: 75,
+	            swipeStatus: function (event, phase, direction, distance, duration, fingerCount, fingerData) {
+	                if ( phase == "start" ) {
+	                    startPosition = -( itemWidth * position);
+	                    prevTime = new Date().getTime();
+	                    clearInterval(posInterval);
+	                }
+	                else if ( phase == "move" ) {
+	                    if( direction == negativeDirection ) distance *= -1;
+	                    setNewPosition(startPosition + distance);
+	                    var newTime = new Date().getTime();
+	                    var timeDelta = (newTime - prevTime) / 1000;
+	                    velocity = (distance - prevDistance) / timeDelta;
+	                    prevTime = newTime;
+	                    prevDistance = distance;
+	                }
+	                else if ( phase == "end" ) {
+	                    validSwipe = true;
+	                    if( direction == negativeDirection ) distance *= -1;
+	                    if(Math.abs(velocity) > 400) {
+	                        velocity *= 0.1;
+	                        var startTime = new Date().getTime();
+	                        var cumulativeDistance = 0;
+	                        posInterval = setInterval(function () {
+	                            var time = (new Date().getTime() - startTime) / 1000;
+	                            cumulativeDistance += velocity * time;
+	                            var newPos = startPosition + distance + cumulativeDistance;
+	                            var decel = 30;
+	                            var end = (Math.abs(velocity) - decel) < 0;
+	                            if(direction == negativeDirection) {
+	                                velocity += decel;
+	                            } else {
+	                                velocity -= decel;
+	                            }
+	                            if(end || !setNewPosition(newPos)) {
+	                                clearInterval(posInterval);
+	                                setFinalPosition();
+	                            }
+	                        }, 20);
+	                    } else {
+	                        setFinalPosition();
+	                    }
+	                }
+	                else if( phase == "cancel") {
+	                    updatePosition();
+	                }
+	            }
+	        } );
+        }
+        
+        
         var setNewPosition = function(newPosition) {
             if(newPosition < 50 && newPosition >  -( itemWidth * numItems )) {
                 $itemsContainer.css('transition-duration', "0s");


### PR DESCRIPTION
JS throws a `Uncaught TypeError: $$.swipe is not a function` error in some cases.

Wrapping method into a `typeof` check to avoid issues. 