### PR TITLE
Post Selector: Only exclude current post if page is singular

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -88,7 +88,7 @@ function siteorigin_widget_post_selector_process_query( $query ){
 	}
 
 	// Exclude the current post (if applicable) to avoid any issues associated with showing the same post again
-	if( get_the_id() != false ){
+	if( is_singular() && get_the_id() != false ){
 		$query['post__not_in'][] = get_the_id();
 	}
 


### PR DESCRIPTION
This prevents an issue where the most recent post will be excluded from a post carousel on a non-singular page such as a WooCommerce shop page (which is an archive), or category page.