### PR TITLE
Slider: don't hide video on mobile

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -100,7 +100,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 
 			'background_video_mobile' => array(
 				'type' => 'checkbox',
-				'label' => __( 'Show Slide Background Videos on mobile', 'so-widgets-bundle' ),
+				'label' => __( 'Show slide background videos on mobile', 'so-widgets-bundle' ),
 				'description' => __( 'Ticking this setting will allow for slide backgorund videos to appear on devices that support autoplaying videos on mobile.', 'so-widgets-bundle' ),
 			)
 		);
@@ -279,7 +279,10 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			if( !empty( $background['videos'] ) ) {
 
 				$classes = array( 'sow-' . $background['video-sizing'] . '-element' );
-				$classes[] = ! empty( $controls['background_video_mobile'] ) ? 'sow-mobile-video_enabled' : '';
+				if ( ! empty( $controls['background_video_mobile'] ) ) {
+					$classes[] = 'sow-mobile-video_enabled';
+				}
+
 				$this->video_code( $background['videos'], $classes );
 			}
 

--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -96,6 +96,12 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				'label' => __( 'Swipe Control', 'so-widgets-bundle' ),
 				'description' => __( 'Allow users to swipe through frames on mobile devices.', 'so-widgets-bundle' ),
 				'default' => true,
+			),
+
+			'background_video_mobile' => array(
+				'type' => 'checkbox',
+				'label' => __( 'Show Slide Background Videos on mobile', 'so-widgets-bundle' ),
+				'description' => __( 'Ticking this setting will allow for slide backgorund videos to appear on devices that support autoplaying videos on mobile.', 'so-widgets-bundle' ),
 			)
 		);
 	}
@@ -143,10 +149,10 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 
 	function slider_settings( $controls ){
 		return array(
-			'pagination' => true,
-			'speed'      => empty( $controls['speed'] ) ? 1 : $controls['speed'],
-			'timeout'    => $controls['timeout'],
-			'swipe'      => $controls['swipe'],
+			'pagination'               => true,
+			'speed'                    => empty( $controls['speed'] ) ? 1 : $controls['speed'],
+			'timeout'                  => $controls['timeout'],
+			'swipe'                    => $controls['swipe'],
 		);
 	}
 
@@ -155,7 +161,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		$this->render_template_part('before_slides', $controls, $frames);
 
 		foreach( $frames as $i => $frame ) {
-			$this->render_frame( $i, $frame );
+			$this->render_frame( $i, $frame, $controls );
 		}
 
 		$this->render_template_part('after_slides', $controls, $frames);
@@ -219,7 +225,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 	 * @param $i
 	 * @param $frame
 	 */
-	function render_frame( $i, $frame ){
+	function render_frame( $i, $frame, $controls ){
 		$background = wp_parse_args( $this->get_frame_background( $i, $frame ), array(
 			'color' => false,
 			'image' => false,
@@ -271,7 +277,10 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			<?php
 			$this->render_frame_contents( $i, $frame );
 			if( !empty( $background['videos'] ) ) {
-				$this->video_code( $background['videos'], array('sow-' . $background['video-sizing'] . '-element') );
+
+				$classes = array( 'sow-' . $background['video-sizing'] . '-element' );
+				$classes[] = ! empty( $controls['background_video_mobile'] ) ? 'sow-mobile-video_enabled' : '';
+				$this->video_code( $background['videos'], $classes );
 			}
 
 			if( $background['opacity'] < 1 && !empty($background['image']) ) {
@@ -312,7 +321,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 	 */
 	function video_code( $videos, $classes = array() ){
 		if( empty( $videos ) ) return;
-		$video_element = '<video class="' . esc_attr( implode( ',', $classes ) ) . '" autoplay loop muted playsinline>';
+		$video_element = '<video class="' . esc_attr( implode( ' ', $classes ) ) . '" autoplay loop muted playsinline>';
 
 		$so_video = new SiteOrigin_Video();
 		foreach( $videos as $video ) {

--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -197,10 +197,6 @@
 		.sow-slide-nav, .sow-slider-pagination{
 			/* display: none; */
 		}
-
-		video.sow-background-element {
-			visibility: hidden;
-		}
 	}
 
 	/* Icon fonts for the left and right slider images */

--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -197,6 +197,10 @@
 		.sow-slide-nav, .sow-slider-pagination{
 			/* display: none; */
 		}
+
+		video.sow-background-element:not(.sow-mobile-video_enabled) {	
+			visibility: hidden;	
+		}
 	}
 
 	/* Icon fonts for the left and right slider images */


### PR DESCRIPTION
This CSS was added when autoplaying on mobile just wasn't possible so it was better just to up and hide the video.

@Misplon Can you please try this on iOS? I can confirm this is working on Android (for at least devices where autoplaying videos are possible)