### PR TITLE
Fix icon selector closing unexpectedly

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -351,10 +351,12 @@
                         container.append(icon);
 
                         if( $v.val() === family + '-' + i ) {
-                            if( !icon.hasClass('siteorigin-widget-active') ) {
-                                // This is becoming active, so simulate a click
-                                icon.click();
-                            }
+							// Add selected icon to the button.
+							$b.find('span')
+								.show()
+								.attr( 'data-sow-icon', icon.attr('data-sow-icon') )
+								.attr( 'class', '' )
+								.addClass( 'sow-icon-' + family );
                             icon.addClass('siteorigin-widget-active');
                         }
                     }


### PR DESCRIPTION
To resolve GH-162.
It was simulating a click on the selected icon when choosing the icon family from the dropdown, which caused the icon grid to close. As far as I could see, the only purpose of this was to set the selected icon on the icon selector button.