### PR TITLE
Allow multiple post types in posts selector field.

### DIFF
--- a/base/css/admin.css
+++ b/base/css/admin.css
@@ -418,6 +418,10 @@
 .siteorigin-widgets-query-builder .query-builder-content .query-builder-form-field input[type="number"] {
   width: 150px;
 }
+.siteorigin-widgets-query-builder .query-builder-content .query-builder-form-field select[multiple] {
+  min-width: 150px;
+  max-height: 83px;
+}
 .siteorigin-widgets-query-builder .query-builder-content .query-builder-form-field input[type="date"] {
   width: 150px;
   margin: 0 10px;

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -512,6 +512,11 @@
 				width: 150px;
 			}
 
+			select[multiple] {
+				min-width: 150px;
+				max-height: 83px;
+			}
+
 			input[type="date"] {
 				width: 150px;
 				margin: 0 10px;

--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -119,7 +119,7 @@ function siteorigin_widget_post_selector_form_fields(){
 	// The post type field
 	$return['post_type'] = '';
 	$return['post_type'] .= '<label><span>' . __('Post type', 'so-widgets-bundle') . '</span>';
-	$return['post_type'] .= '<select name="post_type">';
+	$return['post_type'] .= '<select name="post_type" multiple>';
 	$return['post_type'] .= '<option value="_all">' . __('All', 'so-widgets-bundle') . '</option>';
 	foreach( get_post_types( array( 'public' => true  ), 'objects' ) as $id => $type ) {
 		if(!empty($type->labels->name)) {
@@ -279,7 +279,9 @@ function siteorigin_widget_post_selector_post_search_action(){
 	if ( empty( $_REQUEST['_widgets_nonce'] ) || !wp_verify_nonce( $_REQUEST['_widgets_nonce'], 'widgets_action' ) ) return;
 	$term = !empty($_GET['term']) ? stripslashes($_GET['term']) : '';
 	$type = !empty($_GET['type']) ? stripslashes($_GET['type']) : '_all';
-	if($type == '_all') $type = explode(',', siteorigin_widget_post_selector_all_post_types());
+	if($type == '_all') $type = siteorigin_widget_post_selector_all_post_types();
+
+	$type = explode(',', $type);
 
 	$results = array();
 	$r = new WP_Query( array('s' => $term, 'post_status' => 'publish', 'posts_per_page' => 20, 'post_type' => $type) );

--- a/base/js/posts-selector.js
+++ b/base/js/posts-selector.js
@@ -64,7 +64,7 @@ var soWidgetPostSelector = ( function ($, _) {
         sticky: null,
 
         defaults: {
-            'post_type' : 'post',
+            'post_type' : [ 'post' ],
             'orderby' : 'post_date',
             'order' : 'DESC',
             'posts_per_page' : '',
@@ -79,7 +79,7 @@ var soWidgetPostSelector = ( function ($, _) {
         // Get the post query model as a WordPress get_posts query
         getQuery: function(){
             var query = [];
-            if( typeof this.get('post_type') !== 'undefined' ) query.push('post_type=' + this.get('post_type'));
+            if( typeof this.get('post_type') !== 'undefined' ) query.push('post_type=' + this.get('post_type').join(','));
             if( typeof this.get('post__in') !== 'undefined' && !_.isEmpty( this.get('post__in') ) ) query.push( 'post__in=' + this.get('post__in').join(',') );
             if( typeof this.get('tax_query') !== 'undefined' && !_.isEmpty( this.get('tax_query') ) ) query.push( 'tax_query=' + this.get('tax_query').join(',') );
             if( typeof this.get('date_query') !== 'undefined' && !_.isEmpty( this.get('date_query') ) ) query.push( 'date_query=' + JSON.stringify(this.get('date_query')) );
@@ -120,7 +120,7 @@ var soWidgetPostSelector = ( function ($, _) {
             // This is a simple array that we use to store parts of the query.
             var theQuery = {};
 
-            if( params.hasOwnProperty('post_type') ) theQuery.post_type = params.post_type;
+            if( params.hasOwnProperty('post_type') ) theQuery.post_type = params.post_type.split(',');
             if( params.hasOwnProperty('post__in') ) theQuery.post__in = params.post__in.split(',');
             if( params.hasOwnProperty('tax_query') ) theQuery.tax_query = params.tax_query.split(',');
             if( params.hasOwnProperty('date_query') ) theQuery.date_query = JSON.parse(params.date_query);
@@ -322,7 +322,7 @@ var soWidgetPostSelector = ( function ($, _) {
 
             // The post type field
             this.form.append('<div class="query-builder-form-field">' + sowPostsSelectorTpl.fields.post_type + '</div>');
-            if( typeof this.model.get('post_type') !== 'undefined' ) this.form.find('select[name="post_type"]').val( this.model.get('post_type'));
+            if( typeof this.model.get('post_type') !== 'undefined' ) this.form.find('select[name="post_type"]').val( this.model.get('post_type') );
 
             // The post__in field
             this.form.append('<div class="query-builder-form-field">' + sowPostsSelectorTpl.fields.post__in + '</div>');
@@ -447,7 +447,7 @@ var soWidgetPostSelector = ( function ($, _) {
         updateModel: function(){
             this.model.set( 'post_type', this.$el.find('*[name="post_type"]').val() );
 
-            // Add the posts in part to the mode
+            // Add the posts in part to the model
             if(this.$el.find('*[name="post__in"]').val().trim() !== '') {
                 this.model.set( 'post__in', this.$el.find('*[name="post__in"]').val().split(',').map(function(a){ return Number( a.trim() ); }) );
             }
@@ -551,7 +551,7 @@ var soWidgetPostSelector = ( function ($, _) {
 
         render: function(){
             var posts = this.model.get('post__in');
-            var postType = this.model.get('post_type');
+            var postType = this.model.get('post_type').join(',');
 
             this.$el.find('.query-builder-content').empty().html(sowPostsSelectorTpl.selector);
 
@@ -692,7 +692,7 @@ var soWidgetPostSelector = ( function ($, _) {
             this.model.set('post__in', ids);
 
             if(!_.isEmpty(ids)) {
-                this.model.set('post_type', '_all');
+                this.model.set('post_type', ['_all']);
                 this.model.set('orderby', 'post__in');
             }
 


### PR DESCRIPTION
Resolve #271.

This just adds the `multiple` attribute to the `select` element. We should consider using the generic form fields for the posts selector.