### PR TITLE
Social Media Buttons: Ensure Mobile Alignment Global setting has a unit of measurement

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -394,6 +394,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 					$instance[$id] = isset( $field['default'] ) ? $field['default'] : '';
 				}
 				if ( empty( $instance[ $id . '_unit' ] ) ) {
+					$instance[$id] .= 'px';
 					$instance[ $id . '_unit' ] = 'px';
 				}
 			}

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -393,8 +393,10 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				if( ! isset( $instance[$id] ) ) {
 					$instance[$id] = isset( $field['default'] ) ? $field['default'] : '';
 				}
-				if ( empty( $instance[ $id . '_unit' ] ) ) {
+				if ( is_numeric(  $instance[ $id ] ) ) {
 					$instance[$id] .= 'px';
+				}
+				if ( empty( $instance[ $id . '_unit' ] ) ) {
 					$instance[ $id . '_unit' ] = 'px';
 				}
 			}

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -246,7 +246,6 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 		// Ensure responsive_breakpoint global setting has a unit of measurement
 		if ( ! empty( $global_settings['responsive_breakpoint'] ) && is_numeric( $global_settings['responsive_breakpoint'] ) ) {
 			$global_settings['responsive_breakpoint'] .= 'px';
-			$this->save_global_settings( $global_settings );
 		}
 
 		return array(

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -30,7 +30,7 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 			'responsive_breakpoint' => array(
 				'type'        => 'measurement',
 				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
-				'default'     => 780,
+				'default'     => 780px,
 				'description' => __( 'This setting controls when the Mobile Align setting will be used. The default value is 780px', 'so-widgets-bundle' ),
 			)
 		);
@@ -243,6 +243,12 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 		$margin = $top . ' ' . $right . ' ' . $bottom . ' ' . $left;
 
 		$global_settings = $this->get_global_settings();
+		// Ensure responsive_breakpoint global setting has a unit of measurement
+		if ( ! empty( $global_settings['responsive_breakpoint'] ) && is_numeric( $global_settings['responsive_breakpoint'] ) ) {
+			$global_settings['responsive_breakpoint'] .= 'px';
+			$this->save_global_settings( $global_settings );
+		}
+
 		return array(
 			'icon_size'             => $design['icon_size'] . 'em',
 			'rounding'              => $design['rounding'] . 'em',


### PR DESCRIPTION
Previously, the mobile alignment button wouldn't work as the media query would output as 780 rather than 780px. I'm not 100% sure if this is the best place to output this, would you prefer this code is ran using something else (`modify_instance`?)