### PR TITLE
Contact: Fix checkboxes and radio alignment on android

### DIFF
--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -110,11 +110,13 @@
 
 			label {
 				margin-bottom: 0;
+				display: flex;
+				align-items: center;
 			}
 
 			input {
 				float: left;
-				margin: 0.4em 0.5em 0 0;
+				margin-right: 0.5em;
 				height: auto;
 			}
 		}


### PR DESCRIPTION
On Android devices,  the checkboxes and radios form types are oddly aligned when multiple items are present due to the top margin applied to each option.

![](https://vgy.me/42WzOD.png)

This cannot be replicated using Device Mode in DevTools and will only occur on mobile.
This PR will fix this issue and prevent it from happening again regardless of device. There will be a slight movement in the radio/checkbox placement as they are now veritically aligned with the label text.