### PR TITLE
Features: Better feature padding removal on row ends

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -278,6 +278,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 
 		$less_vars['container_size'] = $instance['container_size'];
 		$less_vars['icon_size'] = $instance['icon_size'];
+		$less_vars['per_row'] = $instance['per_row'];
 		$less_vars['use_icon_size'] = empty( $instance['icon_size_custom'] ) ? 'false' : 'true';
 
 		$global_settings = $this->get_global_settings();

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -16,6 +16,7 @@
 @more_text_font_weight: 400;
 @more_text_size: default;
 @more_text_color: default;
+@per_row: 3;
 
 @container_size: 84px;
 @icon_size: 24px;
@@ -24,9 +25,6 @@
 @responsive_breakpoint: 520px;
 
 .sow-features-list {
-
-    margin: 0 -25px;
-
     .clearfix();
 
     .sow-features-feature {
@@ -35,6 +33,14 @@
         .box-sizing(border-box);
         padding: 0 25px;
         display: flex;
+
+        &:nth-of-type(@{per_row}n+1) {
+            padding-left: 0;
+        }
+
+        &:last-of-type, &:nth-of-type(@{per_row}n) {
+            padding-right: 0;
+        }
 
         &.sow-icon-container-position-top {
             flex-direction: column;

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -38,7 +38,7 @@
             padding-left: 0;
         }
 
-        &:last-of-type, &:nth-of-type(@{per_row}n) {
+        &:nth-of-type(@{per_row}n) {
             padding-right: 0;
         }
 

--- a/widgets/features/tpl/default.php
+++ b/widgets/features/tpl/default.php
@@ -7,10 +7,6 @@ $last_row = floor( ( count($instance['features']) - 1 ) / $instance['per_row'] )
 	<?php if( isset( $instance['features'] ) ) : ?>
 		<?php foreach( $instance['features'] as $i => $feature ) : ?>
 
-			<?php if( $i % $instance['per_row'] == 0 && $i != 0 ) : ?>
-				<div class="sow-features-clear"></div>
-			<?php endif; ?>
-
 			<div class="sow-features-feature sow-icon-container-position-<?php echo esc_attr( $feature['container_position'] ) ?> <?php if(  floor( $i / $instance['per_row'] ) == $last_row ) echo 'sow-features-feature-last-row' ?>" style="width: <?php echo round( 100 / $instance['per_row'], 3 ) ?>%">
 
 				<?php if( !empty( $feature['more_url'] ) && $instance['icon_link'] ) echo '<a href="' . sow_esc_url( $feature['more_url'] ) . '" ' . ( $instance['new_window'] ? 'target="_blank" rel="noopener noreferrer"' : '' ) . '>'; ?>


### PR DESCRIPTION
This fixes an overflow issue on full width stretched features widgets. This issue only occurs in themes that don't hide overflow on their theme/content container.

[Related thread](https://wordpress.org/support/topic/page-width-exceeds/#post-9913254)