### PR TITLE
Features: Change text form field to a tinymce field

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -106,7 +106,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 					),
 
 					'text' => array(
-						'type' => 'text',
+						'type' => 'tinymce',
 						'label' => __('Text', 'so-widgets-bundle')
 					),
 


### PR DESCRIPTION
#427 

> A few user's have recently asked for the ability to add bullet lists to the feature's text and while it's possible, they have to use HTML. Changing this field to a TinyMCE field rather than a text field would make the whole process easier for people overall and give more control.

I see haven't seen any issues pop up as a result of this change. I've opted to not include shortcode support as I feel like at that point other widgets would be more suitable. Thoughts?