### PR TITLE
Accordion: Icon title collapse fix

### DIFF
--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -60,6 +60,7 @@
 
 			.sow-accordion-title {
 				display: inline-block;
+				width: ~"calc(100% - 20px)";
 				& when ( @show_open_close_icon = true ) and ( @heading_title_align = @open_close_location ) {
 					margin-@{open_close_location}: 5px;
 				}


### PR DESCRIPTION
Resolves #617. This is a fixed version of #623.

Credit @acollis for the initial idea for this fix. This version escapes the calc to prevent less.js from processing the calc as math.