### PR TITLE
Post Selector: Exclude current post id

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -93,6 +93,11 @@ function siteorigin_widget_post_selector_process_query($query){
 		}
 		unset( $query['sticky'] );
 	}
+	
+	// Exclude the current post (if applicable) to avoid any issues associated with showing the same post again
+	if( get_the_id() != false ){
+		$query['post__not_in'][] = get_the_id();
+	}
 
 	if ( ! empty( $query['additional'] ) ) {
 		$query = wp_parse_args( $query['additional'], $query );


### PR DESCRIPTION
Exclude the current post (if applicable) to avoid any issues associated with showing the same post again.

Use case: A third party plugin doesn't handle things correctly and lets SiteOrigin Page Builder handle the post. This, in turn, will leed to an infinite loop.

I can't think of a valid reason as to why you would want the current post to appear so I feel it's safe to disregard it completely.