### PR TITLE
Allow design options to be unset without errors on save.

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -244,7 +244,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'button_width' => isset( $instance['design']['width'] ) ? $instance['design']['width'] : '',
 			'has_button_width' => empty( $instance['design']['width'] ) ? 'false' : 'true',
 			'button_color' => isset($instance['design']['button_color']) ? $instance['design']['button_color'] : '',
-			'text_color' =>   isset($instance['design']['text_color']) ? $instance['design']['button_color'] : '',
+			'text_color' =>   isset($instance['design']['text_color']) ? $instance['design']['text_color'] : '',
 
 			'font_size' => isset($instance['design']['font_size']) ? $instance['design']['font_size'] . 'em' : '',
 			'rounding' => isset($instance['design']['rounding']) ? $instance['design']['rounding'] . 'em' : '',

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -243,12 +243,12 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 		$less_vars = array(
 			'button_width' => isset( $instance['design']['width'] ) ? $instance['design']['width'] : '',
 			'has_button_width' => empty( $instance['design']['width'] ) ? 'false' : 'true',
-			'button_color' => $instance['design']['button_color'],
-			'text_color' => $instance['design']['text_color'],
+			'button_color' => isset($instance['design']['button_color']) ? $instance['design']['button_color'] : '',
+			'text_color' =>   isset($instance['design']['text_color']) ? $instance['design']['button_color'] : '',
 
-			'font_size' => $instance['design']['font_size'] . 'em',
-			'rounding' => $instance['design']['rounding'] . 'em',
-			'padding' => $instance['design']['padding'] . 'em',
+			'font_size' => isset($instance['design']['font_size']) ? $instance['design']['font_size'] . 'em' : '',
+			'rounding' => isset($instance['design']['rounding']) ? $instance['design']['rounding'] . 'em' : '',
+			'padding' => isset($instance['design']['padding']) ? $instance['design']['padding'] . 'em' : '',
 			'has_text' => empty( $instance['text'] ) ? 'false' : 'true',
 		);
 


### PR DESCRIPTION
Hello!

For a site I'm building I wanted to streamline the options the site owners had, so I unhooked some of the design options for buttons. This worked, but on load they threw errors because they where not set (But viewing them still worked). So I figured I'd fix that and create a pull request.

My first formal pull request to an open source project, so please tell me if something should've been done differently.