### PR TITLE
Testimonial: Updated text radius label and fixed resulting functionality

### DIFF
--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -37,7 +37,7 @@
 		background: @text_background;
 		color: @text_color;
 		padding: @testimonial_padding @testimonial_padding*1.5;
-		.border-radius(@text_border_radius);
+		.rounded(@text_border_radius);
 	}
 
 	.sow-round-image-frame {

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -223,7 +223,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 
 					'border_radius' => array(
 						'type' => 'slider',
-						'label' => __('Padding', 'so-widgets-bundle'),
+						'label' => __( 'Testimonial Radius', 'so-widgets-bundle' ),
 						'integer' => true,
 						'default' => 4,
 						'max' => 100,


### PR DESCRIPTION
The testimonial widget has a testimonial radius field mislabled as padding, I've changed it to Testimonial Radius.

The resulting funcitonality also doesn't work currently due to uising .border-radius() over .rounded()