### PR TITLE
Contact: add reply-to header

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1151,7 +1151,8 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 		$headers = array(
 			'Content-Type: text/html; charset=UTF-8',
-			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $email_fields['email'] ) . '>',
+			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . get_option( 'admin_email' ) . '>',
+			'Reply-To: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $email_fields['email'] ) . '>',
 		);
 
 		// Check if this is a duplicated send


### PR DESCRIPTION
This should resolve the vast majority of email related issues with the contact form, but there may be a few issues still present due to the possibility of the admin email being at a different domain.