### PR TITLE
Tabs: Account for accented characters

### DIFF
--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -113,13 +113,15 @@ jQuery( function ( $ ) {
 			if ( useAnchorTags ) {
 				var updateSelectedTab = function () {
 					if ( window.location.hash ) {
-						var anchors = window.location.hash.replace( '#', '' ).split( ',' );
-						anchors.forEach( function ( anchor ) {
-							var tab = $tabs.filter( '[data-anchor="' + anchor + '"]' );
-							if ( tab ) {
-								selectTab( tab, true );
+						var tabs = $tabs.toArray();
+						for ( var i = 0; i < tabs.length; i++ ) {
+							var panel = tabs[ i ];
+							var anchor = $( panel ).data( 'anchor' );
+							var anchorHash = decodeURI( window.location.hash.replace( '#', '' ) ).split( ',' );
+							if ( anchor && $.inArray( decodeURI( anchor ), anchorHash ) > -1 ) {
+								selectTab( panel, true );
 							}
-						} );
+						}
 					}
 				};
 				$( window ).on( 'hashchange', updateSelectedTab );


### PR DESCRIPTION
This PR will fix an issue with Anchor Tags that prevented tabs with accented characters from opening automatically on load. For an example of this:

Set a Tab title to Le Réflexologie and then save.
Open the page, select the tab and then reload - the default tab will be opened.

This PR also updates updateSelectedTab to use, in my opinion, the more robust solution that the Accordion widget is using.

[Layout](https://drive.google.com/a/siteorigin.com/uc?id=1BDk8EszSfQCspYTuULcEIeWLPbuN3bd6)