### PR TITLE
Features: Prevent error when no features specified

### DIFF
--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -203,8 +203,10 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 	function get_template_variables( $instance, $args ) {
 		$columns = array();
 		foreach( $instance['columns'] as $column ) {
-			foreach( $column['features'] as &$feature ) {
-				$feature['text'] = do_shortcode( $feature['text'] );
+			if( ! empty( $column['features'] ) ) {
+				foreach( $column['features'] as &$feature ) {
+					$feature['text'] = do_shortcode( $feature['text'] );
+				}
 			}
 			$columns[] = $column;
 		}


### PR DESCRIPTION
This will prevent a warning for when users don't add any features for a column.

> Warning: Invalid argument supplied for foreach() in D:\wamp\www\siteorigin\wp-content\plugins\so-widgets-bundle\widgets\price-table\price-table.php on line 206