### PR TITLE
Simple Masonry: ensure masonry resize on load

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -60,7 +60,13 @@ jQuery(function ($) {
 			});
         });
     };
+	
+	resizeMasonry();
 
 	$(window).on('resize panelsStretchRows', resizeMasonry);
-    resizeMasonry();
+
+	// Ensure that the masonry has resized correct on load.
+	setTimeout( function () {
+		resizeMasonry();
+	}, 100 );
 });


### PR DESCRIPTION
Resolve #281 

There's a chance the simple masonry won't resize on load. This PR ensures this isn't the case.
