### PR TITLE
Post Carousel: Add default thumbnail

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -91,11 +91,32 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget {
 				'label' => __('Title', 'so-widgets-bundle'),
 			),
 
+			'default_thumbnail' => array(
+				'type'     => 'media',
+				'library'  => 'image',
+				'label'    => __( 'Default Thumbnail', 'so-widgets-bundle' ),
+				'choose'   => __( 'Choose Thumbnail', 'so-widgets-bundle' ),
+				'update'   => __( 'Set Thumbnail', 'so-widgets-bundle' ),
+				'fallback' => true,
+			),
+
 			'posts' => array(
 				'type' => 'posts',
 				'label' => __('Posts query', 'so-widgets-bundle'),
 			),
 		);
+	}
+
+	public function get_template_variables( $instance, $args ) {
+		if ( ! empty( $instance['default_thumbnail'] ) ) {
+			$default_thumbnail = wp_get_attachment_image_src( $instance['default_thumbnail'], 'sow-carousel-default' );
+			if( $default_thumbnail ){
+				return array(
+					'default_thumbnail' => $default_thumbnail[0],
+				);
+			}
+		}
+		return array();
 	}
 
 	function get_template_name($instance){

--- a/widgets/post-carousel/tpl/carousel-post-loop.php
+++ b/widgets/post-carousel/tpl/carousel-post-loop.php
@@ -8,7 +8,9 @@ while($posts->have_posts()) : $posts->the_post(); ?>
 					<span class="overlay"></span>
 				</a>
 			<?php else : ?>
-				<a href="<?php the_permalink() ?>" class="sow-carousel-default-thumbnail"><span class="overlay"></span></a>
+				<a href="<?php the_permalink() ?>" class="sow-carousel-default-thumbnail"
+				<?php echo isset( $default_thumbnail ) ? 
+				'style="background-image: url('. sow_esc_url( $default_thumbnail ) .')"' : '' ?>><span class="overlay"></span></a>
 			<?php endif; ?>
 		</div>
 		<h3><a href="<?php the_permalink() ?>"><?php the_title() ?></a></h3>


### PR DESCRIPTION
When a post doesn't have a featured image set, it shows nothing. This PR will allow users to specify a default image to provide more of a site-specific touch to their carousel.