### PR TITLE
Simple Masonry: Add load event for resizeMasonry

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -64,9 +64,9 @@ sowb.setupSimpleMasonry = function() {
         });
     };
 	
-	$(window).on('resize panelsStretchRows', resizeMasonry);
+	$(window).on('resize panelsStretchRows load', resizeMasonry);
 	
-	// Ensure that the masonry has resized correct on load.
+	// Ensure that the masonry has resized correctly on load.
 	setTimeout( function () {
 		resizeMasonry();
 	}, 100 );


### PR DESCRIPTION
If the user has an awful connection or the designers are using awfully large images, the timer is too slow - gotta rely on the .load to ensure the masonry effect. Hopefully, it doesn't look too bad during the wait (ie. the time between 100 and load). :/