### PR TITLE
FitText: Set minimum font size to ensure readability

### DIFF
--- a/js/sow.jquery.fittext.js
+++ b/js/sow.jquery.fittext.js
@@ -55,6 +55,7 @@ jQuery( function( $ ){
 			fitTextWrapper.find( 'h1,h2,h3,h4,h5,h6' ).each( function () {
 				var $$ = $( this );
 				$$.fitText( compressor, {
+					minFontSize: '12px',
 					maxFontSize: $$.css( 'font-size' )
 				} );
 			} );


### PR DESCRIPTION
This PR will set a minimum font size for FitText. This will prevent cases where the user ends up with text unreadable (without zoom) due to it being set sub 12px. The specific reason I've set it to 12px due to [the Google recommendation](https://developers.google.com/web/tools/lighthouse/audits/font-sizes).