### PR TITLE
SiteOrigin_Widget: Fix use of wrong variable

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -60,7 +60,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			'has_preview' => true,
 		) );
 
-		$control_options = wp_parse_args($widget_options, array(
+		$control_options = wp_parse_args( $control_options, array(
 			'width' => 800,
 		) );
 


### PR DESCRIPTION
Actually use `$control_options` instead of `$widget_options`
for passing control options to parent constructor.

Original code has been in place since Nov 2014, so this fix could possibly break workarounds in other places. A compatibility fix is possible if deemed necessary.