### PR TITLE
Features: Don't set margin for one column left/right feature

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -77,13 +77,24 @@
                 margin-top: 10px;
             }
         }
-
+        
+        & when ( @per_row = 1 ) {
+            &.sow-icon-container-position-top, &.sow-icon-container-position-bottom {
+                .sow-icon-container {
+                    margin: auto;
+                }
+            }
+        }
+        
         .sow-icon-container {
             width: @container_size;
             height: @container_size;
             font-size: @container_size;
             text-decoration: none;
-            margin: auto;
+
+            & when not ( @per_row = 1 ) {
+                margin: auto;
+            }
 
             [class^="sow-icon-"],
             .sow-icon-image {


### PR DESCRIPTION
This prevents alignment issues with the icon in left/right positioned feature when the features widget is set to use a single column.

[Here's a test layout](https://drive.google.com/a/siteorigin.com/uc?id=1fUvUq735nR37kSnGLlMPji0X7BHkHPtg)

Before:
![](https://i.imgur.com/k8HHNOz.png)

After:
![](https://i.imgur.com/cgbc2KY.png)
