### PR TITLE
Accordion: Prevent history state from being pushed on load when no hash is present

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -98,7 +98,7 @@ jQuery( function ( $ ) {
 					
 					if ( anchors && anchors.length ) {
 						window.location.hash = anchors.join( ',' );
-					} else {
+					} else if ( window.location.hash ) { // This prevents adding a history event if no was present on load
 						window.history.pushState( '', document.title, window.location.pathname + window.location.search );
 					}
 				};


### PR DESCRIPTION
This PR prevents a history state being pushed on load when no hash is present.

Before:
![](https://vgy.me/m9Xtu6.png)

After:
![](https://vgy.me/jmhhBz.png)
