### PR TITLE
Image Subtitles

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -79,11 +79,29 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 					'below' => __( 'Below', 'so-widgets-bundle' ),
 				),
 			),
+			
+			/****BY SGC****/
+			'subtitle' => array(
+				'type' => 'text',
+				'label' => __('Subtitle text', 'so-widgets-bundle'),
+			),
+			'subtitle_position' => array(
+				'type' => 'select',
+				'label' => __('Subtitle position', 'so-widgets-bundle'),
+				'default' => 'hidden',
+				'options' => array(
+					'hidden' => __( 'Hidden', 'so-widgets-bundle' ),
+					'above' => __( 'Above', 'so-widgets-bundle' ),
+					'below' => __( 'Below', 'so-widgets-bundle' ),
+				),
+			),
+			/******************/
 
 			'alt' => array(
 				'type' => 'text',
 				'label' => __('Alt text', 'so-widgets-bundle'),
 			),
+
 
 			'url' => array(
 				'type' => 'link',
@@ -123,6 +141,10 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 		return array(
 			'title' => $instance['title'],
 			'title_position' => $instance['title_position'],
+			/****BY SGC****/
+			'subtitle' => $instance['subtitle'],
+			'subtitle_position' => $instance['subtitle_position'],
+			/**************/
 			'image' => $instance['image'],
 			'size' => $instance['size'],
 			'image_fallback' => ! empty( $instance['image_fallback'] ) ? $instance['image_fallback'] : false,

--- a/widgets/image/tpl/base.php
+++ b/widgets/image/tpl/base.php
@@ -11,11 +11,22 @@
  */
 ?>
 
-<?php if( $title_position == 'above' ) : ?>
-	<?php echo $args['before_title']; ?>
-	<h2> <?php echo $title ?> </h2>
-	<?php echo $args['after_title']; ?>
-<?php endif; ?>
+<?php 
+/**** By SGC *****/
+	if( $title_position == 'above' ) : ?>
+	<?php if(!empty($url)) : ?><a href="<?php echo sow_esc_url($url) ?>" <?php if($new_window) echo 'target="_blank"' ?>><?php endif; ?>
+		<div class="img-titles">
+		<?php echo $args['before_title']; ?>
+		
+			<h2> <?php echo $title ?> </h2>
+			<h3> <?php echo $subtitle ?> </h3>
+		
+		<?php echo $args['after_title']; ?>
+		</div>
+	<?php if(!empty($url)) : ?></a><?php endif; ?>
+<?php endif; 
+/****************/
+?>
 
 <?php
 $src = siteorigin_widgets_get_attachment_image_src(
@@ -40,6 +51,9 @@ if( !empty($src) ) {
 $classes = array('so-widget-image');
 
 if(!empty($title)) $attr['title'] = $title;
+/**** By SGC *****/
+if(!empty($subtitle)) $attr['subtitle'] = $subtitle;
+/****************/
 if(!empty($alt)) $attr['alt'] = $alt;
 
 ?>
@@ -48,9 +62,17 @@ if(!empty($alt)) $attr['alt'] = $alt;
 	<img <?php foreach($attr as $n => $v) echo $n.'="' . esc_attr($v) . '" ' ?> class="<?php echo esc_attr( implode(' ', $classes) ) ?>"/>
 <?php if(!empty($url)) : ?></a><?php endif; ?>
 </div>
-
+<!--**** By SGC *****/-->
 <?php if( $title_position == 'below' ) : ?>
-	<?php echo $args['before_title']; ?>
-	<h2> <?php echo $title ?> </h2>
-	<?php echo $args['after_title']; ?>
+	<?php if(!empty($url)) : ?><a href="<?php echo sow_esc_url($url) ?>" <?php if($new_window) echo 'target="_blank"' ?>><?php endif; ?>
+		<div class="img-titles">
+		<?php echo $args['before_title']; ?>
+		
+			<h2> <?php echo $title ?> </h2>
+			<h3> <?php echo $subtitle ?> </h3>
+		
+		<?php echo $args['after_title']; ?>
+		</div>
+	<?php if(!empty($url)) : ?></a><?php endif; ?>
 <?php endif; ?>
+<!--*****************/-->


### PR DESCRIPTION
By adding few lines of code we can accomplish to have titles + subtitles
texts for your images. The modified files create the "subtitle text"
field and the "subtitle position" field in the SiteOrigin Image widget
backend.

I tested for previous version localy and now I've made the changes in
the updated plugin (Version 1.5.11) and working fine.

Maybe the way of echoing way for titles and subtitles in base.php have to be updated, but does the job.

This is a minor change that could be easily integrated for the new
version.