### PR TITLE
contact widget: add email default email subject if no subject defined in form

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -832,6 +832,11 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 		}
 
+		// Add in the default subject if no subject field is defined in the form at all
+		if ( !isset( $email_fields['subject'] ) && !empty($instance['settings']['default_subject']) ) {
+			$email_fields['subject'] = $instance['settings']['default_subject'];
+		}
+
 		// Add in the default subject prefix
 		if( !empty( $email_fields['subject'] ) && !empty($instance['settings']['subject_prefix']) ) {
 			$email_fields['subject'] = $instance['settings']['subject_prefix'] . ' ' . $email_fields['subject'];


### PR DESCRIPTION
sorry, I messed up with branches in my local repo, so I had to send this PR again.

it is the same as pull #280 which I messed up due to more commits and so I will close them.

again the info:

if you have multiple contact forms and want to have a fixed subject on each form, this case has not been catched in the code:
- do not define a subject field
- set a default subject field

if subject is not definad and default subject is defined that default subject will be used for the email.

this should basically fix #248 
