### PR TITLE
Post Selector: Add option to adjust taxonomies relationship

### DIFF
--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -38,6 +38,16 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 				'description' => __( 'Taxonomies are groups such as categories, tags, posts and products.', 'so-widgets-bundle' ),
 			),
 
+			'tax_query_relation' => array(
+				'type' => 'radio',
+				'label' => __( 'Taxonomies Relationship', 'so-widgets-bundle' ),
+				'options' => array(
+					'OR' => __( 'OR', 'so-widgets-bundle' ),
+					'AND' => __( 'AND', 'so-widgets-bundle' ),
+				),
+				'description' => __( 'The relationship between the taxonomies. AND will require all posts to have all of the taxonomies while OR will allow for a post that only has a one of the taxonomies ', 'so-widgets-bundle' ),
+				'default' => 'OR',
+			),
 			'date_type' => array(
 				'type' => 'radio',
 				'label' => __( 'Date selection type', 'so-widgets-bundle' ),

--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -33,7 +33,7 @@ function siteorigin_widget_post_selector_process_query( $query ){
 		$tax_queries = explode(',', $query['tax_query']);
 
 		$query['tax_query'] = array();
-		$query['tax_query']['relation'] = 'OR';
+		$query['tax_query']['relation'] = !empty( $query['tax_query_relation'] ) ? $query['tax_query_relation'] : 'OR';
 		foreach($tax_queries as $tq) {
 			list($tax, $term) = explode(':', $tq);
 


### PR DESCRIPTION
This PR will add a new setting to the posts form field that will allow users to change the taxonomies relationship. Previously, it was only possible to adjust the taxonomies relationship filtering the [siteorigin_widgets_posts_selector_query](https://github.com/siteorigin/so-widgets-bundle/blob/1.13.0/base/inc/post-selector.php#L106) hook and adjusting the value using PHP.

![](https://i.imgur.com/ZmkFIvR.png)
