### PR TITLE
Contact: Display email after name

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -992,7 +992,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	}
 
 	function send_mail( $email_fields, $instance ){
-		$body = '<strong>From:</strong> <a href="mailto:' . sanitize_email( $email_fields['email'] ) . '">' . esc_html( $email_fields['name'] ) . "</a>\n\n";
+		$body = '<strong>From:</strong> <a href="mailto:' . sanitize_email( $email_fields['email'] ) . '">' . esc_html( $email_fields['name'] ) . '</a> &#60;' . sanitize_email( $email_fields['email'] ) . "&#62; \n\n";
 		foreach( $email_fields['message'] as $m ) {
 			$body .= '<strong>' . $m['label'] . ':</strong>';
 			$body .= "\n";


### PR DESCRIPTION
Display email along side name in the contact email. This will stop the question, "Where's the email?".

![](https://i.imgur.com/kzU3KoP.png)
