### PR TITLE
Do not compile empty less stylesheet

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -818,7 +818,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				}
 			}
 			catch ( Exception $e ) {
-				$css = '';
+				
 			}
 
 			// Remove any attributes with default as the value

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -795,38 +795,38 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		$css = '';
 
 		if( ! empty( $less ) ) {
-		$style = $this->get_style_name( $instance );
-		$hash = $this->get_style_hash( $instance );
-		$css_name = $this->id_base . '-' . $style . '-' . $hash;
+			$style = $this->get_style_name( $instance );
+			$hash = $this->get_style_hash( $instance );
+			$css_name = $this->id_base . '-' . $style . '-' . $hash;
 
-		//we assume that any remaining @imports are plain css imports and should be kept outside selectors
-		$css_imports = '';
-		if ( preg_match_all( '/^@import.+/m', $less, $imports ) ) {
-			$css_imports = implode( "\n", $imports[0] );
-			$less = preg_replace( '/^@import.+/m', '', $less );
-		}
-
-		$less = $css_imports . "\n\n" . '.so-widget-'.$css_name." { \n".$less."\n } ";
-
-		$compiler = new lessc();
-		$lc_functions = new SiteOrigin_Widgets_Less_Functions($this, $instance);
-		$lc_functions->registerFunctions( $compiler );
-
-		try {
-			if( method_exists( $compiler, 'compile' ) ) {
-				$css = $compiler->compile( $less );
+			//we assume that any remaining @imports are plain css imports and should be kept outside selectors
+			$css_imports = '';
+			if ( preg_match_all( '/^@import.+/m', $less, $imports ) ) {
+				$css_imports = implode( "\n", $imports[0] );
+				$less = preg_replace( '/^@import.+/m', '', $less );
 			}
-		}
-		catch ( Exception $e ) {
-			$css = '';
-		}
 
-		// Remove any attributes with default as the value
-		$css = preg_replace('/[a-zA-Z\-]+ *: *default *;/', '', $css);
+			$less = $css_imports . "\n\n" . '.so-widget-'.$css_name." { \n".$less."\n } ";
 
-		// Remove any empty CSS
-		$css = preg_replace('/[^{}]*\{\s*\}/m', '', $css);
-		$css = trim($css);
+			$compiler = new lessc();
+			$lc_functions = new SiteOrigin_Widgets_Less_Functions($this, $instance);
+			$lc_functions->registerFunctions( $compiler );
+
+			try {
+				if( method_exists( $compiler, 'compile' ) ) {
+					$css = $compiler->compile( $less );
+				}
+			}
+			catch ( Exception $e ) {
+				$css = '';
+			}
+
+			// Remove any attributes with default as the value
+			$css = preg_replace('/[a-zA-Z\-]+ *: *default *;/', '', $css);
+
+			// Remove any empty CSS
+			$css = preg_replace('/[^{}]*\{\s*\}/m', '', $css);
+			$css = trim($css);
 		}
 
 		return apply_filters( 'siteorigin_widgets_instance_css', $css, $instance, $this );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -792,6 +792,9 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		$less = apply_filters( 'siteorigin_widgets_styles', $less, $this->widget_class, $instance );
 		$less = apply_filters( 'siteorigin_widgets_less_' . $this->id_base, $less, $instance, $this );
 
+		$css = '';
+
+		if( ! empty( $less ) ) {
 		$style = $this->get_style_name( $instance );
 		$hash = $this->get_style_hash( $instance );
 		$css_name = $this->id_base . '-' . $style . '-' . $hash;
@@ -824,6 +827,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		// Remove any empty CSS
 		$css = preg_replace('/[^{}]*\{\s*\}/m', '', $css);
 		$css = trim($css);
+		}
 
 		return apply_filters( 'siteorigin_widgets_instance_css', $css, $instance, $this );
 	}


### PR DESCRIPTION
Widget less styles are filtered:

```
$less = apply_filters( 'siteorigin_widgets_styles', $less, $this->widget_class, $instance );
$less = apply_filters( 'siteorigin_widgets_less_' . $this->id_base, $less, $instance, $this );
```

If some filter returns empty string there is no reason to start compiler.
