### PR TITLE
Add new filters on get_less_variables and get_style_hash_variables

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -789,7 +789,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		//handle less @import statements
 		$less = preg_replace_callback( '/^@import\s+".*?\/?([\w-\.]+)";/m', array( $this, 'get_less_import_contents' ), $less );
 
-		$vars = $this->get_less_variables($instance);
+		$vars = apply_filters( 'siteorigin_widgets_less_variables_' . $this->id_base, $this->get_less_variables( $instance ), $instance, $this );
 		if( !empty( $vars ) ){
 			foreach($vars as $name => $value) {
 				// Ignore empty string, false and null values (but keep '0')
@@ -1042,7 +1042,11 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 * @return string
 	 */
 	function get_style_hash( $instance ) {
-		$vars = method_exists($this, 'get_style_hash_variables') ? $this->get_style_hash_variables( $instance ) : $this->get_less_variables( $instance );
+		if( method_exists( $this, 'get_style_hash_variables' ) ) {
+			$vars = apply_filters( 'siteorigin_widgets_hash_variables_' . $this->id_base, $this->get_style_hash_variables( $instance ), $instance, $this );
+		} else {
+			$vars = apply_filters( 'siteorigin_widgets_less_variables_' . $this->id_base, $this->get_less_variables( $instance ), $instance, $this );
+		}
 		$version = property_exists( $this, 'version' ) ? $this->version : '';
 
 		return substr( md5( json_encode( $vars ) . $version ), 0, 12 );


### PR DESCRIPTION
One of the only important functions on the SiteOrigin_Widget that does not have a filter to override it’s value is the “get_less_variables()” function. Normally this wouldn’t be such a big deal, but it’s very important that we be able to override this with a filter because it’s used by the “get_style_hash()” function which uniquely identifies the instance. This means that with the way it currently works, it’s impossible to add new editor fields to a widget via the “siteorigin_widgets_form_options” filter and have it work properly, because the new field values will not be properly factored into the widget’s style hash and it will be grouped with other widgets that have different values of the new field. I could add this new field by subclassing the widget class and overriding the “get_less_variables()” function that way, but this is a rather heavyweight solution for what I want to do, which is just add one simple editor field that adds a particular CSS style to the widget in order to customize it for my theme.

[Alex S suggested I submit a pull request here.](https://siteorigin.com/thread/siteorigin-widgets-class-needs-filter-over-get_less_variables/)