### PR TITLE
Change links form field to only allow queryable posts

### DIFF
--- a/base/inc/actions.php
+++ b/base/inc/actions.php
@@ -65,7 +65,8 @@ function siteorigin_widget_search_posts_action(){
 
 	// Get all public post types, besides attachments
 	$post_types = (array) get_post_types( array(
-		'public'   => true
+		'public'             => true,
+		'publicly_queryable' => true
 	) );
 	unset($post_types['attachment']);
 


### PR DESCRIPTION
As odd as it may sound, checking purely for public to know if the post type is actually queryable or not is not very reliable.

For example, Meta Slider sliders are set to public but it's effectively private as publicly_queryable is set to false and exclude_from_search is set to true. In other words, this results in a 404 if the user links the link on the frontend.