### PR TITLE
Features: Remove flex from each feature on mobile

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -192,6 +192,7 @@
                 width: 100% !important;
                 float: none;
                 margin-bottom: 40px;
+                display: block;
 
                 &:last-child {
                     margin-bottom: 0px;


### PR DESCRIPTION
This PR will remove flex from each feature on mobile to prevent text from being (horizontally) cut off on mobile. This change will only apply when the user has the features widget to be enabled.

Before:
![](https://vgy.me/mzkfkA.png)

After:
![](https://vgy.me/fVlLZY.png)

[Test layout](https://drive.google.com/a/siteorigin.com/uc?id=1bQAhYEq1fkgmOCIqgqbNzZiTM98awPUJ).