### PR TITLE
Contact: Prevent empty title markup from being output

### DIFF
--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -2,7 +2,7 @@
 $result = $this->contact_form_action( $instance, $instance_hash );
 
 // Display the title
-if( $instance['display_title'] ) {
+if( $instance['display_title'] && !empty( $instance['title'] ) ) {
 	echo $args['before_title'] . $instance['title'] . $args['after_title'];
 }
 $short_hash = substr( $instance_hash, 0, 4 );


### PR DESCRIPTION
If Display Title is ticked but the contact title is empty the contact title will still be output. There's a reason to have the title not display, but there's no real reason to have the markup present if it's not being used.