### PR TITLE
Image widget - if no alt text is supplied add an empty alt attribute

### DIFF
--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -19,7 +19,7 @@
 ?>
 <div class="sow-image-container">
 <?php if ( ! empty( $url ) ) : ?><a href="<?php echo sow_esc_url( $url ) ?>" <?php foreach( $link_attributes as $att => $val ) if ( ! empty( $val ) ) : echo $att.'="' . esc_attr( $val ) . '" '; endif; ?>><?php endif; ?>
-	<img <?php foreach( $attributes as $n => $v ) if ( ! empty( $v ) ) : echo $n.'="' . esc_attr( $v ) . '" '; endif; ?>
+	<img <?php foreach( $attributes as $n => $v ) if ( $n === 'alt' || ! empty( $v ) ) : echo $n.'="' . esc_attr( $v ) . '" '; endif; ?>
 		class="<?php echo esc_attr( implode(' ', $classes ) ) ?>"/>
 <?php if ( ! empty( $url ) ) : ?></a><?php endif; ?>
 </div>


### PR DESCRIPTION
If no alt text is supplied for an image widget add an empty alt
attribute (alt="") for WCAG compliance. Nearly all images should have an
alt attribute to meet WCAG 2.1 Level A.

See

https://www.w3.org/WAI/WCAG21/Techniques/failures/F38

"This describes a failure condition for text alternatives for images
that should be ignored by AT. If there is no alt attribute at all
assistive technologies are not able to ignore the non-text content. The
alt attribute must be provided and have a null value (i.e., alt="" ) to
avoid a failure of this Success Criterion."

and

https://webaim.org/techniques/alttext/

"Every image must have an alt attribute. This is a requirement of HTML
standard (with perhaps a few exceptions in HTML5). Images without an alt
attribute are likely inaccessible. In some cases, images may be given an
empty or null alt attribute (e.g., alt="")."

Prevents image widget from failing accessibility audit through lack of
alt attribute.