### PR TITLE
Price Table: Shortcode support for feature text

### DIFF
--- a/widgets/price-table/tpl/atom.php
+++ b/widgets/price-table/tpl/atom.php
@@ -38,7 +38,7 @@
 						?>
 						<div class="sow-feature-text">
 							<p <?php if(!empty( $feature['hover'] ) ) : ?>data-tooltip-text="<?php echo esc_attr($feature['hover']) ?>"<?php endif; ?>>
-								<?php echo wp_kses_post($feature['text']) ?>
+								<?php echo wp_kses_post( do_shortcode( $feature['text'] ) ) ?>
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
This will allow users to use shortcode tooltip plugins while we currently don't have said functionality.

@gregpriday I ran do_shortcode before escaping the text as I suspect that might be better overall. With that said, should it be escaped before? I worry that a plugin might not escape the text at all and will end up trusting "bad" data.