### PR TITLE
Widget CSS: Use inline CSS as a fallback if siteorigin-widgets directory or CSS file wasn't able to be created

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -731,7 +731,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			if ( WP_Filesystem() ) {
 				global $wp_filesystem;
 				$upload_dir = wp_upload_dir();
-						$add_cache = true;
+				$add_cache = true;
 
 				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
 					$directory_created = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -731,22 +731,26 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			if ( WP_Filesystem() ) {
 				global $wp_filesystem;
 				$upload_dir = wp_upload_dir();
-
-				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
-					$store_css = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+				
+				$dir_exists = $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+				
+				if ( empty( $dir_exists ) ) {
+					// The 'siteorigin-widgets' directory doesn't exist, so try to create it.
+					$dir_exists = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
 				}
 				
-				if ( empty( $store_css ) ) {
+				if ( ! empty( $dir_exists ) ) {
+					// The 'siteorigin-widgets' directory exists, so we can try to write the CSS to a file.
 					$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $name );
-					$store_css = $wp_filesystem->put_contents(
+					$file_put_success = $wp_filesystem->put_contents(
 						$upload_dir['basedir'] . '/siteorigin-widgets/' . $name,
 						$css
 					);
 				}
 			}
 
-			// Check if we're able to store CSS (based on the above checks) and if we are, store a record of it
-			if ( empty( $store_css ) ) {
+			// We couldn't write to file, so let's use cache instead.
+			if ( empty( $file_put_success ) ) {
 				wp_cache_add( $name, $css, 'siteorigin_widgets' );
 			}
 

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -727,23 +727,34 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		$css = $this->get_instance_css($instance);
 
-		if( !empty($css) ) {
-
+		if ( !empty( $css ) ) {
 			if ( WP_Filesystem() ) {
 				global $wp_filesystem;
 				$upload_dir = wp_upload_dir();
+						$add_cache = true;
 
 				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
-					$wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+					$directory_created = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+					if ( ! $directory_created ) {
+						$add_cache = true;
+					}
 				}
 
-				$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $name );
-				$wp_filesystem->put_contents(
-					$upload_dir['basedir'] . '/siteorigin-widgets/' . $name,
-					$css
-				);
-
+				if ( !isset( $add_cache ) ) {
+					$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $name );
+					$file_created = $wp_filesystem->put_contents(
+						$upload_dir['basedir'] . '/siteorigin-widgets/' . $name,
+						$css
+					);
+					if ( ! $file_created ) {
+						$add_cache = true;
+					}
+				}
 			} else {
+				$add_cache = true;
+			}
+
+			if ( !empty( $add_cache ) ) {
 				wp_cache_add( $name, $css, 'siteorigin_widgets' );
 			}
 

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -733,24 +733,16 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				$upload_dir = wp_upload_dir();
 
 				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
-					$directory_created = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
-					if ( ! $directory_created ) {
-						$add_cache = true;
-					}
+					$add_cache = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
 				}
 
 				if ( !isset( $add_cache ) ) {
 					$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $name );
-					$file_created = $wp_filesystem->put_contents(
+					$add_cache = $wp_filesystem->put_contents(
 						$upload_dir['basedir'] . '/siteorigin-widgets/' . $name,
 						$css
 					);
-					if ( ! $file_created ) {
-						$add_cache = true;
-					}
 				}
-			} else {
-				$add_cache = true;
 			}
 
 			if ( !empty( $add_cache ) ) {

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -731,7 +731,6 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			if ( WP_Filesystem() ) {
 				global $wp_filesystem;
 				$upload_dir = wp_upload_dir();
-				$add_cache = true;
 
 				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
 					$directory_created = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -727,7 +727,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		$css = $this->get_instance_css($instance);
 
-		if ( !empty( $css ) ) {
+		if ( ! empty( $css ) ) {
 			if ( WP_Filesystem() ) {
 				global $wp_filesystem;
 				$upload_dir = wp_upload_dir();

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -733,19 +733,20 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				$upload_dir = wp_upload_dir();
 
 				if ( ! $wp_filesystem->is_dir( $upload_dir['basedir'] . '/siteorigin-widgets/' ) ) {
-					$add_cache = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+					$store_css = $wp_filesystem->mkdir( $upload_dir['basedir'] . '/siteorigin-widgets/' );
 				}
-
-				if ( !isset( $add_cache ) ) {
+				
+				if ( empty( $store_css ) ) {
 					$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $name );
-					$add_cache = $wp_filesystem->put_contents(
+					$store_css = $wp_filesystem->put_contents(
 						$upload_dir['basedir'] . '/siteorigin-widgets/' . $name,
 						$css
 					);
 				}
 			}
 
-			if ( !empty( $add_cache ) ) {
+			// Check if we're able to store CSS (based on the above checks) and if we are, store a record of it
+			if ( empty( $store_css ) ) {
 				wp_cache_add( $name, $css, 'siteorigin_widgets' );
 			}
 


### PR DESCRIPTION
[Slack](https://siteorigin.slack.com/archives/C02SYBBH2/p1535963127000100)