### PR TITLE
Price Table: Disable equalized row heights on mobile

### DIFF
--- a/widgets/price-table/styles/atom.less
+++ b/widgets/price-table/styles/atom.less
@@ -207,8 +207,13 @@
 
 @media (max-width:680px) {
 	.ow-pt-columns-atom {
-
 		padding-top: 0;
+		
+		&.sow-equalize-row-heights {
+			.ow-pt-title, .ow-pt-details, .ow-pt-image, .ow-pt-features, .ow-pt-button, .ow-pt-feature {
+				height: auto !important;
+			}
+		}
 
 		.ow-pt-column {
 			float: none;


### PR DESCRIPTION
Resolve #494

> Currently, on mobile devices, the equalize row functionality can result in really large amounts of scrolling of blank areas. As a result, we shouldn't try and equalize rows on mobile devices - basically, when the price table collapses.

This is a quick and simple fix.