### PR TITLE
SiteOrigin Widgets block: Fix Layout Slider not being editable

### DIFF
--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -192,7 +192,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 	}
 
 	function form( $instance, $form_type = 'widget' ) {
-		if( is_admin() && defined('SITEORIGIN_PANELS_VERSION') ) {
+		if( defined('SITEORIGIN_PANELS_VERSION') ) {
 			parent::form( $instance, $form_type );
 		} else {
 			?>

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -192,7 +192,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 	}
 
 	function form( $instance, $form_type = 'widget' ) {
-		if( defined('SITEORIGIN_PANELS_VERSION') ) {
+		if ( ( is_admin() || ( defined('REST_REQUEST' ) && function_exists( 'register_block_type' ) ) ) && defined('SITEORIGIN_PANELS_VERSION') ) {
 			parent::form( $instance, $form_type );
 		} else {
 			?>


### PR DESCRIPTION
This PR removes the `is_admin()` check from the Layout Slider widget. This check prevents the form from displaying in the SiteOrigin Widgets block. During testing, I wasn't able to find any issues with removing it. With that said, if you have a replacement you would like to be used, let me know and I'll add that.