### PR TITLE
Contact: Altered required message and indicator. Resolve #567

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -867,7 +867,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 		$indicate_required_fields = $instance['settings']['required_field_indicator'];
 
-		if ( ! empty( $indicate_required_fields ) ) {
+		if ( ! empty( $indicate_required_fields ) && ! empty( $instance['settings']['required_field_indicator_message'] ) ) {
 			?>
             <p><em><?php echo esc_html( $instance['settings']['required_field_indicator_message'] ) ?></em></p>
 			<?php
@@ -891,9 +891,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
             <div class="sow-form-field sow-form-field-<?php echo sanitize_html_class( $field['type'] ) ?>"><?php
 
 			$label = $field['label'];
-			if ( $indicate_required_fields && ! empty( $field['required']['required'] ) ) {
-				$label .= '*';
-			}
 			$is_text_input_field = ( $field['type'] != 'select' && $field['type'] != 'radio' && $field['type'] != 'checkboxes' );
 			// label should be rendered before the field, then CSS will do the exact positioning.
 			$render_label_before_field = ( $label_position != 'below' && $label_position != 'inside' ) || ( $label_position == 'inside' && ! $is_text_input_field );
@@ -902,6 +899,9 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 
 			$show_placeholder = $label_position == 'inside';
+			if ( $show_placeholder && $indicate_required_fields && ! empty( $field['required']['required'] ) ) {
+				$label .= '*';
+			}
 
 			if ( ! empty( $errors[ $field_name ] ) ) {
 				?>
@@ -956,7 +956,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 			?><label<?php if ( ! empty( $label_class ) ) {
 				echo $label_class;
-			} ?> for="<?php echo esc_attr( $field_id ) ?>"><strong><?php echo esc_html( $label ) ?></strong></label>
+			} ?> for="<?php echo esc_attr( $field_id ) ?>"><strong><?php echo esc_html( $label ) ?><span class="sow-form-required">*</span></strong></label>
 			<?php
 		}
 	}
@@ -1227,6 +1227,12 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			$instance['settings']['from'] = get_option( 'admin_email' );
 		}
 
+		if ( $instance['settings']['from'] == $instance['settings']['from'] ) {
+			$domain = parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
+			$domain = str_replace( 'www.', '', $domain );
+			$instance['settings']['from'] = "wordpress@$domain";
+		}
+		
 		$headers = array(
 			'Content-Type: text/html; charset=UTF-8',
 			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $instance['settings']['from'] ) . '>',

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -69,7 +69,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						'label'       => __( 'From email address', 'so-widgets-bundle' ),
 						'description' => __( 'It will appear as if emails are sent from this address. Ideally this should be in the same domain as this server to avoid spam filters.', 'so-widgets-bundle' ),
 						'sanitize'    => 'email',
-						'default'     => $this->default_domain_email(),
 					),
 					'default_subject'                  => array(
 						'type'        => 'text',
@@ -851,23 +850,19 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	function email_validation( $instance ) {
 		// Replace default and empty email address.
 		// Also replaces the email address that comes from the prebuilt layout directory
-		if ( empty( $instance['settings']['to'] || $instance['settings']['to'] == 'ibrossiter@gmail.com' || $instance['settings']['to'] == 'test@example.com' ) ) {
+		if ( empty( $instance['settings']['to'] ) || $instance['settings']['to'] == 'ibrossiter@gmail.com' || $instance['settings']['to'] == 'test@example.com' ) {
 			$instance['settings']['to'] = get_option( 'admin_email' );
 		}
 
 		if ( empty( $instance['settings']['from'] ) || $instance['settings']['from'] == 'test@example.com' || $instance['settings']['to'] == $instance['settings']['from'] ) {
-			$instance['settings']['from'] = $this->default_domain_email();
+			$domain = parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
+			$domain = str_replace( 'www.', '', $domain );
+			$domain = "wordpress@$domain";
+
+			$instance['settings']['from'] = apply_filters( 'siteorigin_widgets_contact_default_email', $domain );
 		}
 
 		return $instance;
-	}
-
-	function default_domain_email () {
-		$domain = parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
-		$domain = str_replace( 'www.', '', $domain );
-		$domain = "wordpress@$domain";
-
-		return apply_filters( 'siteorigin_widgets_contact_default_email', $domain );
 	}
 
 	/**

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -891,15 +891,16 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
             <div class="sow-form-field sow-form-field-<?php echo sanitize_html_class( $field['type'] ) ?>"><?php
 
 			$label = $field['label'];
+			$required = ! empty( $field['required']['required'] );
 			$is_text_input_field = ( $field['type'] != 'select' && $field['type'] != 'radio' && $field['type'] != 'checkboxes' );
 			// label should be rendered before the field, then CSS will do the exact positioning.
 			$render_label_before_field = ( $label_position != 'below' && $label_position != 'inside' ) || ( $label_position == 'inside' && ! $is_text_input_field );
 			if ( empty( $label_position ) || $render_label_before_field ) {
-				$this->render_form_label( $field_id, $label, $label_position );
+				$this->render_form_label( $field_id, $label, $label_position, $required );
 			}
 
 			$show_placeholder = $label_position == 'inside';
-			if ( $show_placeholder && $indicate_required_fields && ! empty( $field['required']['required'] ) ) {
+			if ( $show_placeholder && $indicate_required_fields && $required ) {
 				$label .= '*';
 			}
 
@@ -933,7 +934,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			?></span><?php
 
 			if ( ! empty( $label_position ) && $label_position == 'below' ) {
-				$this->render_form_label( $field_id, $label, $instance );
+				$this->render_form_label( $field_id, $label, $instance, $required );
 			}
 
 			if ( ! empty( $field['description'] ) ) {
@@ -948,15 +949,20 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		}
 	}
 
-	function render_form_label( $field_id, $label, $position ) {
+	function render_form_label( $field_id, $label, $position, $required ) {
 		if ( ! empty( $label ) ) {
 			$label_class = '';
 			if ( ! empty( $position ) ) {
 				$label_class = ' class="sow-form-field-label-' . $position . '"';
 			}
-			?><label<?php if ( ! empty( $label_class ) ) {
-				echo $label_class;
-			} ?> for="<?php echo esc_attr( $field_id ) ?>"><strong><?php echo esc_html( $label ) ?><span class="sow-form-required">*</span></strong></label>
+
+			if ( $required ) {
+				$required = '<span class="sow-form-required">*</span>';
+			}
+			?>
+			<label<?php echo ! empty( $label_class ) ? $label_class : ''; ?> for="<?php echo esc_attr( $field_id ) ?>">
+				<strong><?php echo esc_html( $label ) . $required; ?></strong>
+			</label>
 			<?php
 		}
 	}

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -855,7 +855,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			$instance['settings']['to'] = get_option( 'admin_email' );
 		}
 
-		if ( empty( $instance['settings']['from'] ) || $instance['settings']['from'] == 'test@example.com' || $instance['settings']['from'] = $instance['settings']['from'] ) {
+		if ( empty( $instance['settings']['from'] ) || $instance['settings']['from'] == 'test@example.com' || $instance['settings']['to'] == $instance['settings']['from'] ) {
 			$instance['settings']['from'] = $this->default_domain_email();
 		}
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -682,7 +682,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	}
 
 	function modify_instance( $instance ) {
-		$instance = $this->email_validation( $instance );
+		$instance = $this->sanitize_emails( $instance );
 
 		if ( empty( $instance['fields'] ) ) {
 			$instance['fields'] = array(
@@ -847,7 +847,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		return $id;
 	}
 
-	function email_validation( $instance ) {
+	private function sanitize_emails( $instance ) {
 		// Replace default and empty email address.
 		// Also replaces the email address that comes from the prebuilt layout directory
 		if ( empty( $instance['settings']['to'] ) || $instance['settings']['to'] == 'ibrossiter@gmail.com' || $instance['settings']['to'] == 'test@example.com' ) {
@@ -1231,7 +1231,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		}
 		$body = wpautop( trim( $body ) );
 
-		$instance = $this->email_validation( $instance );
+		$instance = $this->sanitize_emails( $instance );
 		
 		$headers = array(
 			'Content-Type: text/html; charset=UTF-8',


### PR DESCRIPTION
- Resolves #567
- Don't output required text message if field is empty
- Wrap required indicator in span with class to allow for easier styling