### PR TITLE
Accordion overflow

### DIFF
--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -96,6 +96,7 @@
 				color: @panels_font_color;
 				font-family: @panels_font_family;
 				font-size: @panels_font_size;
+				overflow: auto;
 			}
 		}
 		margin-bottom: @panels_margin_bottom;


### PR DESCRIPTION
This fixes long title overflow and the toggle expand / collapse button location. 

/* Fixes Accordion Title width */
.sow-accordion-title{
width: calc(100% - 20px);
}
