### PR TITLE
Layout Slider: Add ability to set Background Image to Title

### DIFF
--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -60,9 +60,10 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 
 							'image_type' => array(
 								'type' => 'select',
-								'label' => __('Background image type', 'so-widgets-bundle'),
+								'label' => __( 'Background image type', 'so-widgets-bundle' ),
 								'options' => array(
-									'cover' => __('Cover', 'so-widgets-bundle'),
+									'cover' => __( 'Cover', 'so-widgets-bundle '),
+									'tile' => __( 'Tile', 'so-widgets-bundle' ),
 								),
 								'default' => 'cover',
 							),


### PR DESCRIPTION
Certain slides will look better if the user has the option of tiling the background rather than setting it to cover.

![](https://i.imgur.com/zZC4EWj.png)