### PR TITLE
Google Font import: Replace is_ssl() with a HTTPS check of site_url()

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -105,7 +105,7 @@ function siteorigin_widget_get_font($font_value) {
 			$font['weight'] = $font_parts[1];
 			$font_url_param .= ':' . $font_parts[1];
 		}
-		$font['css_import'] = '@import url(http' . ( is_ssl() ? 's' : '' ) . '://fonts.googleapis.com/css?family=' . $font_url_param . ');';
+		$font['css_import'] = '@import url(http' . ( strpos( site_url(), 'https' ) !== false ? 's' : '' ) . '://fonts.googleapis.com/css?family=' . $font_url_param . ');';
 	}
 	else {
 		$font['family'] = $font_value;

--- a/base/base.php
+++ b/base/base.php
@@ -105,7 +105,7 @@ function siteorigin_widget_get_font($font_value) {
 			$font['weight'] = $font_parts[1];
 			$font_url_param .= ':' . $font_parts[1];
 		}
-		$font['css_import'] = '@import url(http' . ( strpos( site_url(), 'https' ) !== false ? 's' : '' ) . '://fonts.googleapis.com/css?family=' . $font_url_param . ');';
+		$font['css_import'] = '@import url(https://fonts.googleapis.com/css?family=' . $font_url_param . ');';
 	}
 	else {
 		$font['family'] = $font_value;


### PR DESCRIPTION
Resolves #277

Using is_ssl() is fine for most occurrences but when the website allows both http and https it falls flat if the version stored in the cache wasn't secure at the time of generation.