### PR TITLE
Accordion: Add Repeator Label Title

### DIFF
--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -44,6 +44,11 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 			'panels' => array(
 				'type' => 'repeater',
 				'label' => __( 'Panels', 'so-widgets-bundle' ),
+				'item_label' => array(
+					'selector' => "[id*='panels-title']",
+					'update_event' => 'change',
+					'value_method' => 'val'
+				),
 				'fields' => array(
 					'title' => array(
 						'type' => 'text',


### PR DESCRIPTION
This will change the accordion repeater label title based on the item title.

Before:
![](https://vgy.me/h6uYmG.png)

After:
![](https://vgy.me/PBNbGG.png)


