### PR TITLE
Release 1.9.6

### DIFF
--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -3,6 +3,10 @@
 (function ( $ ) {
 	$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-tinymce', function ( e ) {
 		var $$ = $( this );
+		if( $$.data( 'initialized' ) ) {
+			return;
+		}
+
 		var $container = $$.find( '.siteorigin-widget-tinymce-container' );
 		var settings = $container.data( 'editorSettings' );
 		var $textarea = $container.find( 'textarea' );
@@ -69,6 +73,8 @@
 				$$.find( '.siteorigin-widget-tinymce-selected-editor' ).val( mode );
 			}
 		} );
+
+		$$.data( 'initialized', true );
 	} );
 
 })( jQuery );

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -62,7 +62,7 @@
 								$textarea.val( content );
 							}
 						}
-						editor.setContent(window.switchEditors.wpautop(content));
+						editor.setContent( window.switchEditors.wpautop( content ) );
 					}
 				}
 

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -385,7 +385,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			<?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
 			<?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
-			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo $value ?></textarea>
+			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo htmlentities( $value ) ?></textarea>
 		</div>
 		<input type="hidden"
 		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -173,15 +173,15 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		if ( ! empty( $this->wp_version_lt_4_8 ) ) {
 			add_filter( 'mce_buttons', array( $this, 'mce_buttons_filter' ), 10, 2 );
 			add_filter( 'quicktags_settings', array( $this, 'quicktags_settings' ), 10, 2 );
-			
-			if ( ! empty( $this->button_filters ) ) {
-				foreach ( $this->button_filters as $filter_name => $filter ) {
-					$is_valid_filter = preg_match(
-						'/mce_buttons(?:_[1-4])?|quicktags_settings/', $filter_name
-					) && ! empty( $filter ) && is_callable( $filter );
-					if ( $is_valid_filter ) {
-						add_filter( $filter_name, array( $this, $filter_name ), 10, 2 );
-					}
+		}
+		
+		if ( ! empty( $this->button_filters ) ) {
+			foreach ( $this->button_filters as $filter_name => $filter ) {
+				$is_valid_filter = preg_match(
+					'/mce_buttons(?:_[1-4])?|quicktags_settings/', $filter_name
+				) && ! empty( $filter ) && is_callable( $filter );
+				if ( $is_valid_filter ) {
+					add_filter( $filter_name, array( $this, $filter_name ), 10, 2 );
 				}
 			}
 		}

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -358,6 +358,8 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			),
 		);
 		
+		$tmce_settings = apply_filters( 'tiny_mce_before_init', $tmce_settings, $this->element_id );
+		
 		foreach ( $tmce_settings as $name => $setting ) {
 			if ( ! empty( $tmce_settings[ $name ] ) ) {
 				$settings['tinymce'][$name] = $setting;

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -1,15 +1,3 @@
-body #elementor-editor-wrapper .elementor-panel {
-	min-width: 400px;
-}
-
-body.elementor-editor-preview #elementor-editor-wrapper #elementor-panel {
-	left: -400px;
-}
-
-body.elementor-editor-active #elementor-editor-wrapper #elementor-preview {
-	left: 400px;
-}
-
 .elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form {
 	min-width: inherit;
 

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,15 @@ The SiteOrigin Widgets Bundle is the perfect platform to build widgets for your 
 
 == Changelog ==
 
+= 1.9.6 - 4 August 2017 =
+* Slider: Background Video: Try embedding the video if oEmbed fails.
+* Contact: Added some nonce checks.
+* Contact: add reply-to header.
+* Remove elementor panel width override.
+* Editor: Fix TinyMCE editor button filters in WP >= 4.8.
+* Editor: Preserve encoded HTML entities in TinyMCE field.
+* TinyMCE field: Added missing `tiny_mce_before_init` filter.
+
 = 1.9.5 - 25 July 2017 =
 * Fixed icon field selection.
 * TinyMCE field is initialized when quicktags is selected.

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -313,7 +313,8 @@ class SiteOrigin_Widgets_Bundle {
 	 */
 	function admin_activate_widget() {
 		if(
-			!empty($_GET['page'])
+			current_user_can( apply_filters( 'siteorigin_widgets_admin_menu_capability', 'manage_options' ) )
+			&& !empty($_GET['page'])
 			&& $_GET['page'] == 'so-widgets-plugins'
 			&& !empty( $_GET['widget_action'] ) && !empty( $_GET['widget'] )
 			&& isset($_GET['_wpnonce'])

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -831,7 +831,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			$field_id   = 'sow-contact-form-field-' . $field_name;
 
 			$value = '';
-			if ( ! empty( $_POST[ $field_name ] ) ) {
+			if ( ! empty( $_POST[ $field_name ] ) && wp_verify_nonce( $_POST['_wpnonce'] ) ) {
 				$value = stripslashes_deep( $_POST[ $field_name ] );
 			}
 
@@ -913,6 +913,9 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	 * Ajax action handler to send the form
 	 */
 	function contact_form_action( $instance, $storage_hash ) {
+		if ( ! wp_verify_nonce( $_POST['_wpnonce'] ) ) {
+			exit();
+		}
 		if ( empty( $_POST['instance_hash'] ) || $_POST['instance_hash'] != $storage_hash ) {
 			return false;
 		}

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -914,7 +914,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	 */
 	function contact_form_action( $instance, $storage_hash ) {
 		if ( ! wp_verify_nonce( $_POST['_wpnonce'] ) ) {
-			exit();
+			return false;
 		}
 		if ( empty( $_POST['instance_hash'] ) || $_POST['instance_hash'] != $storage_hash ) {
 			return false;

--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -39,7 +39,8 @@ else {
 		<?php endif ?>
 
 		<?php $this->render_form_fields( $instance['fields'], $result['errors'], $instance ) ?>
-		<input type="hidden" name="instance_hash" value="<?php echo esc_attr($instance_hash) ?>" />
+		<input type="hidden" name="instance_hash" value="<?php echo esc_attr( $instance_hash ) ?>" />
+		<?php echo wp_nonce_field() ?>
 
 		<?php if( $use_recaptcha ) : ?>
 			<div class="sow-recaptcha"


### PR DESCRIPTION
Just a few smallish fixes:
* Slider: Background Video: Try embedding the video if oEmbed fails.
* Contact: Added some nonce checks.
* Contact: add reply-to header.
* Remove elementor panel width override.
* Editor: Fix TinyMCE editor button filters in WP >= 4.8.
* Editor: Preserve encoded HTML entities in TinyMCE field.
* TinyMCE field: Added missing `tiny_mce_before_init` filter.