### PR TITLE
Contact: Improved type Validation and added empty field check

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -804,19 +804,18 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			$field_name = $this->name_from_label( !empty($field['label']) ? $field['label'] : $i, $field_ids ) . '-' . $instance['_sow_form_id'];
 			$value = !empty( $post_vars[$field_name] ) ? $post_vars[$field_name] : '';
 
-			if( $field['required']['required'] && empty($value) ) {
-				// Add in the default subject
-				if( $field['type'] == 'subject' && !empty($instance['settings']['default_subject'] ) ) {
-					$value = $instance['settings']['default_subject'];
-				} else {
-					$errors[ $field_name ] = ! empty( $field['required']['missing_message'] ) ? $field['required']['missing_message'] : __( 'Required field', 'so-widgets-bundle' );
-					continue;
-				}
-			}
-			
-			// Don't process an unrequired empty field
 			if( empty( $value ) ) {
-				continue;
+				if( $field['required']['required'] ) {
+					// Add in the default subject
+					if( $field['type'] == 'subject' && !empty($instance['settings']['default_subject'] ) ) {
+						$value = $instance['settings']['default_subject'];
+					} else {
+						$errors[ $field_name ] = ! empty( $field['required']['missing_message'] ) ? $field['required']['missing_message'] : __( 'Required field', 'so-widgets-bundle' );
+						continue;
+					}
+				} else {
+					continue; // Don't process an empty field that's not required
+				}
 			}
 
 			// Type Validation
@@ -825,11 +824,14 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					if( $value != sanitize_email( $value ) ) {
 						$errors[ $field_name ] = __( 'Invalid email address.', 'so-widgets-bundle' );
 					}
+					$email_fields[ $field['type'] ] = $value;
+
+					break;
 
 				case 'name':
 				case 'subject':
 					$email_fields[ $field['type'] ] = $value;
-
+					
 					break;
 
 				case 'checkboxes':

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -827,12 +827,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					}
 
 				case 'name':
-					// Check if this name field is empty or not. This prevents an empty name field type from overriding a name field with a value
-
-					if( empty( $value ) ) {
-						continue;
-					}
-
 				case 'subject':
 					$email_fields[ $field['type'] ] = $value;
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -813,36 +813,39 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					continue;
 				}
 			}
-
+			
+			// Type Validation
 			switch( $field['type'] ) {
 				case 'email':
-					if( $value != sanitize_email($value) ) {
-						$errors[$field_name] = __('Invalid email address.', 'so-widgets-bundle');
+					if( $value != sanitize_email( $value ) ) {
+						$errors[ $field_name ] = __( 'Invalid email address.', 'so-widgets-bundle' );
 					}
+
+				case 'name':
+					// Check if this name field is empty or not. This prevents an empty name field type from overriding a name field with a value
+
+					if( empty( $value ) ) {
+						continue;
+					}
+
+				case 'subject':
+					$email_fields[ $field['type'] ] = $value;
+
 					break;
-			}
 
-			if( in_array( $field['type'], array( 'email', 'name', 'subject' ) ) ) {
-				$email_fields[$field['type']] = $value;
-			}
-			else {
-				if( empty($email_fields['message']) ) $email_fields['message'] = array();
+				case 'checkboxes':
+					$email_fields['message'][] = array(
+						'label' => $field['label'],
+						'value' => implode( ', ', $value ),
+					);
+					break;
 
-				switch( $field['type'] ) {
-					case 'checkboxes':
-						$email_fields['message'][] = array(
-							'label' => $field['label'],
-							'value' => implode(', ', $value),
-						);
-						break;
-
-					default:
-						$email_fields['message'][] = array(
-							'label' => $field['label'],
-							'value' => $value,
-						);
-						break;
-				}
+				default:
+					$email_fields['message'][] = array(
+						'label' => $field['label'],
+						'value' => $value,
+					);
+					break;
 			}
 		}
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -814,6 +814,11 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				}
 			}
 			
+			// Don't process an unrequired empty field
+			if( empty( $value ) ) {
+				continue;
+			}
+
 			// Type Validation
 			switch( $field['type'] ) {
 				case 'email':


### PR DESCRIPTION
Added empty field check to prevent empty fields from overwriting valid fields (for example, two name fields). This will also prevent empty fields from being added to the email.

Changed the type validation to a single `switch()`.