### PR TITLE
Set default color option in wpColorPicker.

### DIFF
--- a/base/inc/fields/color.class.php
+++ b/base/inc/fields/color.class.php
@@ -11,6 +11,14 @@ class SiteOrigin_Widget_Field_Color extends SiteOrigin_Widget_Field_Text_Input_B
 		return $input_classes;
 	}
 
+	protected function get_input_data_attributes() {
+		$data_attributes = parent::get_input_data_attributes();
+		if ( ! empty( $this->default ) ) {
+			$data_attributes['default-color'] = $this->default;
+		}
+		return $data_attributes;
+	}
+
 	protected function sanitize_field_input( $value, $instance ) {
 		$sanitized_value = $value;
 		if( ! preg_match('|^#|', $sanitized_value) ) {

--- a/base/inc/fields/text-input-base.class.php
+++ b/base/inc/fields/text-input-base.class.php
@@ -30,10 +30,26 @@ abstract class SiteOrigin_Widget_Field_Text_Input_Base extends SiteOrigin_Widget
 		return array( 'widefat', 'siteorigin-widget-input' );
 	}
 
+	/**
+	 * The data attributes to be added to the input element.
+	 */
+	protected function get_input_data_attributes() {
+		return array();
+	}
+
+	protected function render_data_attributes( $data_attributes ) {
+		$attr_string = '';
+		foreach ( $data_attributes as $name => $value ) {
+			$attr_string = ' data-' . esc_html( $name ) . '="' . esc_attr( $value ) . '"';
+		}
+		echo $attr_string;
+	}
+
 	protected function render_field( $value, $instance ) {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->element_name ) ?>" id="<?php echo esc_attr( $this->element_id ) ?>"
 		         value="<?php echo esc_attr( $value ) ?>"
+		         <?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
 		         <?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
 			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?> />

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -175,13 +175,20 @@
             $el.find('.siteorigin-widget-field-repeater-item').sowSetupRepeaterItems();
 
             // Set up any color fields
-			$fields.find('> .siteorigin-widget-input-color').wpColorPicker( {
-				change: function(event, ui) {
-					setTimeout(function() {
-						$(event.target).trigger('change');
-					}, 100);
-				}
-			} );
+            $fields.find('> .siteorigin-widget-input-color').each(function () {
+                var colorField = $(this);
+                var colorFieldOptions = {
+                    change: function(event, ui) {
+                        setTimeout(function() {
+                            $(event.target).trigger('change');
+                        }, 100);
+                    }
+                };
+                if( colorField.data('defaultColor') ) {
+                    colorFieldOptions.defaultColor = colorField.data('defaultColor');
+                }
+                colorField.wpColorPicker( colorFieldOptions );
+            });
 
             ///////////////////////////////////////
             // Handle the sections


### PR DESCRIPTION
Resolves GH-180.

If a default color is set for a field, the 'Clear' button will become a 'Default' button and revert to the default color when clicked.