### PR TITLE
Social Media Buttons Widget: Comply with WCAG 2.4.4

### DIFF
--- a/widgets/social-media-buttons/tpl/default.php
+++ b/widgets/social-media-buttons/tpl/default.php
@@ -6,9 +6,11 @@
 		if( !empty($instance['design']['hover']) ) $classes[] = 'ow-button-hover';
 		$classes[] = "sow-social-media-button-" . sanitize_html_class( $network['name'] );
 		$classes[] = "sow-social-media-button";
+		$title = empty( $network['icon_title'] ) ? sprintf( __( '%s on %s', 'so-widgets-bundle' ), get_bloginfo( 'name' ), ucwords( str_replace( '-', ' ', $network['name'] ) ) ) : $network['icon_title'];
 		$button_attributes = array(
 			'class' => esc_attr( implode(' ', $classes) ),
-			'title' => empty( $network['icon_title'] ) ? sprintf( __( '%s on %s', 'so-widgets-bundle' ), get_bloginfo( 'name' ), ucwords( str_replace( '-', ' ', $network['name'] ) ) ) : $network['icon_title'],
+			'title' => $title,
+			'aria-label' => $title,
 		);
 		if( !empty( $instance['design']['new_window'] ) ) {
 			$button_attributes['target'] = '_blank';


### PR DESCRIPTION
This PR will allow for the SiteOrigin Social Media Buttons to comply with [WCAG 2.4.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html) by using [ARIA8](https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html). Tested using [WAVE](http://wave.webaim.org/).