### PR TITLE
Removed double slash from icon form field

### DIFF
--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -78,8 +78,8 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 	}
 
 	public function enqueue_scripts(){
-		wp_enqueue_script( 'so-icon-field', plugin_dir_url( __FILE__ ) . '/js/icon-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
-		wp_enqueue_style( 'so-icon-field', plugin_dir_url( __FILE__ ) . '/css/icon-field.css', array( ), SOW_BUNDLE_VERSION );
+		wp_enqueue_script( 'so-icon-field', plugin_dir_url( __FILE__ ) . 'js/icon-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
+		wp_enqueue_style( 'so-icon-field', plugin_dir_url( __FILE__ ) . 'css/icon-field.css', array( ), SOW_BUNDLE_VERSION );
 	}
 
 }


### PR DESCRIPTION
Same issue as #325

"Google AppEngine does not auto-correct double slashes in a URL, [...] result[ing] in a 404 error"
