### PR TITLE
Contact: Prevent form fields from having 0px height if no height spec…

### DIFF
--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -69,7 +69,7 @@
 	@field_border_color: default;
 	@field_border_width: default;
 	@field_border_style: default;
-	@field_height: 0;
+	@field_height: default;
 
 	textarea,
 	.sow-text-field {


### PR DESCRIPTION
This PR prevents the contact form fields from having 0px height if no height specified. I somehow missed this during testing. 😞 