### PR TITLE
Accordion/Tabs FitText display issue fix

### DIFF
--- a/js/sow.jquery.fittext.js
+++ b/js/sow.jquery.fittext.js
@@ -35,7 +35,7 @@ var sowb = window.sowb || {};
             resizer();
 
             // Call on resize. Opera debounces their resize by default.
-            $(window).on('resize.fittext orientationchange.fittext', resizer);
+            $(window).on('resize.fittext orientationchange.fittext open', resizer);
 
         });
     };


### PR DESCRIPTION
Resolves #698. This may not be the best fix as it's kind of just thrown on, but from testing, it does its job and ensures FitText is readable and correctly sized.