### PR TITLE
Accordion/Tabs: Unable to use Masonry widget if not visible by default

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -64,6 +64,16 @@ jQuery( function($){
 				});
 			});
 		};
+		
+		// If the Simple Masonry container is hidden it won't display properly. This is an attempt to make it display by
+		// calling resize when a custom 'show' event is fired. The 'show' event is something we fire in a few widgets
+		// like Accordion and Tabs and in future any widgets which might show and hide content using `display:none;`.
+		if ( $( $grid ).is( ':hidden' ) ) {
+			var $visParent = $( $grid ).closest( ':visible' );
+			$visParent.find( '> :hidden' ).on( 'show', function () {
+				resizeMasonry();
+			} );
+		}
 
 		$(window).on('resize panelsStretchRows', resizeMasonry);
 


### PR DESCRIPTION
This issue is similar to siteorigin/siteorigin-premium#133, and siteorigin/siteorigin-premium#129. Basically, add an accordion or tab. Create a non-visible (by default) item and set the content type to Layout Builder. Add a Simple Masonry widget and set it up as desired. Save and view the results. The simple masonry won't appear as the Simple Masonry widget calculates sizing on load so we need to add a check/trigger for Simple Masonry to avoid this, which this PR does. I wasn't sure about the comment to leave so I just copied the existing one used in the Google Maps widget.