### PR TITLE
Taxonomy Display Setting: Text

### DIFF
--- a/widgets/taxonomy/taxonomy.php
+++ b/widgets/taxonomy/taxonomy.php
@@ -47,6 +47,7 @@ class SiteOrigin_Widget_Taxonomy_Widget extends SiteOrigin_Widget {
 				'options' => array(
 					'link'   => __( 'Links', 'so-widgets-bundle' ),
 					'button' => __( 'Buttons', 'so-widgets-bundle' ),
+					'text' => __( 'Text', 'so-widgets-bundle' ),
 				),
 			),
 			'color'          => array(

--- a/widgets/taxonomy/tpl/default.php
+++ b/widgets/taxonomy/tpl/default.php
@@ -16,12 +16,16 @@
 		<label class="sow-taxonomy-label"><?php echo esc_html( $label ) ?></label>
 	<?php endif; ?>
 
-	<?php foreach ( get_the_terms( $post->ID, $taxonomy_name ) as $term ) : ?>
-		<?php if ( $display_format == 'text' ) : ?>
-			<span class="so-taxonomy-text" ref="tag"><?php echo esc_html( $term->name ) ?></span>
-		<?php else: ?>
-			<a class="so-taxonomy-<?php echo esc_attr( $display_format )?>" href="<?php echo get_term_link( $term, $taxonomy_name ) ?>" rel="tag"  <?php if ( ! empty( $new_window ) ) echo 'target="_blank"'; ?>><?php echo esc_html( $term->name ) ?></a>
-		<?php endif; ?>
-	<?php endforeach; ?>
+	<?php if ( $display_format == 'text' || $display_format == 'links' ) echo '<p>' ?>
+
+		<?php foreach ( get_the_terms( $post->ID, $taxonomy_name ) as $term ) : ?>
+			<?php if ( $display_format == 'text' ) : ?>
+				<span class="so-taxonomy-text" ref="tag"><?php echo esc_html( $term->name ) ?></span>
+			<?php else: ?>
+				<a class="so-taxonomy-<?php echo esc_attr( $display_format )?>" href="<?php echo get_term_link( $term, $taxonomy_name ) ?>" rel="tag"  <?php if ( ! empty( $new_window ) ) echo 'target="_blank"'; ?>><?php echo esc_html( $term->name ) ?></a>
+			<?php endif; ?>
+		<?php endforeach; ?>
+
+	<?php if ( $display_format == 'text' || $display_format == 'links' ) echo '</p>' ?>
 
 </div>

--- a/widgets/taxonomy/tpl/default.php
+++ b/widgets/taxonomy/tpl/default.php
@@ -18,7 +18,11 @@
 	<?php endif; ?>
 
 	<?php foreach ( get_the_terms( $post->ID, $taxonomy_name ) as $term ) : ?>
-		<a class="so-taxonomy-<?php echo esc_attr( $display_format )?>" href="<?php echo get_term_link( $term, $taxonomy_name ) ?>" rel="tag"><?php echo esc_html( $term->name ) ?></a>
+		<?php if ( $display_format == 'text' ) : ?>
+			<span class="so-taxonomy-text" ref="tag"><?php echo esc_html( $term->name ) ?></span>
+		<?php else: ?>
+			<a class="so-taxonomy-<?php echo esc_attr( $display_format )?>" href="<?php echo get_term_link( $term, $taxonomy_name ) ?>" rel="tag"  <?php if ( ! empty( $new_window ) ) echo 'target="_blank"'; ?>><?php echo esc_html( $term->name ) ?></a>
+		<?php endif; ?>
 	<?php endforeach; ?>
 
 </div>


### PR DESCRIPTION
This PR adds a text display setting for the taxonomy widget. This is ideal for when the user doesn't actually want to link to a specific page but instead purely wants to list them.