### PR TITLE
Update action order of widget field buttons

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -159,7 +159,7 @@
 		}
 
 		.siteorigin-widget-field-expand {
-			right: 12px;
+			right: 48px;
 
 			&:before {
 				content: "\f140";
@@ -191,7 +191,7 @@
 		}
 
 		.siteorigin-widget-field-remove {
-			right: 48px;
+			right: 12px;
 
 			&:before {
 				content: '\f158';

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -186,7 +186,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			}
 		}
 
-		if ( ! empty( $instance['sub_headline'] ) ) {
+		if ( ! empty( $instance['sub_headline'] ) && ! empty ( $instance['sub_headline']['text'] ) ) {
 			$sub_headline_styles = $instance['sub_headline'];
 			if ( ! empty( $sub_headline_styles['align'] ) ) {
 				$less_vars['sub_headline_align'] = $sub_headline_styles['align'];


### PR DESCRIPTION
Everywhere the action order is: "Edit, Copy, Delete" except here.
Here is "Delete, Copy, Edit".

Don't know if this has a special reason and I'm the only one who always clicks on the wrong button but I think this should be the same everywhere.
Fixed that.