### PR TITLE
Release 1.11.8

### DIFF
--- a/base/inc/actions.php
+++ b/base/inc/actions.php
@@ -31,6 +31,8 @@ function siteorigin_widget_preview_widget_action() {
 
 	$sowb = SiteOrigin_Widgets_Bundle::single();
 	$sowb->register_general_scripts();
+	
+	do_action( 'siteorigin_widgets_render_preview_' . $widget->id_base, $widget );
 
 	ob_start();
 	$widget->widget( array(

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -9,6 +9,12 @@
 
 		var $container = $field.find( '.siteorigin-widget-tinymce-container' );
 		var settings = $container.data( 'editorSettings' );
+		var $wpautopToggleField;
+		if ( settings.wpautopToggleField ) {
+			var $widgetForm = $container.closest( '.siteorigin-widget-form' );
+			$wpautopToggleField = $widgetForm.find( settings.wpautopToggleField );
+			settings.tinymce.wpautop = $wpautopToggleField.is( ':checked' );
+		}
 		var $textarea = $container.find( 'textarea' );
 		var id = $textarea.attr( 'id' );
 		var setupEditor = function ( editor ) {
@@ -18,16 +24,24 @@
 					$textarea.trigger( 'change' );
 				}
 			);
+			if ( $wpautopToggleField ) {
+				$wpautopToggleField.off( 'change' );
+				$wpautopToggleField.on( 'change', function () {
+					wp.editor.remove( id );
+					settings.tinymce.wpautop = $wpautopToggleField.is( ':checked' );
+					wp.editor.initialize( id, settings );
+				} );
+			}
 		};
 
 		settings.tinymce = $.extend( {}, settings.tinymce, { selector: '#' + id, setup: setupEditor } );
-		$( document ).one( 'wp-before-tinymce-init', function ( event, init ) {
+		$( document ).on( 'wp-before-tinymce-init', function ( event, init ) {
 			if ( init.selector === settings.tinymce.selector ) {
 				var mediaButtons = $container.data( 'mediaButtons' );
 				$field.find( '.wp-editor-tabs' ).before( mediaButtons.html );
 			}
 		} );
-		$( document ).one( 'tinymce-editor-setup', function () {
+		$( document ).on( 'tinymce-editor-setup', function () {
 			if ( ! $field.find( '.wp-editor-wrap' ).hasClass( settings.selectedEditor + '-active' ) ) {
 				setTimeout( function () {
 					window.switchEditors.go( id );
@@ -65,6 +79,7 @@
 					editor.setContent(window.switchEditors.wpautop(content));
 				}
 			}
+			settings.selectedEditor = mode;
 			$field.find( '.siteorigin-widget-tinymce-selected-editor' ).val( mode );
 		} );
 		

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -100,14 +100,6 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 	 */
 	private $wp_version_lt_4_8;
 	
-	public static function unautop( $text ) {
-		$text = str_replace('<p>', '', $text);
-		$text = str_replace(array('<br />', '<br>', '<br/>'), "\n", $text);
-		$text = str_replace('</p>', "\n\n", $text);
-		
-		return $text;
-	}
-	
 	protected function get_default_options() {
 		return array(
 			'wpautop' => true,
@@ -320,9 +312,9 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 	}
 	
 	protected function render_before_field( $value, $instance ) {
-		$selected_editor_name = $this->get_selected_editor_field_name( $this->base_name );
-		if( ! empty( $instance[ $selected_editor_name ] ) ) {
-			$this->selected_editor = $instance[ $selected_editor_name ];
+		$selected_editor = $this->get_selected_editor( $instance );
+		if( ! empty( $selected_editor ) ) {
+			$this->selected_editor = $selected_editor;
 		}
 		else {
 			$this->selected_editor = $this->default_editor;
@@ -496,8 +488,9 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 	}
 	
 	protected function sanitize_field_input( $value, $instance ) {
-		if ( ! empty( $this->wpautop ) ) {
-			$value = wpautop( self::unautop( $value ) );
+		$selected_editor = $this->get_selected_editor( $instance );
+		if ( in_array( $selected_editor, array( 'tinymce', 'tmce' ) ) && ! empty( $this->wpautop ) ) {
+			$value = wpautop( $value );
 		}
 		if( current_user_can( 'unfiltered_html' ) ) {
 			$sanitized_value = $value;
@@ -515,6 +508,16 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			$instance[ $selected_editor_name ] = in_array( $selected_editor, array( 'tinymce', 'tmce', 'quicktags', 'html' ) ) ? $selected_editor : $this->default_editor;
 		}
 		return $instance;
+	}
+	
+	public function get_selected_editor( $instance ) {
+		$selected_editor = null;
+		$selected_editor_name = $this->get_selected_editor_field_name( $this->base_name );
+		if( ! empty( $instance[ $selected_editor_name ] ) ) {
+			$selected_editor = $instance[ $selected_editor_name ];
+		}
+		
+		return $selected_editor;
 	}
 	
 	public function get_selected_editor_field_name( $base_name ) {

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ Once you enable a widget, you'll be able to use it anywhere standard widgets are
 
 == Documentation ==
 
-[Documentation](https://siteorigin.com/css/getting-started/) is available on SiteOrigin.
+[Documentation](https://siteorigin.com/widgets-bundle/getting-started/) is available on SiteOrigin.
 
 == Support ==
 

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -83,8 +83,19 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 				$instance['text'] = $GLOBALS['wp_embed']->run_shortcode( $instance['text'] );
 				$instance['text'] = $GLOBALS['wp_embed']->autoembed( $instance['text'] );
 			}
-
+			
+			// As in the Text Widget, we need to prevent plugins and themes from running `do_shortcode` in the `widget_text`
+			// filter to avoid running it twice and to prevent `wpautop` from interfering with shortcodes' output.
+			$widget_text_do_shortcode_priority = has_filter( 'widget_text', 'do_shortcode' );
+			if ( $widget_text_do_shortcode_priority !== false ) {
+				remove_filter( 'widget_text', 'do_shortcode', $widget_text_do_shortcode_priority );
+			}
+			
 			$instance['text'] = apply_filters( 'widget_text', $instance['text'] );
+			
+			if ( $widget_text_do_shortcode_priority !== false ) {
+				add_filter( 'widget_text', 'do_shortcode', $widget_text_do_shortcode_priority );
+			}
 			
 			if( $instance['autop'] ) {
 				$instance['text'] = wpautop( $instance['text'] );

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -34,7 +34,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			'text' => array(
 				'type' => 'tinymce',
 				'rows' => 20,
-				'wpautop' => false, // Let the editor handle it's own processing.
+				'wpautop_toggle_field' => '.siteorigin-widget-field-autop input[type="checkbox"]',
 			),
 			'autop' => array(
 				'type' => 'checkbox',

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -54,27 +54,17 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 		);
 	}
 
-	function unwpautop($string) {
-		$string = str_replace("<p>", "", $string);
-		$string = str_replace(array("<br />", "<br>", "<br/>"), "\n", $string);
-		$string = str_replace("</p>", "\n\n", $string);
-
-		return $string;
-	}
-
 	public function get_template_variables( $instance, $args ) {
 		$instance = wp_parse_args(
 			$instance,
 			array(  'text' => '' )
-		);
+	);
 		
 		if (
 			// Only run these parts if we're rendering for the frontend
 			empty( $GLOBALS[ 'SITEORIGIN_PANELS_CACHE_RENDER' ] ) &&
 			empty( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] )
 		) {
-			$instance['text'] = $this->unwpautop( $instance['text'] );
-			
 			if (function_exists('wp_make_content_images_responsive')) {
 				$instance['text'] = wp_make_content_images_responsive( $instance['text'] );
 			}
@@ -97,7 +87,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			$instance['text'] = apply_filters( 'widget_text', $instance['text'] );
 			
 			if( $instance['autop'] ) {
-					$instance['text'] = wpautop( $instance['text'] );
+				$instance['text'] = wpautop( $instance['text'] );
 			}
 			
 			$instance['text'] = do_shortcode( shortcode_unautop( $instance['text'] ) );


### PR DESCRIPTION
* Added action just before rendering widget previews.
* Editor: Removed `unwpautop`.
* Editor: Ensure TinyMCE field knows whether to apply `autop` or not.
* Editor: Only apply `autop` on display when using HTML editor.
* Editor: Prevent `widget_text` filters from running `do_shortcode`.
* Correct documentation link in the readme.