### PR TITLE
Remove slider slide number from output

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -179,7 +179,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				?>
 				<ol class="sow-slider-pagination">
 					<?php foreach($frames as $i => $frame) : ?>
-						<li><a href="#" data-goto="<?php echo $i ?>" aria-label="<?php printf( __( 'display slide %s', 'so-widgets-bundle' ), $i+1 ) ?>"><?php echo $i+1 ?></a></li>
+						<li><a href="#" data-goto="<?php echo $i ?>" aria-label="<?php printf( __( 'display slide %s', 'so-widgets-bundle' ), $i+1 ) ?>"></a></li>
 					<?php endforeach; ?>
 				</ol>
 


### PR DESCRIPTION
This PR removes the slide numbers from the slider output. I can't see any use for these numbers but I do see a valid use for removing them - they appear in the automatic WordPress excerpts.