### PR TITLE
Features: Add ability to control responsive breakpoint

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -276,11 +276,38 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 			}
 		}
 
-        $less_vars['container_size'] = $instance['container_size'];
-        $less_vars['icon_size'] = $instance['icon_size'];
-        $less_vars['use_icon_size'] = empty( $instance['icon_size_custom'] ) ? 'false' : 'true';
+		$less_vars['container_size'] = $instance['container_size'];
+		$less_vars['icon_size'] = $instance['icon_size'];
+		$less_vars['use_icon_size'] = empty( $instance['icon_size_custom'] ) ? 'false' : 'true';
+
+		$global_settings = $this->get_global_settings();
+		if ( function_exists( 'siteorigin_panels_setting' ) ) {
+			// If the global widget setting is different to the page builder responsive setting, we should use the global widget setting
+			if ( ! empty( $global_settings['responsive_breakpoint'] ) && siteorigin_panels_setting( 'mobile-width' ) != intval( $global_settings['responsive_breakpoint'] ) ) {
+				$less_vars['responsive_breakpoint'] = $global_settings['responsive_breakpoint'];
+			} else {
+				$less_vars['responsive_breakpoint'] = siteorigin_panels_setting( 'mobile-width' );
+			}
+		} else {
+			$less_vars['responsive_breakpoint'] = $global_settings['responsive_breakpoint'];
+		}
+		$less_vars['responsive_breakpoint'] .= 'px';
 
 		return $less_vars;
+	}
+
+	function get_settings_form() {
+		return array(
+			'responsive_breakpoint' => array(
+				'type'        => 'number',
+				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
+				'default'     => ( ! function_exists( 'siteorigin_panels_setting' ) ? 520 : false ), // We want to default to the global setting if Page Builder is enabled so we're not going to set anything
+				'description' => sprintf(
+					__( 'At what resolution the features widget will collapse. %s', 'so-widgets-bundle' ),
+					( function_exists( 'siteorigin_panels_setting' ) ?  sprintf( __( 'This setting will override the global mobile breakpoint which is currently set to %dpx'), siteorigin_panels_setting( 'mobile-width' ) ) : '' )
+				)
+			)
+		);
 	}
 
 	function get_google_font_fields( $instance ) {

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -281,17 +281,10 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 		$less_vars['use_icon_size'] = empty( $instance['icon_size_custom'] ) ? 'false' : 'true';
 
 		$global_settings = $this->get_global_settings();
-		if ( function_exists( 'siteorigin_panels_setting' ) ) {
-			// If the global widget setting is different to the page builder responsive setting, we should use the global widget setting
-			if ( ! empty( $global_settings['responsive_breakpoint'] ) && siteorigin_panels_setting( 'mobile-width' ) != intval( $global_settings['responsive_breakpoint'] ) ) {
-				$less_vars['responsive_breakpoint'] = $global_settings['responsive_breakpoint'];
-			} else {
-				$less_vars['responsive_breakpoint'] = siteorigin_panels_setting( 'mobile-width' );
-			}
-		} else {
+
+		if ( ! empty( $global_settings['responsive_breakpoint'] ) ) {
 			$less_vars['responsive_breakpoint'] = $global_settings['responsive_breakpoint'];
 		}
-		$less_vars['responsive_breakpoint'] .= 'px';
 
 		return $less_vars;
 	}
@@ -299,13 +292,10 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 	function get_settings_form() {
 		return array(
 			'responsive_breakpoint' => array(
-				'type'        => 'number',
+				'type'        => 'measurement',
 				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
-				'default'     => ( ! function_exists( 'siteorigin_panels_setting' ) ? 520 : false ), // We want to default to the global setting if Page Builder is enabled so we're not going to set anything
-				'description' => sprintf(
-					__( 'At what resolution the features widget will collapse. %s', 'so-widgets-bundle' ),
-					( function_exists( 'siteorigin_panels_setting' ) ?  sprintf( __( 'This setting will override the global mobile breakpoint which is currently set to %dpx'), siteorigin_panels_setting( 'mobile-width' ) ) : '' )
-				)
+				'default'     => '520px',
+				'description' => __( 'This setting controls when the features widget will collapse for mobile devices. The default value is 520px', 'so-widgets-bundle' )
 			)
 		);
 	}

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -21,6 +21,8 @@
 @icon_size: 24px;
 @use_icon_size: false;
 
+@responsive_breakpoint: 520px;
+
 .sow-features-list {
 
     margin: 0 -25px;
@@ -162,7 +164,7 @@
         clear: both;
     }
 
-    @media (max-width: 520px) {
+    @media (max-width: @responsive_breakpoint) {
         &.sow-features-responsive {
             margin: 0;
 


### PR DESCRIPTION
Replaces #372. Resolves #298

This PR adds a global widget setting that adds the ability to control the features breakpoint. If SiteOrigin Page Builder is installed, it'll default to the global mobile breakpoint but the global widget setting is still present if the user wishes to override the Page Builder setting for the features widgets.