### PR TITLE
Image Widget: Allow title to contain HTML

### DIFF
--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -12,7 +12,7 @@
 ?>
 
 <?php if( $title_position == 'above' ) : ?>
-	<?php echo $args['before_title'] . esc_html( $title ) . $args['after_title']; ?>
+	<?php echo $args['before_title'] . wp_kses_post( $title ) . $args['after_title']; ?>
 <?php endif; ?>
 
 <?php
@@ -49,5 +49,5 @@ if(!empty($alt)) $attr['alt'] = $alt;
 </div>
 
 <?php if( $title_position == 'below' ) : ?>
-	<?php echo $args['before_title'] . esc_html( $title ) . $args['after_title']; ?>
+	<?php echo $args['before_title'] . wp_kses_post( $title ) . $args['after_title']; ?>
 <?php endif; ?>


### PR DESCRIPTION
In a [recent commit](https://github.com/siteorigin/so-widgets-bundle/commit/a637b000e6090c956e983ead7a4c583c719cac30#diff-2c014a234ca0e640366c9f32dd8d18c3), the image title wasn't allowed to use HTML. This makes sense for the image title but it doesn't really make sense for the widget title (that's displayed) as it was previously allowed.
