### PR TITLE
Editor: stop removing grunion_media_button on widgets page

### DIFF
--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -516,16 +516,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		
 		echo '<div id="wp-' . esc_attr( $editor_id ) . '-media-buttons" class="wp-media-buttons">';
 		
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		// Temporarily disable the Jetpack Grunion contact form editor on the widgets screen.
-		if( ! is_null( $screen ) && $screen->id == 'widgets' ) {
-			remove_action( 'media_buttons', 'grunion_media_button', 999 );
-		}
 		do_action( 'media_buttons', $editor_id );
-		// Temporarily disable the Jetpack Grunion contact form editor on the widgets screen.
-		if( ! is_null( $screen ) && $screen->id == 'widgets' ) {
-			add_action( 'media_buttons', 'grunion_media_button', 999 );
-		}
 		
 		echo "</div>\n";
 		


### PR DESCRIPTION
Replacement for #635

grunion_media_button is no longer run on the Widgets page ([reference](https://github.com/Automattic/jetpack/blame/5.6.1/modules/contact-form/grunion-editor-view.php#L18)) so there's no reason to do this anymore. It's been long enough that this shouldn't affect users as it's been several months.