### PR TITLE
Release 1.9.8

### DIFF
--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -62,7 +62,7 @@
 								$textarea.val( content );
 							}
 						}
-						editor.setContent(window.switchEditors.wpautop(content));
+						editor.setContent( window.switchEditors.wpautop( content ) );
 					}
 				}
 

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -331,11 +331,32 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			'plugins' => array_unique( apply_filters( 'tiny_mce_plugins', $this->mce_plugins ) ),
 		);
 		
-		foreach ( $tmce_settings as $name => $buttons ) {
-			$tmce_settings[ $name ] = is_array( $buttons ) ? implode( ',', $buttons ) : '';
+		foreach ( $tmce_settings as $name => $setting ) {
+			$tmce_settings[ $name ] = is_array( $setting ) ? implode( ',', $setting ) : '';
 		}
 		
 		$tmce_settings['external_plugins'] = array_unique( apply_filters( 'mce_external_plugins', $this->mce_external_plugins ) );
+		
+		$suffix = SCRIPT_DEBUG ? '' : '.min';
+		$version = 'ver=' . get_bloginfo( 'version' );
+		// Default stylesheets
+		$mce_css = includes_url( "css/dashicons$suffix.css?$version" ) . ',' .
+		                                includes_url( "js/tinymce/skins/wordpress/wp-content.css?$version" );
+		
+		$editor_styles = get_editor_stylesheets();
+		
+		if ( ! empty( $editor_styles ) ) {
+			// Force urlencoding of commas.
+			foreach ( $editor_styles as $key => $url ) {
+				if ( strpos( $url, ',' ) !== false ) {
+					$editor_styles[ $key ] = str_replace( ',', '%2C', $url );
+				}
+			}
+			
+			$mce_css .= ',' . implode( ',', $editor_styles );
+		}
+		$mce_css = trim( apply_filters( 'mce_css', $mce_css ), ' ,' );
+		$tmce_settings['content_css'] = $mce_css;
 		
 		$qt_settings = apply_filters(
 			'quicktags_settings',
@@ -372,6 +393,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			$value = preg_replace( '%</textarea%i', '&lt;/textarea', $value );
 		}
 		
+		
 		$media_buttons = $this->render_media_buttons( $this->element_id );
 		
 		?><div class="siteorigin-widget-tinymce-container"
@@ -387,7 +409,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			<?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
 			<?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
-			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo htmlentities( $value ) ?></textarea>
+			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo htmlentities( $value, ENT_QUOTES, 'UTF-8' ) ?></textarea>
 		</div>
 		<input type="hidden"
 		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -383,7 +383,9 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		
 		foreach ( $tmce_settings as $name => $setting ) {
 			if ( ! empty( $tmce_settings[ $name ] ) ) {
-				$settings['tinymce'][$name] = $setting;
+				// Attempt to decode setting as JSON. For back compat with filters used by WP editor.
+				$jdec = json_decode( $setting, true );
+				$settings['tinymce'][ $name ] = empty( $jdec ) ? $setting : $jdec;
 			}
 		}
 		

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -515,7 +515,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		
 		echo '<div id="wp-' . esc_attr( $editor_id ) . '-media-buttons" class="wp-media-buttons">';
 		
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		// Temporarily disable the Jetpack Grunion contact form editor on the widgets screen.
 		if( ! is_null( $screen ) && $screen->id == 'widgets' ) {
 			remove_action( 'media_buttons', 'grunion_media_button', 999 );

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -385,7 +385,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			<?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
 			<?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
-			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo $value ?></textarea>
+			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo htmlentities( $value ) ?></textarea>
 		</div>
 		<input type="hidden"
 		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -173,15 +173,15 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		if ( ! empty( $this->wp_version_lt_4_8 ) ) {
 			add_filter( 'mce_buttons', array( $this, 'mce_buttons_filter' ), 10, 2 );
 			add_filter( 'quicktags_settings', array( $this, 'quicktags_settings' ), 10, 2 );
-			
-			if ( ! empty( $this->button_filters ) ) {
-				foreach ( $this->button_filters as $filter_name => $filter ) {
-					$is_valid_filter = preg_match(
-						'/mce_buttons(?:_[1-4])?|quicktags_settings/', $filter_name
-					) && ! empty( $filter ) && is_callable( $filter );
-					if ( $is_valid_filter ) {
-						add_filter( $filter_name, array( $this, $filter_name ), 10, 2 );
-					}
+		}
+		
+		if ( ! empty( $this->button_filters ) ) {
+			foreach ( $this->button_filters as $filter_name => $filter ) {
+				$is_valid_filter = preg_match(
+					'/mce_buttons(?:_[1-4])?|quicktags_settings/', $filter_name
+				) && ! empty( $filter ) && is_callable( $filter );
+				if ( $is_valid_filter ) {
+					add_filter( $filter_name, array( $this, $filter_name ), 10, 2 );
 				}
 			}
 		}

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -358,6 +358,8 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			),
 		);
 		
+		$tmce_settings = apply_filters( 'tiny_mce_before_init', $tmce_settings, $this->element_id );
+		
 		foreach ( $tmce_settings as $name => $setting ) {
 			if ( ! empty( $tmce_settings[ $name ] ) ) {
 				$settings['tinymce'][$name] = $setting;

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -384,7 +384,9 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		foreach ( $tmce_settings as $name => $setting ) {
 			if ( ! empty( $tmce_settings[ $name ] ) ) {
 				// Attempt to decode setting as JSON. For back compat with filters used by WP editor.
-				$jdec = json_decode( $setting, true );
+				if ( is_string( $setting )  ) {
+					$jdec = json_decode( $setting, true );
+				}
 				$settings['tinymce'][ $name ] = empty( $jdec ) ? $setting : $jdec;
 			}
 		}
@@ -513,7 +515,16 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		
 		echo '<div id="wp-' . esc_attr( $editor_id ) . '-media-buttons" class="wp-media-buttons">';
 		
+		$screen = get_current_screen();
+		// Temporarily disable the Jetpack Grunion contact form editor on the widgets screen.
+		if( ! is_null( $screen ) && $screen->id == 'widgets' ) {
+			remove_action( 'media_buttons', 'grunion_media_button', 999 );
+		}
 		do_action( 'media_buttons', $editor_id );
+		// Temporarily disable the Jetpack Grunion contact form editor on the widgets screen.
+		if( ! is_null( $screen ) && $screen->id == 'widgets' ) {
+			add_action( 'media_buttons', 'grunion_media_button', 999 );
+		}
 		
 		echo "</div>\n";
 		

--- a/compat/beaver-builder/beaver-builder.php
+++ b/compat/beaver-builder/beaver-builder.php
@@ -67,11 +67,12 @@ class SiteOrigin_Widgets_Bundle_Beaver_Builder {
 		wp_enqueue_media();
 
 		wp_enqueue_style( 'sowb-styles-for-beaver', plugin_dir_url( __FILE__ ) . 'styles.css' );
-
+		
+		$deps = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? array( 'jquery', 'fl-builder' ) : array( 'fl-builder-min' );
 		wp_enqueue_script(
 			'sowb-js-for-beaver',
 			plugin_dir_url( __FILE__ ) . 'sowb-beaver-builder' . SOW_BUNDLE_JS_SUFFIX . '.js',
-			array( 'jquery', 'fl-builder' )
+			$deps
 		);
 
 		wp_enqueue_style( 'siteorigin-widget-admin', plugin_dir_url(SOW_BUNDLE_BASE_FILE).'base/css/admin.css', array( 'media-views' ), SOW_BUNDLE_VERSION );

--- a/compat/beaver-builder/beaver-builder.php
+++ b/compat/beaver-builder/beaver-builder.php
@@ -63,9 +63,6 @@ class SiteOrigin_Widgets_Bundle_Beaver_Builder {
 			) );
 		}
 
-		wp_enqueue_style( 'dashicons' );
-		wp_enqueue_media();
-
 		wp_enqueue_style( 'sowb-styles-for-beaver', plugin_dir_url( __FILE__ ) . 'styles.css' );
 		
 		$deps = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? array( 'jquery', 'fl-builder' ) : array( 'fl-builder-min' );

--- a/compat/beaver-builder/sowb-beaver-builder.js
+++ b/compat/beaver-builder/sowb-beaver-builder.js
@@ -2,6 +2,12 @@ var sowb = window.sowb || {};
 
 ( function($){
 	if( typeof FLBuilder !== 'undefined') {
+		// If you're going to override jQuery's `ready` function, at least make sure it still works. :/
+		sowb.orig_FLBuilder_initJQueryReadyFix = FLBuilder._initJQueryReadyFix;
+		FLBuilder._initJQueryReadyFix = function() {
+			return;
+		};
+
 		sowb.orig_FLBuilder_getSettings = FLBuilder._getSettings;
 
 		/**

--- a/compat/elementor/elementor.php
+++ b/compat/elementor/elementor.php
@@ -16,20 +16,23 @@ class SiteOrigin_Widgets_Bundle_Elementor {
 	private $plugin;
 
 	function __construct() {
-		add_action( 'template_redirect', array( $this, 'init' ) );
+		add_action( 'admin_action_elementor', array( $this, 'init_editor' ) );
+		add_action( 'template_redirect', array( $this, 'init_preview' ) );
 
 		add_action( 'wp_ajax_elementor_render_widget', array( $this, 'ajax_render_widget_preview' ) );
 		add_action( 'wp_ajax_elementor_editor_get_wp_widget_form', array( $this, 'ajax_render_widget_form' ) );
 	}
 
-	function init() {
+	function init_editor() {
+		add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'enqueue_active_widgets_scripts' ) );
+	}
+	
+	function init_preview() {
 		$this->plugin = Elementor\Plugin::instance();
 		if ( !empty( $this->plugin->preview ) && method_exists( $this->plugin->preview, 'is_preview_mode' ) && $this->plugin->preview->is_preview_mode() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 			add_action( 'elementor/preview/enqueue_styles', array( $this, 'enqueue_preview_scripts' ) );
 		}
-
-		add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'enqueue_active_widgets_scripts' ) );
 	}
 
 	function enqueue_frontend_scripts() {
@@ -103,10 +106,7 @@ class SiteOrigin_Widgets_Bundle_Elementor {
 
 	function render_widget_preview( $widget_output ) {
 		
-		$wp_styles  = wp_styles();
-
-		// Print any styles we may have enqueued for live preview.
-		wp_print_styles( $wp_styles->queue );
+		siteorigin_widget_print_styles();
 
 		return $widget_output;
 	}

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -1,15 +1,3 @@
-body #elementor-editor-wrapper .elementor-panel {
-	min-width: 400px;
-}
-
-body.elementor-editor-preview #elementor-editor-wrapper #elementor-panel {
-	left: -400px;
-}
-
-body.elementor-editor-active #elementor-editor-wrapper #elementor-preview {
-	left: 400px;
-}
-
 .elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form {
 	min-width: inherit;
 

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -80,6 +80,9 @@ class SiteOrigin_Widgets_Bundle {
 
 		add_filter( 'wp_enqueue_scripts', array($this, 'register_general_scripts') );
 		add_filter( 'wp_enqueue_scripts', array($this, 'enqueue_active_widgets_scripts') );
+		
+		// This is a temporary filter to disable the new Jetpack Grunion contact form editor.
+		add_filter( 'tmp_grunion_allow_editor_view', '__return_false' );
 	}
 
 	/**

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -64,6 +64,12 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						'description' => __( 'Where contact emails will be delivered to.', 'so-widgets-bundle' ),
 						'sanitize'    => 'multiple_emails',
 					),
+					'from'                               => array(
+						'type'        => 'text',
+						'label'       => __( 'From email address', 'so-widgets-bundle' ),
+						'description' => __( 'It will appear as if emails are sent from this address. Ideally this should be in the same domain as this server to avoid spam filters.', 'so-widgets-bundle' ),
+						'sanitize'    => 'email',
+					),
 					'default_subject'                  => array(
 						'type'        => 'text',
 						'label'       => __( 'Default subject', 'so-widgets-bundle' ),
@@ -647,6 +653,9 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			$current_user               = wp_get_current_user();
 			$instance['settings']['to'] = $current_user->user_email;
 		}
+		if ( empty( $instance['settings']['from'] ) ) {
+			$instance['settings']['from'] = get_option( 'admin_email' );
+		}
 		if ( empty( $instance['fields'] ) ) {
 			$instance['fields'] = array(
 				array(
@@ -1148,10 +1157,14 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			// Also replaces the email address that comes from the prebuilt layout directory
 			$instance['settings']['to'] = get_option( 'admin_email' );
 		}
+		
+		if ( $instance['settings']['from'] == 'test@example.com' || empty( $instance['settings']['from'] ) ) {
+			$instance['settings']['from'] = get_option( 'admin_email' );
+		}
 
 		$headers = array(
 			'Content-Type: text/html; charset=UTF-8',
-			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . get_option( 'admin_email' ) . '>',
+			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . $instance['settings']['from'] . '>',
 			'Reply-To: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $email_fields['email'] ) . '>',
 		);
 

--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -398,6 +398,11 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 						'type'  => 'checkbox',
 						'label' => __( 'Avoid tolls', 'so-widgets-bundle' ),
 					),
+					'preserve_viewport' => array(
+						'type'  => 'checkbox',
+						'label' => __( 'Preserve viewport', 'so-widgets-bundle' ),
+						'description' => __( 'This will prevent the map from centering and zooming around the directions. Use this when you have other markers or features on your map.', 'so-widgets-bundle' ),
+					),
 					'waypoints'          => array(
 						'type'       => 'repeater',
 						'label'      => __( 'Waypoints', 'so-widgets-bundle' ),

--- a/widgets/google-map/js/js-map.js
+++ b/widgets/google-map/js/js-map.js
@@ -254,6 +254,7 @@ sowb.SiteOriginGoogleMap = function($) {
 					},
 					function(result, status) {
 						if (status === google.maps.DirectionsStatus.OK) {
+							directionsRenderer.setOptions( { preserveViewport: directions.preserveViewport } );
 							directionsRenderer.setDirections(result);
 						}
 					});

--- a/widgets/image-grid/js/image-grid.js
+++ b/widgets/image-grid/js/image-grid.js
@@ -1,8 +1,10 @@
 /* globals jQuery, sowb */
 var sowb = window.sowb || {};
 
-jQuery( function($){
-	sowb.setupImageGrids = function(){
+jQuery( function() {
+	// Some page builders (ahem Beaver Builder) override the jQuery `ready` function, but don't pass in the jQuery object. :(
+	var $ = jQuery;
+	sowb.setupImageGrids = function() {
 		$('.sow-image-grid-wrapper').each( function(){
 			var $$ = $(this);
 			$$.imagesLoaded( function () {

--- a/widgets/image-grid/js/image-grid.js
+++ b/widgets/image-grid/js/image-grid.js
@@ -1,9 +1,7 @@
 /* globals jQuery, sowb */
 var sowb = window.sowb || {};
 
-jQuery( function() {
-	// Some page builders (ahem Beaver Builder) override the jQuery `ready` function, but don't pass in the jQuery object. :(
-	var $ = jQuery;
+jQuery( function($) {
 	sowb.setupImageGrids = function() {
 		$('.sow-image-grid-wrapper').each( function(){
 			var $$ = $(this);

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -14,7 +14,7 @@ jQuery( function($){
             fetching = false,
             numItems = $items.length,
             totalPosts = $$.data('found-posts'),
-            complete = numItems == totalPosts,
+            complete = numItems === totalPosts,
             itemWidth = ( $firstItem.width() + parseInt($firstItem.css('margin-right')) ),
             isRTL = $postsContainer.hasClass('js-rtl'),
             updateProp = isRTL ? 'margin-right' : 'margin-left';
@@ -29,7 +29,7 @@ jQuery( function($){
                     page++;
                     $itemsContainer.append('<li class="sow-carousel-item sow-carousel-loading"></li>');
                     var instanceHash = $container.find('input[name="instance_hash"]').val();
-                    
+
                     $.get(
                         $$.data('ajax-url'),
                         {
@@ -43,7 +43,7 @@ jQuery( function($){
                             $items.appendTo( $itemsContainer ).hide().fadeIn();
                             $$.find('.sow-carousel-loading').remove();
                             numItems = $$.find('.sow-carousel-item').length;
-                            complete = numItems == totalPosts;
+                            complete = numItems === totalPosts;
                             fetching = false;
                         }
                     )
@@ -68,28 +68,57 @@ jQuery( function($){
                 updatePosition();
             }
         );
-        var validSwipe = false;
-        var prevDistance = 0;
-        var startPosition = 0;
-        var velocity = 0;
-        var prevTime = 0;
-        var posInterval;
-        var negativeDirection = isRTL ? 'right' : 'left';
-        
+
         // Verify "swipe" method exists prior to invoking it.
         if( 'function' === typeof $$.swipe ) {
+			var validSwipe = false;
+			var prevDistance = 0;
+			var startPosition = 0;
+			var velocity = 0;
+			var prevTime = 0;
+			var posInterval;
+			var negativeDirection = isRTL ? 'right' : 'left';
+
+			var setNewPosition = function(newPosition) {
+				if(newPosition < 50 && newPosition >  -( itemWidth * numItems )) {
+					$itemsContainer.css('transition-duration', "0s");
+					$itemsContainer.css(updateProp, newPosition + 'px' );
+					return true;
+				}
+				return false;
+			};
+
+			var setFinalPosition = function() {
+				var finalPosition = parseInt( $itemsContainer.css(updateProp) );
+				position = Math.abs( Math.round( finalPosition / itemWidth ) );
+				updatePosition();
+			};
+
+			$$.on('click', '.sow-carousel-item a',
+				function (event) {
+					if(validSwipe) {
+						event.preventDefault();
+						validSwipe = false;
+					}
+				}
+			);
+
         	$$.swipe( {
 	            excludedElements: "",
 	            triggerOnTouchEnd: true,
 	            threshold: 75,
-	            swipeStatus: function (event, phase, direction, distance, duration, fingerCount, fingerData) {
-	                if ( phase == "start" ) {
+				swipeStatus: function (event, phase, direction, distance, duration, fingerCount, fingerData) {
+					if ( direction === 'up' || direction === 'down') {
+						return false;
+					}
+
+	                if ( phase === "start" ) {
 	                    startPosition = -( itemWidth * position);
 	                    prevTime = new Date().getTime();
 	                    clearInterval(posInterval);
 	                }
-	                else if ( phase == "move" ) {
-	                    if( direction == negativeDirection ) distance *= -1;
+	                else if ( phase === "move" ) {
+	                    if( direction === negativeDirection ) distance *= -1;
 	                    setNewPosition(startPosition + distance);
 	                    var newTime = new Date().getTime();
 	                    var timeDelta = (newTime - prevTime) / 1000;
@@ -97,9 +126,9 @@ jQuery( function($){
 	                    prevTime = newTime;
 	                    prevDistance = distance;
 	                }
-	                else if ( phase == "end" ) {
+	                else if ( phase === "end" ) {
 	                    validSwipe = true;
-	                    if( direction == negativeDirection ) distance *= -1;
+	                    if( direction === negativeDirection ) distance *= -1;
 	                    if(Math.abs(velocity) > 400) {
 	                        velocity *= 0.1;
 	                        var startTime = new Date().getTime();
@@ -110,7 +139,7 @@ jQuery( function($){
 	                            var newPos = startPosition + distance + cumulativeDistance;
 	                            var decel = 30;
 	                            var end = (Math.abs(velocity) - decel) < 0;
-	                            if(direction == negativeDirection) {
+	                            if(direction === negativeDirection) {
 	                                velocity += decel;
 	                            } else {
 	                                velocity -= decel;
@@ -124,34 +153,11 @@ jQuery( function($){
 	                        setFinalPosition();
 	                    }
 	                }
-	                else if( phase == "cancel") {
+	                else if( phase === "cancel") {
 	                    updatePosition();
 	                }
 	            }
 	        } );
         }
-        
-        
-        var setNewPosition = function(newPosition) {
-            if(newPosition < 50 && newPosition >  -( itemWidth * numItems )) {
-                $itemsContainer.css('transition-duration', "0s");
-                $itemsContainer.css(updateProp, newPosition + 'px' );
-                return true;
-            }
-            return false;
-        };
-        var setFinalPosition = function() {
-            var finalPosition = parseInt( $itemsContainer.css(updateProp) );
-            position = Math.abs( Math.round( finalPosition / itemWidth ) );
-            updatePosition();
-        };
-        $$.on('click', '.sow-carousel-item a',
-            function (event) {
-                if(validSwipe) {
-                    event.preventDefault();
-                    validSwipe = false;
-                }
-            }
-        )
     } );
 } );

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -1,76 +1,76 @@
-jQuery( function($){
-    // The carousel widget
-    $('.sow-carousel-wrapper').each(function(){
+jQuery( function ( $ ) {
+	// The carousel widget
+	$( '.sow-carousel-wrapper' ).each( function () {
 
-        var $$ = $(this),
-            $postsContainer = $$.closest('.sow-carousel-container'),
-            $container = $$.closest('.sow-carousel-container').parent(),
-            $itemsContainer = $$.find('.sow-carousel-items'),
-            $items = $$.find('.sow-carousel-item'),
-            $firstItem = $items.eq(0);
+		var $$ = $( this ),
+			$postsContainer = $$.closest( '.sow-carousel-container' ),
+			$container = $$.closest( '.sow-carousel-container' ).parent(),
+			$itemsContainer = $$.find( '.sow-carousel-items' ),
+			$items = $$.find( '.sow-carousel-item' ),
+			$firstItem = $items.eq( 0 );
 
-        var position = 0,
-            page = 1,
-            fetching = false,
-            numItems = $items.length,
-            totalPosts = $$.data('found-posts'),
-            complete = numItems === totalPosts,
-            itemWidth = ( $firstItem.width() + parseInt($firstItem.css('margin-right')) ),
-            isRTL = $postsContainer.hasClass('js-rtl'),
-            updateProp = isRTL ? 'margin-right' : 'margin-left';
+		var position = 0,
+			page = 1,
+			fetching = false,
+			numItems = $items.length,
+			totalPosts = $$.data( 'found-posts' ),
+			complete = numItems === totalPosts,
+			itemWidth = ( $firstItem.width() + parseInt( $firstItem.css( 'margin-right' ) ) ),
+			isRTL = $postsContainer.hasClass( 'js-rtl' ),
+			updateProp = isRTL ? 'margin-right' : 'margin-left';
 
-        var updatePosition = function() {
-            if ( position < 0 ) position = 0;
-            if ( position >= $$.find('.sow-carousel-item').length - 1 ) {
-                position = $$.find('.sow-carousel-item').length - 1;
-                // Fetch the next batch
-                if( !fetching &&  !complete ) {
-                    fetching = true;
-                    page++;
-                    $itemsContainer.append('<li class="sow-carousel-item sow-carousel-loading"></li>');
-                    var instanceHash = $container.find('input[name="instance_hash"]').val();
+		var updatePosition = function () {
+			if ( position < 0 ) position = 0;
+			if ( position >= $$.find( '.sow-carousel-item' ).length - 1 ) {
+				position = $$.find( '.sow-carousel-item' ).length - 1;
+				// Fetch the next batch
+				if ( !fetching && !complete ) {
+					fetching = true;
+					page++;
+					$itemsContainer.append( '<li class="sow-carousel-item sow-carousel-loading"></li>' );
+					var instanceHash = $container.find( 'input[name="instance_hash"]' ).val();
 
-                    $.get(
-                        $$.data('ajax-url'),
-                        {
-                            query : $$.data('query'),
-                            action : 'sow_carousel_load',
-                            paged : page,
-                            instance_hash : instanceHash,
-                        },
-                        function (data, status){
-                            var $items = $(data.html);
-                            $items.appendTo( $itemsContainer ).hide().fadeIn();
-                            $$.find('.sow-carousel-loading').remove();
-                            numItems = $$.find('.sow-carousel-item').length;
-                            complete = numItems === totalPosts;
-                            fetching = false;
-                        }
-                    )
-                }
-            }
-            $itemsContainer.css('transition-duration', "0.45s");
-            $itemsContainer.css(updateProp, -( itemWidth * position) + 'px' );
-        };
+					$.get(
+						$$.data( 'ajax-url' ),
+						{
+							query: $$.data( 'query' ),
+							action: 'sow_carousel_load',
+							paged: page,
+							instance_hash: instanceHash,
+						},
+						function ( data, status ) {
+							var $items = $( data.html );
+							$items.appendTo( $itemsContainer ).hide().fadeIn();
+							$$.find( '.sow-carousel-loading' ).remove();
+							numItems = $$.find( '.sow-carousel-item' ).length;
+							complete = numItems === totalPosts;
+							fetching = false;
+						}
+					)
+				}
+			}
+			$itemsContainer.css( 'transition-duration', "0.45s" );
+			$itemsContainer.css( updateProp, -( itemWidth * position) + 'px' );
+		};
 
-        $container.on( 'click', 'a.sow-carousel-previous',
-            function(e){
-                e.preventDefault();
-                position -= isRTL ? -1 : 1;
-                updatePosition();
-            }
-        );
+		$container.on( 'click', 'a.sow-carousel-previous',
+			function ( e ) {
+				e.preventDefault();
+				position -= isRTL ? -1 : 1;
+				updatePosition();
+			}
+		);
 
-        $container.on( 'click', 'a.sow-carousel-next',
-            function(e){
-                e.preventDefault();
-                position += isRTL ? -1 : 1;
-                updatePosition();
-            }
-        );
+		$container.on( 'click', 'a.sow-carousel-next',
+			function ( e ) {
+				e.preventDefault();
+				position += isRTL ? -1 : 1;
+				updatePosition();
+			}
+		);
 
-        // Verify "swipe" method exists prior to invoking it.
-        if( 'function' === typeof $$.swipe ) {
+		// Verify "swipe" method exists prior to invoking it.
+		if ( 'function' === typeof $$.swipe ) {
 			var validSwipe = false;
 			var prevDistance = 0;
 			var startPosition = 0;
@@ -79,85 +79,85 @@ jQuery( function($){
 			var posInterval;
 			var negativeDirection = isRTL ? 'right' : 'left';
 
-			var setNewPosition = function(newPosition) {
-				if(newPosition < 50 && newPosition >  -( itemWidth * numItems )) {
-					$itemsContainer.css('transition-duration', "0s");
-					$itemsContainer.css(updateProp, newPosition + 'px' );
+			var setNewPosition = function ( newPosition ) {
+				if ( newPosition < 50 && newPosition > -( itemWidth * numItems ) ) {
+					$itemsContainer.css( 'transition-duration', "0s" );
+					$itemsContainer.css( updateProp, newPosition + 'px' );
 					return true;
 				}
 				return false;
 			};
 
-			var setFinalPosition = function() {
-				var finalPosition = parseInt( $itemsContainer.css(updateProp) );
+			var setFinalPosition = function () {
+				var finalPosition = parseInt( $itemsContainer.css( updateProp ) );
 				position = Math.abs( Math.round( finalPosition / itemWidth ) );
 				updatePosition();
 			};
 
-			$$.on('click', '.sow-carousel-item a',
-				function (event) {
-					if(validSwipe) {
+			$$.on( 'click', '.sow-carousel-item a',
+				function ( event ) {
+					if ( validSwipe ) {
 						event.preventDefault();
 						validSwipe = false;
 					}
 				}
 			);
 
-        	$$.swipe( {
-	            excludedElements: "",
-	            triggerOnTouchEnd: true,
-	            threshold: 75,
-				swipeStatus: function (event, phase, direction, distance, duration, fingerCount, fingerData) {
-					if ( direction === 'up' || direction === 'down') {
+			$$.swipe( {
+				excludedElements: "",
+				triggerOnTouchEnd: true,
+				threshold: 75,
+				swipeStatus: function ( event, phase, direction, distance, duration, fingerCount, fingerData ) {
+					if ( direction === 'up' || direction === 'down' ) {
 						return false;
 					}
 
-	                if ( phase === "start" ) {
-	                    startPosition = -( itemWidth * position);
-	                    prevTime = new Date().getTime();
-	                    clearInterval(posInterval);
-	                }
-	                else if ( phase === "move" ) {
-	                    if( direction === negativeDirection ) distance *= -1;
-	                    setNewPosition(startPosition + distance);
-	                    var newTime = new Date().getTime();
-	                    var timeDelta = (newTime - prevTime) / 1000;
-	                    velocity = (distance - prevDistance) / timeDelta;
-	                    prevTime = newTime;
-	                    prevDistance = distance;
-	                }
-	                else if ( phase === "end" ) {
-	                    validSwipe = true;
-	                    if( direction === negativeDirection ) distance *= -1;
-	                    if(Math.abs(velocity) > 400) {
-	                        velocity *= 0.1;
-	                        var startTime = new Date().getTime();
-	                        var cumulativeDistance = 0;
-	                        posInterval = setInterval(function () {
-	                            var time = (new Date().getTime() - startTime) / 1000;
-	                            cumulativeDistance += velocity * time;
-	                            var newPos = startPosition + distance + cumulativeDistance;
-	                            var decel = 30;
-	                            var end = (Math.abs(velocity) - decel) < 0;
-	                            if(direction === negativeDirection) {
-	                                velocity += decel;
-	                            } else {
-	                                velocity -= decel;
-	                            }
-	                            if(end || !setNewPosition(newPos)) {
-	                                clearInterval(posInterval);
-	                                setFinalPosition();
-	                            }
-	                        }, 20);
-	                    } else {
-	                        setFinalPosition();
-	                    }
-	                }
-	                else if( phase === "cancel") {
-	                    updatePosition();
-	                }
-	            }
-	        } );
-        }
-    } );
+					if ( phase === "start" ) {
+						startPosition = -( itemWidth * position);
+						prevTime = new Date().getTime();
+						clearInterval( posInterval );
+					}
+					else if ( phase === "move" ) {
+						if ( direction === negativeDirection ) distance *= -1;
+						setNewPosition( startPosition + distance );
+						var newTime = new Date().getTime();
+						var timeDelta = (newTime - prevTime) / 1000;
+						velocity = (distance - prevDistance) / timeDelta;
+						prevTime = newTime;
+						prevDistance = distance;
+					}
+					else if ( phase === "end" ) {
+						validSwipe = true;
+						if ( direction === negativeDirection ) distance *= -1;
+						if ( Math.abs( velocity ) > 400 ) {
+							velocity *= 0.1;
+							var startTime = new Date().getTime();
+							var cumulativeDistance = 0;
+							posInterval = setInterval( function () {
+								var time = (new Date().getTime() - startTime) / 1000;
+								cumulativeDistance += velocity * time;
+								var newPos = startPosition + distance + cumulativeDistance;
+								var decel = 30;
+								var end = (Math.abs( velocity ) - decel) < 0;
+								if ( direction === negativeDirection ) {
+									velocity += decel;
+								} else {
+									velocity -= decel;
+								}
+								if ( end || !setNewPosition( newPos ) ) {
+									clearInterval( posInterval );
+									setFinalPosition();
+								}
+							}, 20 );
+						} else {
+							setFinalPosition();
+						}
+					}
+					else if ( phase === "cancel" ) {
+						updatePosition();
+					}
+				}
+			} );
+		}
+	} );
 } );

--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -2,8 +2,7 @@
 
 var sowb = window.sowb || {};
 
-jQuery( function(){
-	var $ = jQuery;
+jQuery( function($){
 	sowb.setupSimpleMasonries = function() {
 		var $grid = $('.sow-masonry-grid');
 

--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -2,7 +2,8 @@
 
 var sowb = window.sowb || {};
 
-jQuery( function($){
+jQuery( function(){
+	var $ = jQuery;
 	sowb.setupSimpleMasonries = function() {
 		var $grid = $('.sow-masonry-grid');
 

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -193,16 +193,18 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 	
 	function get_template_variables( $instance, $args ) {
 		$frames = $instance['frames'];
-		foreach ( $frames as &$frame ) {
-			$link_atts = array();
-			if ( ! empty( $frame['new_window'] ) ) {
-				$link_atts['target'] = '_blank';
+		if ( ! empty( $frames ) ) {
+			foreach ( $frames as &$frame ) {
+				$link_atts = array();
+				if ( ! empty( $frame['new_window'] ) ) {
+					$link_atts['target'] = '_blank';
+				}
+				$frame['link_attributes'] = $link_atts;
 			}
-			$frame['link_attributes'] = $link_atts;
 		}
 		return array(
 			'controls' => $instance['controls'],
-			'frames' => $frames,
+			'frames' => empty( $frames ) ? array() : $frames,
 		);
 	}
 	


### PR DESCRIPTION
* Use WordPress functions to exit AJAX actions.
* TinyMCE field: Initialized once.
* TinyMCE field: Simplified switching between TinyMCE and QuickTags.
* TinyMCE field: Check if individual TinyMCE settings are encoded as JSON and decode before re-encoding all settings.
* Some compat fixes for Elementor.
* TinyMCE field: Temporarily disable Jetpack Grunion editor.
* Use correct JS dependencies for Beaver Builder compatibility when `WP_DEBUG` not defined.
* Removed unnecessary enqueues in Beaver Builder compat for dashicons and wp media scripts.
* Post carousel: Only handle horizontal swipes.