### PR TITLE
Revert #379 - Link Field publicly_queryable check

### DIFF
--- a/base/inc/actions.php
+++ b/base/inc/actions.php
@@ -65,8 +65,7 @@ function siteorigin_widget_search_posts_action(){
 
 	// Get all public post types, besides attachments
 	$post_types = (array) get_post_types( array(
-		'public'             => true,
-		'publicly_queryable' => true
+		'public'             => true
 	) );
 
 	if ( ! empty( $_REQUEST['postTypes'] ) ) {


### PR DESCRIPTION
It's a nice idea in concept but pages aren't publicly_queryable so it falls flat. 😞 
This might be related to #403, or rather, it might have been the change that exacerbated it.