### PR TITLE
Testimonials: Add responsive image sizes

### DIFF
--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -48,6 +48,18 @@
 
 	.sow-round-image-frame {
 		border-radius: @image_size;
+		width: @image_size;
+		height: @image_size;
+		
+		@media screen and (max-width: @tablet_width) {
+			width: @tablet_image_size;
+			height: @tablet_image_size;
+		}
+
+		@media screen and (max-width: @mobile_width) {
+			width: @mobile_image_size;
+			height: @mobile_image_size;
+		}
 	}
 
 	// All the specific layouts

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -1,6 +1,5 @@
-@import "../../../base/less/mixins";
+@import "mixins";
 
-@image_size: 75px;
 @testimonial_padding: 10px;
 
 @testimonial_background: transparent;
@@ -11,8 +10,15 @@
 // Testimonial sizes
 @testimonial_size: 33.333%;
 @tablet_testimonial_size: 50%;
-@tablet_width: 800px;
 @mobile_testimonial_size: 100%;
+
+// Image Sizes
+@image_size: 75px;
+@tablet_image_size: default;
+@mobile_image_size: default;
+
+// Responsive breakpoints
+@tablet_width: 800px;
 @mobile_width: 480px;
 
 .sow-testimonials {
@@ -62,6 +68,15 @@
 						margin: 0 auto;
 						max-width: 100%;
 						height: auto;
+
+						@media screen and (max-width: @tablet_width) {
+							width: @tablet_image_size;
+						}
+
+						@media screen and (max-width: @mobile_width) {
+							width: @mobile_image_size;
+						}
+
 					}
 				}
 

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -1,4 +1,4 @@
-@import "mixins";
+@import "../../../base/less/mixins";
 
 @testimonial_padding: 10px;
 

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -340,7 +340,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			}
 			else {
 				$src = wp_get_attachment_image_src( $image_id, array( $design['image']['image_size'], $design['image']['image_size'] ) );
-				return '<div class="sow-round-image-frame" style="background-image: url(' . esc_url( $src[0] ) . '); width:' . intval($design['image']['image_size']) . 'px; height:' . intval($design['image']['image_size']) . 'px"></div>';
+				return '<div class="sow-round-image-frame" style="background-image: url(' . esc_url( $src[0] ) . ');"></div>';
 			}
 		}
 	}

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -125,6 +125,14 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 										'integer' => true,
 										'default' => 2
 									),
+									'image_size' => array(
+										'type' => 'slider',
+										'label' => __( 'Image size', 'so-widgets-bundle' ),
+										'integer' => true,
+										'default' => 50,
+										'max' => 150,
+										'min' => 20,
+									),
 									'width' => array(
 										'type' => 'text',
 										'label' => __('Resolution', 'so-widgets-bundle'),
@@ -145,6 +153,14 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 										'max' => 5,
 										'integer' => true,
 										'default' => 1
+									),
+									'image_size' => array(
+										'type' => 'slider',
+										'label' => __( 'Image size', 'so-widgets-bundle' ),
+										'integer' => true,
+										'default' => 50,
+										'max' => 150,
+										'min' => 20,
 									),
 									'width' => array(
 										'type' => 'text',
@@ -299,8 +315,10 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 
 			// All the responsive sizes
 			'tablet_testimonial_size' => round(100/$instance['settings']['responsive']['tablet']['per_line'], 4) . '%',
+			'tablet_image_size' => intval( $instance['settings']['responsive']['tablet']['image_size'] ) . 'px',
 			'tablet_width' => intval($instance['settings']['responsive']['tablet']['width']) . 'px',
 			'mobile_testimonial_size' => round(100/$instance['settings']['responsive']['mobile']['per_line'], 4) . '%',
+			'mobile_image_size' => intval( $instance['settings']['responsive']['mobile']['image_size'] ) . 'px',
 			'mobile_width' => intval($instance['settings']['responsive']['mobile']['width']) . 'px',
 		);
 	}


### PR DESCRIPTION
If the user decides to have a large image size it can cause rather large display issues on tablet and mobile devices. This PR aims to fix that by offering responsive settings for image sizes so they can specificly set their desired mobile and tablet image sizes.