### PR TITLE
Contact: mention it's possible to send to multiple emails

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -61,7 +61,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					'to'                               => array(
 						'type'        => 'text',
 						'label'       => __( 'To email address', 'so-widgets-bundle' ),
-						'description' => __( 'Where contact emails will be delivered to.', 'so-widgets-bundle' ),
+						'description' => __( 'Where contact emails will be delivered to. You can send to multiple emails by separating the emails with a comma (,)', 'so-widgets-bundle' ),
 						'sanitize'    => 'multiple_emails',
 					),
 					'from'                               => array(


### PR DESCRIPTION
Currently, the To Email Address field doesn't mention that you can send to multiple emails by separating the emails with a comma. This PR corrects that.

![](https://i.imgur.com/oHoMfoq.png)