### PR TITLE
Beaver Builder: Dark styling

### DIFF
--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -193,3 +193,16 @@
 .so-widgets-dialog .so-widgets-search-input {
 	width: 100%;
 }
+
+.fl-builder-ui-skin--dark .siteorigin-widget-form {
+	 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-form, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items, .siteorigin-widget-field-type-widget > label, .siteorigin-widget-field-type-section > label {
+		background: #383f46;
+		border-color: #676d72;
+	}
+
+	.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add, .siteorigin-widget-field-type-posts .siteorigin-widget-section, .siteorigin-widget-field-type-widget .siteorigin-widget-section, .siteorigin-widget-field-type-section .siteorigin-widget-section {
+		background: #32373c;
+		border-color: #424242;
+		color: #f1f1f1 !important;
+	}
+}

--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -212,10 +212,23 @@
 		.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add,
 		.siteorigin-widget-field-type-posts .siteorigin-widget-section,
 		.siteorigin-widget-field-type-widget .siteorigin-widget-section,
-		.siteorigin-widget-field-type-section .siteorigin-widget-section {
+		.siteorigin-widget-field-type-section .siteorigin-widget-section,
+		.siteorigin-widget-field-type-media .media-field-wrapper {
 			background: #32373c;
 			border-color: #424242;
 			color: #f1f1f1 !important;
+		}
+
+		.siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector-current label, .siteorigin-widget-field-type-section .siteorigin-widget-section {
+			text-shadow: none;
+		}
+
+		.button, .wp-color-result-text, .button.button-small {
+			border-color: #424242;
+		}
+
+		.wp-color-result-text {
+			border-left: none !important;
 		}
 	}
 
@@ -223,5 +236,5 @@
 	.siteorigin-widgets-query-builder.media-modal .wp-picker-container .wp-color-result.button .wp-color-result-text {
 		background: #383f46;
 	}
-}
 
+}

--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -196,19 +196,32 @@
 
 .fl-builder-ui-skin--dark {
 	.siteorigin-widget-form {
-		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-form, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items, .siteorigin-widget-field-type-widget > label, .siteorigin-widget-field-type-section > label, .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector-current, .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector {
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-top,
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item,
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-top,
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-form,
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items,
+		 .siteorigin-widget-field-type-widget > label,
+		 .siteorigin-widget-field-type-section > label,
+		 .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector-current,
+		 .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector {
 			background: #383f46;
 			border-color: #676d72;
 		}
 
-		.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add, .siteorigin-widget-field-type-posts .siteorigin-widget-section, .siteorigin-widget-field-type-widget .siteorigin-widget-section, .siteorigin-widget-field-type-section .siteorigin-widget-section {
+		.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add,
+		.siteorigin-widget-field-type-posts .siteorigin-widget-section,
+		.siteorigin-widget-field-type-widget .siteorigin-widget-section,
+		.siteorigin-widget-field-type-section .siteorigin-widget-section {
 			background: #32373c;
 			border-color: #424242;
 			color: #f1f1f1 !important;
 		}
 	}
 
-	.fl-lightbox .siteorigin-widget-form .wp-picker-container .wp-color-result.button .wp-color-result-text, .siteorigin-widgets-query-builder.media-modal .wp-picker-container .wp-color-result.button .wp-color-result-text {
+	.fl-lightbox .siteorigin-widget-form .wp-picker-container .wp-color-result.button .wp-color-result-text,
+	.siteorigin-widgets-query-builder.media-modal .wp-picker-container .wp-color-result.button .wp-color-result-text {
 		background: #383f46;
 	}
 }
+

--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -194,15 +194,21 @@
 	width: 100%;
 }
 
-.fl-builder-ui-skin--dark .siteorigin-widget-form {
-	 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-form, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items, .siteorigin-widget-field-type-widget > label, .siteorigin-widget-field-type-section > label {
-		background: #383f46;
-		border-color: #676d72;
+.fl-builder-ui-skin--dark {
+	.siteorigin-widget-form {
+		 .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-top, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items .siteorigin-widget-field-repeater-item .siteorigin-widget-field-repeater-item-form, .siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-items, .siteorigin-widget-field-type-widget > label, .siteorigin-widget-field-type-section > label, .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector-current, .siteorigin-widget-field-type-icon .siteorigin-widget-icon-selector {
+			background: #383f46;
+			border-color: #676d72;
+		}
+
+		.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add, .siteorigin-widget-field-type-posts .siteorigin-widget-section, .siteorigin-widget-field-type-widget .siteorigin-widget-section, .siteorigin-widget-field-type-section .siteorigin-widget-section {
+			background: #32373c;
+			border-color: #424242;
+			color: #f1f1f1 !important;
+		}
 	}
 
-	.siteorigin-widget-field-repeater .siteorigin-widget-field-repeater-add, .siteorigin-widget-field-type-posts .siteorigin-widget-section, .siteorigin-widget-field-type-widget .siteorigin-widget-section, .siteorigin-widget-field-type-section .siteorigin-widget-section {
-		background: #32373c;
-		border-color: #424242;
-		color: #f1f1f1 !important;
+	.fl-lightbox .siteorigin-widget-form .wp-picker-container .wp-color-result.button .wp-color-result-text, .siteorigin-widgets-query-builder.media-modal .wp-picker-container .wp-color-result.button .wp-color-result-text {
+		background: #383f46;
 	}
 }


### PR DESCRIPTION
This PR adds dark styling for SiteOrigin Widget Bundle widgets. For reference, you can enable the dark mode by pressing o.

![](https://vgy.me/psJdlU.png)
The follow-up commit styles the color picker button.

[Slack](https://siteorigin.slack.com/archives/C02SYBBH2/p1525076704000298)