### PR TITLE
changing the html markup on the title of features widget

### DIFF
--- a/widgets/features/tpl/default.php
+++ b/widgets/features/tpl/default.php
@@ -40,11 +40,11 @@ $last_row = floor( ( count($instance['features']) - 1 ) / $instance['per_row'] )
 
 			<div class="textwidget">
 				<?php if(!empty($feature['title'])) : ?>
-					<h5>
+					<strong>
 						<?php if( !empty( $feature['more_url'] ) && $instance['title_link'] ) echo '<a href="' . sow_esc_url( $feature['more_url'] ) . '" ' . ( $instance['new_window'] ? 'target="_blank"' : '' ) . '>'; ?>
 						<?php echo wp_kses_post( $feature['title'] ) ?>
 						<?php if( !empty( $feature['more_url'] ) && $instance['title_link'] ) echo '</a>'; ?>
-					</h5>
+					</strong>
 				<?php endif; ?>
 
 				<?php if(!empty($feature['text'])) : ?>


### PR DESCRIPTION
I'm proposing this because a simple accessibility issue. Using headings here, we may have problems if you don't have other headings before H5. Changing to STRONG it will be ok when you do an accessibility check (at http://achecker.ca/ for instance).
