### PR TITLE
Removed leading slash in paths after plugin_dir_url()

### DIFF
--- a/base/inc/fields/code.class.php
+++ b/base/inc/fields/code.class.php
@@ -31,6 +31,6 @@ class SiteOrigin_Widget_Field_Code extends SiteOrigin_Widget_Field_Text_Input_Ba
 	}
 
 	function enqueue_scripts(){
-		wp_enqueue_script( 'so-code-field', plugin_dir_url( __FILE__ ) . '/js/code-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
+		wp_enqueue_script( 'so-code-field', plugin_dir_url( __FILE__ ) . 'js/code-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
 	}
 }

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -153,8 +153,8 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 	}
 
 	function enqueue_scripts(){
-		wp_enqueue_script( 'so-media-field', plugin_dir_url( __FILE__ ) . '/js/media-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
-		wp_enqueue_style( 'so-media-field', plugin_dir_url( __FILE__ ) . '/css/media-field.css', array( ), SOW_BUNDLE_VERSION );
+		wp_enqueue_script( 'so-media-field', plugin_dir_url( __FILE__ ) . 'js/media-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
+		wp_enqueue_style( 'so-media-field', plugin_dir_url( __FILE__ ) . 'css/media-field.css', array( ), SOW_BUNDLE_VERSION );
 	}
 
 	function image_search_dialog(){


### PR DESCRIPTION
Google AppEngine does not auto-correct double slashes in a URL, the following one result in a 404 error:

`so-widgets-bundle/base/inc/fields//js/media-field.min.js?ver=1.6.5`

plugin_dir_url() already outputs the trailing slash so it's not needed in the string path.