### PR TITLE
Allow icon form field to use different labels

### DIFF
--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -1,6 +1,6 @@
 @import "../../../less/mixins";
 
-.siteorigin-widget-form .siteorigin-widget-field-icon {
+.siteorigin-widget-form .siteorigin-widget-field-type-icon {
 
 	.siteorigin-widget-icon-selector-current {
 		display: inline-block;


### PR DESCRIPTION
Resolves #322.

CSS was written for a form field labeled icon and didn't allow different labels as a result.