### PR TITLE
Move SiteOrigin Editor TinyMCE Enqueue to widget

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -246,11 +246,6 @@ function siteorigin_widgets_font_families( ){
 	return apply_filters('siteorigin_widgets_font_families', $font_families);
 }
 
-function siteorigin_widgets_tinymce_admin_print_styles() {
-	wp_enqueue_style( 'editor-buttons' );
-}
-add_action( 'admin_print_styles', 'siteorigin_widgets_tinymce_admin_print_styles' );
-
 /**
  * Get list of supported measurements
  *

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -22,6 +22,8 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			false,
 			plugin_dir_path(__FILE__)
 		);
+
+		add_action( 'siteorigin_widgets_enqueue_admin_scripts_sow-editor', array( $this, 'enqueue_tinymce' ) );
 	}
 
 	function get_widget_form() {
@@ -114,6 +116,10 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 	function get_style_name($instance) {
 		// We're not using a style
 		return false;
+	}
+
+	function enqueue_tinymce() {
+		wp_enqueue_style( 'editor-buttons' );
 	}
 }
 


### PR DESCRIPTION
[Thread](https://siteorigin.com/thread/toolbar-has-white-icons/)

While SiteOrigin Widgets Bundle is activated, active buttons are white rather than black. This PR changes this.