### PR TITLE
Remove old style after update widget

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -441,7 +441,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		// Filter the instance specifically for the form
 		$instance = apply_filters('siteorigin_widgets_form_instance_' . $this->id_base, $instance, $this);
-		
+
 		// `more_entropy` adds a period to the id.
 		$id = str_replace( '.', '', uniqid( rand(), true ) );
 		$form_id = 'siteorigin_widget_form_' . md5( $id );
@@ -703,7 +703,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		}
 
 		// Remove the old CSS, it'll be regenerated on page load.
-		$this->delete_css( $this->modify_instance( $new_instance ) );
+		$this->delete_css( $this->modify_instance( $old_instance ) );
 		return $new_instance;
 	}
 
@@ -1227,7 +1227,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$instance,
 			$this
 		);
-		
+
 		foreach ( $f_scripts as $f_script ) {
 			if ( ! wp_script_is( $f_script[0] ) ) {
 				wp_enqueue_script(
@@ -1264,7 +1264,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$instance,
 			$this
 		);
-		
+
 		foreach ( $f_styles as $f_style ) {
 			if ( ! wp_style_is( $f_style[0] ) ) {
 				wp_enqueue_style(


### PR DESCRIPTION
1. Hello, looks like I found a bug. When update widget, old css doesn’t deleted, because to delete_css function transferred `$new_instance` data not old one. Could you check this please ?
2. Also I have one question. Do you have a way to disable clear_file_cache() method ?