### PR TITLE
Hero: Add margin-top to .so-widget-sow-button for spacing

### DIFF
--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -75,7 +75,7 @@
 
 				.so-widget-sow-button {
 					display: inline-block;
-					margin: 0 6px;
+					margin: 3px 6px 0;
 				}
 
 			}


### PR DESCRIPTION
When there are either a lot of buttons added or there's more than one on mobile (and they're above normal width), the buttons will touch. This PR avoids this by adding a small amount of top margin.

Overflow of buttons example:
![](https://vgy.me/3BlRVT.png)

Big button mobile example:
![](https://vgy.me/NxlsMw.png)