### PR TITLE
Button: Add max-width to ensure buttons are responsive

### DIFF
--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -21,6 +21,7 @@
 		.box-sizing(border-box);
 		& when( isnumber( @button_width ) ) {
 			width: @button_width;
+			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
 

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -22,6 +22,7 @@
 		.box-sizing(border-box);
 		& when( isnumber( @button_width ) ) {
 			width: @button_width;
+			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
 

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -21,6 +21,7 @@
 		.box-sizing(border-box);
 		& when( isnumber( @button_width ) ) {
 			width: @button_width;
+			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
 


### PR DESCRIPTION
This PR applies a max-width to ensure the button isn't cut off when users set a button width and it's smaller than the available width.

Reference gif:
![](https://i.imgur.com/HOIKvOG.gif)