### PR TITLE
Change post selector sticky include to only

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -181,7 +181,7 @@ function siteorigin_widget_post_selector_form_fields(){
 		'' => __('Default', 'so-widgets-bundle'),
 		'ignore' => __('Ignore sticky', 'so-widgets-bundle'),
 		'exclude' => __('Exclude sticky', 'so-widgets-bundle'),
-		'only' => __('Include sticky', 'so-widgets-bundle'),
+		'only' => __('Only sticky', 'so-widgets-bundle'),
 	);
 	foreach($sticky as $id => $v) {
 		$return['sticky'] .= '<option value="' . $id . '">' . $v . '</option>';


### PR DESCRIPTION
The sticky posts dropdown include sticky option is mislabeled. It should be labeled as only sticky as that's what it actually does. In other words, when the sticky posts option is set to include sticky it will only return sticky posts.

![](https://i.imgur.com/DnqeHYV.png)
