### PR TITLE
Plugin Action Links: Check if edit link is present before removal

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -742,7 +742,9 @@ class SiteOrigin_Widgets_Bundle {
 	 * Add action links.
 	 */
 	function plugin_action_links($links){
-		if ( isset( $links['edit'] ) ) unset( $links['edit'] );
+		if ( isset( $links['edit'] ) ) {
+			unset( $links['edit'] );
+		}
 		$links['manage'] = '<a href="' . admin_url('plugins.php?page=so-widgets-plugins') . '">'.__('Manage Widgets', 'so-widgets-bundle').'</a>';
 		$links['support'] = '<a href="https://siteorigin.com/thread/" target="_blank" rel="noopener noreferrer">'.__('Support', 'so-widgets-bundle').'</a>';
 		return $links;

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -742,7 +742,7 @@ class SiteOrigin_Widgets_Bundle {
 	 * Add action links.
 	 */
 	function plugin_action_links($links){
-		unset( $links['edit'] );
+		if ( isset( $links['edit'] ) ) unset( $links['edit'] );
 		$links['manage'] = '<a href="' . admin_url('plugins.php?page=so-widgets-plugins') . '">'.__('Manage Widgets', 'so-widgets-bundle').'</a>';
 		$links['support'] = '<a href="https://siteorigin.com/thread/" target="_blank" rel="noopener noreferrer">'.__('Support', 'so-widgets-bundle').'</a>';
 		return $links;


### PR DESCRIPTION
This PR prevents a fatal error from occurring if another plugin has already removed the editor link.

`HP Fatal error: Uncaught Error: Cannot unset string offsets in wp-content/plugins/so-widgets-bundle/so-widgets-bundle.php:745
`
[Related](https://siteorigin.com/thread/siteorigin-widgets-bundle-vs-wp-editor/)