### PR TITLE
Corrected post__not_in issue for additional field

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -98,7 +98,7 @@ function siteorigin_widget_post_selector_process_query($query){
 		$query = wp_parse_args( $query['additional'], $query );
 		unset( $query['additional'] );
 
-		// Acount for post_not_in being set
+		// If post_not_in is set, we need to convert it to an array to avoid issues with the query. 
 		if( !empty( $query['post__not_in'] ) && !is_array( $query['post__not_in'] ) ){
 			$query['post__not_in'] = explode( ',', $query['post__not_in'] );
 			$query['post__not_in'] = array_map( 'intval', $query['post__not_in'] );

--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -97,6 +97,12 @@ function siteorigin_widget_post_selector_process_query($query){
 	if ( ! empty( $query['additional'] ) ) {
 		$query = wp_parse_args( $query['additional'], $query );
 		unset( $query['additional'] );
+
+		// Acount for post_not_in being set
+		if( !empty( $query['post__not_in'] ) && !is_array( $query['post__not_in'] ) ){
+			$query['post__not_in'] = explode( ',', $query['post__not_in'] );
+			$query['post__not_in'] = array_map( 'intval', $query['post__not_in'] );
+		}
 	}
 
 	return $query;


### PR DESCRIPTION
Exactly the same issue as in siteorigin/siteorigin-panels#304

If a user adds post__not_in to the additional field it'll cause a fatal error as this line doesn't account for strings.

How to replicate this issue:
- Add the following into the additional field: post__not_in=372

That's it. This will cause this:
![](https://i.imgur.com/3zgba3R.png)


