### PR TITLE
Headline: Remove !important from styling

### DIFF
--- a/widgets/headline/styles/default.less
+++ b/widgets/headline/styles/default.less
@@ -68,10 +68,10 @@
     }
 
     *:first-child {
-        margin-top: 0 !important;
+        margin-top: 0;
     }
 
     *:last-child {
-        margin-bottom: 0 !important;
+        margin-bottom: 0;
     }
 }


### PR DESCRIPTION
Resolves #275

We're already using highly specific selectors there's little reason to !important it. As doing so just prevents other designers from making adjustments to the margins with CSS without writing a page long selector.

![](https://i.imgur.com/Xlz9CdI.png)
