### PR TITLE
Translation: Add context to From strings

### DIFF
--- a/base/inc/fields/date-range.class.php
+++ b/base/inc/fields/date-range.class.php
@@ -28,7 +28,7 @@ class SiteOrigin_Widget_Field_Date_Range extends SiteOrigin_Widget_Field_Base {
 
 	private function render_specific_date_selector() {
 		?><div class="sowb-specific-date-after"><span><?php
-		_e( 'From', 'so-widgets-bundle' );
+		_ex( 'From', 'From this date' 'so-widgets-bundle' );
 		?></span><input type="text" class="datepicker after-picker"/></div><?php
 		?><div class="sowb-specific-date-before"><span><?php
 		_e( 'to', 'so-widgets-bundle' );

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1185,7 +1185,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	}
 
 	function send_mail( $email_fields, $instance ) {
-		$body = '<strong>' . __( 'From', 'so-widgets-bundle' ) . ':</strong> <a href="mailto:' . sanitize_email( $email_fields['email'] ) . '">' . esc_html( $email_fields['name'] ) . '</a> &#60;' . sanitize_email( $email_fields['email'] ) . "&#62; \n\n";
+		$body = '<strong>' . _x( 'From', 'The name of who sent this email', 'so-widgets-bundle' ) . ':</strong> <a href="mailto:' . sanitize_email( $email_fields['email'] ) . '">' . esc_html( $email_fields['name'] ) . '</a> &#60;' . sanitize_email( $email_fields['email'] ) . "&#62; \n\n";
 		foreach ( $email_fields['message'] as $m ) {
 			$body .= '<strong>' . $m['label'] . ':</strong>';
 			$body .= "\n";


### PR DESCRIPTION
There are two different instances of From with two different meanings. This PR will provide context to translators.

[Reported here](https://wordpress.org/support/topic/dont-share-same-string-for-different-purpose/)