### PR TITLE
Accordion: account for duplicate accordion titles

### DIFF
--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -176,7 +176,8 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 		if( empty( $instance ) ) return array();
 		
 		$panels = empty( $instance['panels'] ) ? array() : $instance['panels'];
-		
+
+		$anchor_list = array();
 		foreach ( $panels as $i => &$panel ) {
 			if ( empty( $panel['before_title'] ) ) {
 				$panel['before_title'] = '';
@@ -196,6 +197,12 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 			} else {
 				$panel['anchor'] = $panel['title'];
 			}
+
+			if ( isset( $anchor_list[ $panel['anchor'] ] ) ) {
+				$panel['anchor'] .= '-' . $i;
+
+			}
+			$anchor_list[ $panel['anchor'] ] = true;
 		}
 		
 		

--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -194,14 +194,13 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 					$id .= '-' . $args['widget_id'];
 				}
 				$panel['anchor'] = $id . '-' . $i;
+			} else if ( isset( $anchor_list[ strtolower( $panel['title'] ) ] ) ) {
+				// Ensure this anchor is unique, if it's not, append the array key to the anchor.
+				$panel['anchor'] = $panel['title'] . '-' . $i;
 			} else {
 				$panel['anchor'] = $panel['title'];
 			}
 
-			if ( isset( $anchor_list[ $panel['anchor'] ] ) ) {
-				$panel['anchor'] .= '-' . $i;
-
-			}
 			$anchor_list[ $panel['anchor'] ] = true;
 		}
 		

--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -201,7 +201,7 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 				$panel['anchor'] = $panel['title'];
 			}
 
-			$anchor_list[ $panel['anchor'] ] = true;
+			$anchor_list[ strtolower( $panel['anchor'] ) ] = true;
 		}
 		
 		

--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -196,7 +196,7 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 				$panel['anchor'] = $id . '-' . $i;
 			} else if ( isset( $anchor_list[ strtolower( $panel['title'] ) ] ) ) {
 				// Ensure this anchor is unique, if it's not, append the array key to the anchor.
-				$panel['anchor'] = $panel['title'] . '-' . $i;
+				$panel['anchor'] = $panel['title'] . "-$i-" . uniqid();
 			} else {
 				$panel['anchor'] = $panel['title'];
 			}

--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -108,7 +108,8 @@ jQuery( function ( $ ) {
 					for ( var i = 0; i < panels.length; i++ ) {
 						var panel = panels[ i ];
 						var anchor = $( panel ).data( 'anchor' );
-						if ( anchor && window.location.hash.indexOf( anchor ) > -1 ) {
+						var windowHash = window.location.hash.substring(1).split( ',' ); 
+						if ( anchor && $.inArray( anchor, windowHash ) > -1 ) {
 							openPanel( panel, true );
 						} else {
 							closePanel( panel, true );

--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -108,8 +108,8 @@ jQuery( function ( $ ) {
 					for ( var i = 0; i < panels.length; i++ ) {
 						var panel = panels[ i ];
 						var anchor = $( panel ).data( 'anchor' );
-						var windowHash = window.location.hash.substring(1).split( ',' ); 
-						if ( anchor && $.inArray( anchor, windowHash ) > -1 ) {
+						var anchors = window.location.hash.substring(1).split( ',' ); 
+						if ( anchor && $.inArray( anchor, anchors ) > -1 ) {
 							openPanel( panel, true );
 						} else {
 							closePanel( panel, true );


### PR DESCRIPTION
This PR prevents the need for unique titles. Previously, if you used the same title in more than one place, all instances of that title would opened upon clicking one. This PR ensues the anchors are unique by appending the array index id if the title isn't unique.

This PR also prevents an instance where a partial match title won't open cause other titles to open - opening the `Other Example` item won't open `Example`.