### PR TITLE
Image Widget: use alt / title set via WP if not set

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -102,16 +102,13 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 	}
 
 	public function get_template_variables( $instance, $args ) {
-
-		$existing_alt = get_post_meta( $instance['image'], '_wp_attachment_image_alt', true );
-
 		return array(
 			'title' => !empty( $instance['title'] ) ? $instance['title'] : get_the_title( $instance['image'] ),
 			'title_position' => $instance['title_position'],
 			'image' => $instance['image'],
 			'size' => $instance['size'],
 			'image_fallback' => ! empty( $instance['image_fallback'] ) ? $instance['image_fallback'] : false,
-			'alt' => !empty( $instance['alt'] ) ? $instance['alt'] : $existing_alt,
+			'alt' => !empty( $instance['alt'] ) ? $instance['alt'] : get_post_meta( $instance['image'], '_wp_attachment_image_alt', true ),
 			'url' => $instance['url'],
 			'new_window' => $instance['new_window'],
 		);

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -102,17 +102,21 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 	}
 
 	public function get_template_variables( $instance, $args ) {
+
+		$existing_alt = get_post_meta( $instance['image'], '_wp_attachment_image_alt', true );
+
 		return array(
-			'title' => $instance['title'],
+			'title' => !empty( $instance['title'] ) ? $instance['title'] : get_the_title( $instance['image'] ),
 			'title_position' => $instance['title_position'],
 			'image' => $instance['image'],
 			'size' => $instance['size'],
 			'image_fallback' => ! empty( $instance['image_fallback'] ) ? $instance['image_fallback'] : false,
-			'alt' => $instance['alt'],
+			'alt' => !empty( $instance['alt'] ) ? $instance['alt'] : $existing_alt,
 			'url' => $instance['url'],
 			'new_window' => $instance['new_window'],
 		);
 	}
+
 
 	function get_less_variables($instance){
 		return array(

--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -38,8 +38,17 @@ $attr = apply_filters( 'siteorigin_widgets_image_attr', $attr, $instance, $this 
 
 $classes = array('so-widget-image');
 
-if(!empty($title)) $attr['title'] = $title;
-if(!empty($alt)) $attr['alt'] = $alt;
+if( !empty( $title ) ){
+	$attr['title'] = $title;
+}else{
+	$attr['title'] = get_the_title( $image );
+}
+
+if( empty( $alt ) ){
+	$attr['alt'] = $alt;
+}else{
+	$attr['alt'] = get_post_meta( $image, '_wp_attachment_image_alt', true );
+}
 
 ?>
 <div class="sow-image-container">

--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -38,17 +38,8 @@ $attr = apply_filters( 'siteorigin_widgets_image_attr', $attr, $instance, $this 
 
 $classes = array('so-widget-image');
 
-if( !empty( $title ) ){
-	$attr['title'] = $title;
-}else{
-	$attr['title'] = get_the_title( $image );
-}
-
-if( empty( $alt ) ){
-	$attr['alt'] = $alt;
-}else{
-	$attr['alt'] = get_post_meta( $image, '_wp_attachment_image_alt', true );
-}
+if(!empty($title)) $attr['title'] = $title;
+if(!empty($alt)) $attr['alt'] = $alt;
 
 ?>
 <div class="sow-image-container">

--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -38,8 +38,8 @@ $attr = apply_filters( 'siteorigin_widgets_image_attr', $attr, $instance, $this 
 
 $classes = array('so-widget-image');
 
-if(!empty($title)) $attr['title'] = $title;
-if(!empty($alt)) $attr['alt'] = $alt;
+if( !empty( $title ) ) $attr['title'] = $title;
+if( !empty( $alt ) ) $attr['alt'] = $alt;
 
 ?>
 <div class="sow-image-container">


### PR DESCRIPTION
Resolves #210

This PR will allow for the image widget image to use the title / alt set in WordPress if the widget values aren't set. 
