### PR TITLE
Contact textarea height

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -416,6 +416,10 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 								'type'  => 'measurement',
 								'label' => __( 'Height', 'so-widgets-bundle' )
 							),
+							'height_textarea' => array(
+								'type'  => 'measurement',
+								'label' => __( 'Text Area Height', 'so-widgets-bundle' )
+							),
 							'background'    => array(
 								'type'  => 'color',
 								'label' => __( 'Background', 'so-widgets-bundle' ),
@@ -785,6 +789,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'field_margin'               => $instance['design']['fields']['margin'],
 			'field_padding'              => $instance['design']['fields']['padding'],
 			'field_height'               => $instance['design']['fields']['height'],
+			'field_height_textarea'      => ! empty( $instance['design']['fields']['height_textarea'] ) ? $instance['design']['fields']['height_textarea'] : '',
 			'field_background'           => $instance['design']['fields']['background'],
 			'field_border_color'         => $instance['design']['fields']['border_color'],
 			'field_border_width'         => $instance['design']['fields']['border_width'],

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -72,7 +72,7 @@
 	@field_height: default;
 	@field_height_textarea: default;
 
-	.sow-text-field:not(.sow-form-field-textarea) {
+	.sow-text-field {
 		height: @field_height;
 	}
 

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -70,7 +70,16 @@
 	@field_border_width: default;
 	@field_border_style: default;
 	@field_height: default;
+	@field_height_textarea: default;
 
+	.sow-text-field:not(.sow-form-field-textarea) {
+		height: @field_height;
+	}
+
+	textarea {
+		height: @field_height_textarea;
+	}
+	
 	textarea,
 	.sow-text-field {
 		display: block;
@@ -81,7 +90,6 @@
 		margin: @field_margin;
 		border: @field_border_width @field_border_style @field_border_color;
 		padding: @field_padding;
-		height: @field_height;
 
 		background: @field_background;
 		color: @field_font_color;


### PR DESCRIPTION
Currently, the field height will apply to all fields which is normally okay but it looks odd if you pick a really small height as it'll also apply to the textarea. This change will add a dedicated height option for the textarea and it'll also prevent the standard field height from being applied to the textarea.

For example, here's an example of what it was like prior to this PR:
![](https://i.imgur.com/uXX13Th.png)

Now:
![](https://i.imgur.com/1jxtsXH.png)