### PR TITLE
Carousel: apply static position on .overlay

### DIFF
--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -159,6 +159,7 @@
                         height: 100%;
                         background: #3279BB;
                         opacity: 0;
+						position: static;
                     }
 
                     &:hover {


### PR DESCRIPTION
Due to the generic nature of the `.overlay` class, themes (and plugins) can quite easily unintentionally interfere with the Post Carousel due to the `.overlay` selector. By applying `position: static`; to the overlay, we should be able to avoid the conflict.