### PR TITLE
Add condition get style hash by widget number

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -441,7 +441,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		// Filter the instance specifically for the form
 		$instance = apply_filters('siteorigin_widgets_form_instance_' . $this->id_base, $instance, $this);
-		
+
 		// `more_entropy` adds a period to the id.
 		$id = str_replace( '.', '', uniqid( rand(), true ) );
 		$form_id = 'siteorigin_widget_form_' . md5( $id );
@@ -1093,14 +1093,18 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 * @return string
 	 */
 	function get_style_hash( $instance ) {
-		if( method_exists( $this, 'get_style_hash_variables' ) ) {
-			$vars = apply_filters( 'siteorigin_widgets_hash_variables_' . $this->id_base, $this->get_style_hash_variables( $instance ), $instance, $this );
+		if( siteorigin_panels_setting('hash-by-number') ) {
+			return substr( md5( json_encode( $this->number ) ), 0, 12 );
 		} else {
-			$vars = apply_filters( 'siteorigin_widgets_less_variables_' . $this->id_base, $this->get_less_variables( $instance ), $instance, $this );
-		}
-		$version = property_exists( $this, 'version' ) ? $this->version : '';
+			if( method_exists( $this, 'get_style_hash_variables' ) ) {
+				$vars = apply_filters( 'siteorigin_widgets_hash_variables_' . $this->id_base, $this->get_style_hash_variables( $instance ), $instance, $this );
+			} else {
+				$vars = apply_filters( 'siteorigin_widgets_less_variables_' . $this->id_base, $this->get_less_variables( $instance ), $instance, $this );
+			}
+			$version = property_exists( $this, 'version' ) ? $this->version : '';
 
-		return substr( md5( json_encode( $vars ) . $version ), 0, 12 );
+			return substr( md5( json_encode( $vars ) . $version ), 0, 12 );
+		}
 	}
 
 	/**
@@ -1227,7 +1231,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$instance,
 			$this
 		);
-		
+
 		foreach ( $f_scripts as $f_script ) {
 			if ( ! wp_script_is( $f_script[0] ) ) {
 				wp_enqueue_script(
@@ -1264,7 +1268,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$instance,
 			$this
 		);
-		
+
 		foreach ( $f_styles as $f_style ) {
 			if ( ! wp_style_is( $f_style[0] ) ) {
 				wp_enqueue_style(

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1102,8 +1102,10 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			}
 			$version = property_exists( $this, 'version' ) ? $this->version : '';
 
-			return substr( md5( json_encode( $vars ) . $version ), 0, 12 );
+			$style_hash = substr( md5( json_encode( $vars ) . $version ), 0, 12 );
 		}
+
+		return $style_hash;
 	}
 
 	/**

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1093,9 +1093,8 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 * @return string
 	 */
 	function get_style_hash( $instance ) {
-		if( siteorigin_panels_setting('hash-by-number') ) {
-			return substr( md5( json_encode( $this->number ) ), 0, 12 );
-		} else {
+		$style_hash = apply_filters('siteorigin_widgets_widget_style_hash', '', $this);
+		if( empty( $style_hash ) ) {
 			if( method_exists( $this, 'get_style_hash_variables' ) ) {
 				$vars = apply_filters( 'siteorigin_widgets_hash_variables_' . $this->id_base, $this->get_style_hash_variables( $instance ), $instance, $this );
 			} else {


### PR DESCRIPTION
Hello! We got a problem with using Page Builder in batch with Widgets bundle.
When widget has styles, it generates them once a week when the page is requested.
On this way, we got some middleware before user get the page. We have FCGI and CDN, those two tools cache pages and their static to make it faster for end user.
We trying to figure out how we could fix disappearing widget styles and that what we came to:

We add an option to make `*.css` file name generated with not unique hash everytime, but with sliced md5 of widget-id hash. You can check it here: `base/siteorigin-widget-class.php:1096`