### PR TITLE
Hero: Add responsive height settings

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -162,6 +162,12 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 						'default' => 'default',
 					),
 
+					'height_responsive' => array(
+						'type' => 'measurement',
+						'label' => __( 'Responsive Height', 'so-widgets-bundle' ),
+						'default' => 'default',
+					),
+
 					'padding' => array(
 						'type' => 'measurement',
 						'label' => __('Top and bottom padding', 'so-widgets-bundle'),
@@ -368,7 +374,9 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		$meas_options['slide_padding_sides'] = $instance['design']['padding_sides'];
 		$meas_options['slide_width'] = $instance['design']['width'];
 		$meas_options['slide_height'] = $instance['design']['height'];
-
+		if ( ! empty( $instance['design']['height_responsive'] ) ) {
+			$meas_options['slide_height_responsive'] = $instance['design']['height_responsive'];
+		}
 		$meas_options['heading_size'] = $instance['design']['heading_size'];
 		$meas_options['text_size'] = $instance['design']['text_size'];
 
@@ -400,7 +408,24 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 			}
 		}
 
+		$global_settings = $this->get_global_settings();
+
+		if ( ! empty( $global_settings['responsive_breakpoint'] ) ) {
+			$less_vars['responsive_breakpoint'] = $global_settings['responsive_breakpoint'];
+		}
+
 		return $less;
+	}
+
+	function get_settings_form() {
+		return array(
+			'responsive_breakpoint' => array(
+				'type'        => 'measurement',
+				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
+				'default'     => '780px',
+				'description' => __( 'This setting controls when the Hero widget will switch to the responsive height for slides. This breakpoint will only be used if a responsive height is set in the hero settings. The default value is 780px', 'so-widgets-bundle' )
+			)
+		);
 	}
 
 	function add_default_measurement_unit($val) {

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -25,6 +25,9 @@
 @heading_color: #FFFFFF;
 @heading_shadow: 50;
 
+@responsive_breakpoint: 780px;
+@slide_height_responsive: default;
+
 .sow-slider-base {
 
 	ul.sow-slider-images {
@@ -34,6 +37,12 @@
 
 			max-width: @slide_width;
 			height: @slide_height;
+
+			@media (max-width: @responsive_breakpoint) {
+				&{
+					height: @slide_height_responsive;
+				}
+			}
 
 			h1,h2,h3,h4,h5,h6{
 				line-height: 1.375em;

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -38,9 +38,11 @@
 			max-width: @slide_width;
 			height: @slide_height;
 
-			@media (max-width: @responsive_breakpoint) {
-				&{
-					height: @slide_height_responsive;
+			& when ( isnumber( @slide_height_responsive ) ) {
+				@media (max-width: @responsive_breakpoint) {
+					&{
+						height: @slide_height_responsive;
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR adds responsive height settings for the hero widget. The breakpoint is controlled via the global widget settings.