### PR TITLE
Widget Documentation Links

### DIFF
--- a/admin/admin.less
+++ b/admin/admin.less
@@ -246,13 +246,27 @@
 					}
 				}
 			}
-
-			.so-widget-toggle-active {
+			.so-action-links {
 				margin-top: 15px;
-				display: inline-block;
 
-				button:focus {
+				&:after {
+					content: "";
+					display: table;
+					clear: both;
+				}
+
+				.so-widget-toggle-active, .so-widget-settings, .so-widget-documentation {
+					display: inline-block;
+					float: left;
+					margin-right: 1em;
+				}
+				
+				.so-widget-toggle-active button:focus {
 					outline: none;
+				}
+
+				.so-widget-documentation {
+					margin-top: 5px;
 				}
 			}
 
@@ -283,11 +297,6 @@
 					-webkit-filter: grayscale(1);
 					opacity: 0.7;
 				}
-			}
-
-			.so-widget-settings {
-				margin-top: 15px;
-				display: inline-block;
 			}
 
 		}

--- a/admin/tpl/admin.php
+++ b/admin/tpl/admin.php
@@ -65,33 +65,40 @@
 								</strong>
 							</div>
 						<?php endif; ?>
+						<div class="so-action-links">
+							<div class="so-widget-toggle-active">
+								<button class="button-secondary so-widget-activate" data-status="1"><?php esc_html_e( 'Activate', 'so-widgets-bundle' ) ?></button>
+								<button class="button-secondary so-widget-deactivate" data-status="0"><?php esc_html_e( 'Deactivate', 'so-widgets-bundle' ) ?></button>
+							</div>
 
-						<div class="so-widget-toggle-active">
-							<button class="button-secondary so-widget-activate" data-status="1"><?php esc_html_e( 'Activate', 'so-widgets-bundle' ) ?></button>
-							<button class="button-secondary so-widget-deactivate" data-status="0"><?php esc_html_e( 'Deactivate', 'so-widgets-bundle' ) ?></button>
-						</div>
-
-						<?php
-						/** @var SiteOrigin_Widget $widget_object */
-						$widget_object = !empty( $widget_objects[ $file ] ) ? $widget_objects[ $file ] : false;
-						if( !empty( $widget_object ) && $widget_object->has_form( 'settings' ) ) {
-							$rel_path = str_replace( wp_normalize_path( WP_CONTENT_DIR ), '', $file );
-							
-							$form_url = add_query_arg( array(
-									'id' => $rel_path,
-									'action' => 'so_widgets_setting_form',
-								),
-								admin_url( 'admin-ajax.php' )
-							);
-							$form_url = wp_nonce_url( $form_url, 'display-widget-form' );
-
-							?>
-							<button class="button-secondary so-widget-settings" data-form-url="<?php echo esc_url( $form_url ) ?>">
-								<?php esc_html_e( 'Settings', 'so-widgets-bundle' ) ?>
-							</button>
 							<?php
-						}
-						?>
+							/** @var SiteOrigin_Widget $widget_object */
+							$widget_object = !empty( $widget_objects[ $file ] ) ? $widget_objects[ $file ] : false;
+							if( !empty( $widget_object ) && $widget_object->has_form( 'settings' ) ) {
+								$rel_path = str_replace( wp_normalize_path( WP_CONTENT_DIR ), '', $file );
+								
+								$form_url = add_query_arg( array(
+										'id' => $rel_path,
+										'action' => 'so_widgets_setting_form',
+									),
+									admin_url( 'admin-ajax.php' )
+								);
+								$form_url = wp_nonce_url( $form_url, 'display-widget-form' );
+
+								?>
+								<button class="button-secondary so-widget-settings" data-form-url="<?php echo esc_url( $form_url ) ?>">
+									<?php esc_html_e( 'Settings', 'so-widgets-bundle' ) ?>
+								</button>
+								<?php
+							}
+							?>
+
+							<?php if( ! empty( $widget['Documentation'] ) ) : ?>
+								<a href="<?php echo esc_url( $widget['Documentation'] ) ?>" target="_blank" rel="noopener noreferrer" class="so-widget-documentation">
+									<?php _e( 'Documentation', 'so-widgets-bundle' ) ?>
+								</a>
+							<?php endif; ?>
+						</div>
 					</div>
 
 				</div>

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -617,6 +617,7 @@ class SiteOrigin_Widgets_Bundle {
 			'AuthorURI' => 'Author URI',
 			'WidgetURI' => 'Widget URI',
 			'VideoURI' => 'Video URI',
+			'Documentation' => 'Documentation',
 		);
 
 		$widgets = array();

--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -4,6 +4,7 @@ Widget Name: Accordion
 Description: An accordion to squeeze a lot of content into a small space.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/accordion-widget/
 */
 
 class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -4,6 +4,7 @@ Widget Name: Button
 Description: A powerful yet simple button widget for your sidebars or Page Builder pages.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/button-widget-documentation/
 */
 
 class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -5,6 +5,7 @@ Widget Name: Contact Form
 Description: A light weight contact form builder.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/contact-form-widget/
 */
 
 class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {

--- a/widgets/cta/cta.php
+++ b/widgets/cta/cta.php
@@ -4,6 +4,7 @@ Widget Name: Call-To-Action
 Description: A simple call-to-action widget. You can do what ever you want with a call-to-action widget.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/call-action-widget/
 */
 
 class SiteOrigin_Widget_Cta_Widget extends SiteOrigin_Widget {

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -5,6 +5,7 @@ Widget Name: Editor
 Description: A widget which allows editing of content using the TinyMCE editor.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/editor-widget/
 */
 
 class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -4,6 +4,7 @@ Widget Name: Features
 Description: Displays a block of features with icons.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/features-widget-documentation/
 */
 
 class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {

--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -5,6 +5,7 @@ Widget Name: Google Maps
 Description: A highly customisable Google Maps widget. Help your site find its place and give it some direction.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/google-maps-widget/
 */
 
 class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -5,6 +5,7 @@ Widget Name: Headline
 Description: A headline to headline all headlines.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/headline-widget/
 */
 
 class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -4,6 +4,7 @@ Widget Name: Hero Image
 Description: A big hero image with a few settings to make it your own.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/hero-image-widget/
 */
 
 if( !class_exists( 'SiteOrigin_Widget_Base_Slider' ) ) include_once plugin_dir_path(SOW_BUNDLE_BASE_FILE) . '/base/inc/widgets/base-slider.class.php';

--- a/widgets/icon/icon.php
+++ b/widgets/icon/icon.php
@@ -5,6 +5,7 @@ Widget Name: Icon
 Description: An iconic icon.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/icon-widget/
 */
 
 class SiteOrigin_Widget_Icon_Widget extends SiteOrigin_Widget {

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -4,6 +4,7 @@ Widget Name: Image Grid
 Description: Display a grid of images. Also useful for displaying client logos.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/image-grid/
 */
 
 class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -4,6 +4,7 @@ Widget Name: Image
 Description: A very simple image widget.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/image-widget-documentation/
 */
 
 class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -4,6 +4,7 @@ Widget Name: Layout Slider
 Description: A slider that allows you to create responsive columnized content for each slide.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/layout-slider-widget/
 */
 
 if( !class_exists( 'SiteOrigin_Widget_Base_Slider' ) ) include_once plugin_dir_path(SOW_BUNDLE_BASE_FILE) . '/base/inc/widgets/base-slider.class.php';

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -4,6 +4,7 @@ Widget Name: Post Carousel
 Description: Gives you a widget to display your posts as a carousel.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/post-carousel-widget/
 */
 
 /**

--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -5,6 +5,7 @@ Widget Name: Price Table
 Description: A powerful yet simple price table widget for your sidebars or Page Builder pages.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/price-table-widget/
 */
 
 class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -4,6 +4,7 @@ Widget Name: Simple Masonry Layout
 Description: A masonry layout for images. Images can link to your posts.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/simple-masonry-widget/
 */
 
 class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -4,6 +4,7 @@ Widget Name: Image Slider
 Description: A very simple slider widget.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/slider-widget-documentation/
 */
 
 if( !class_exists( 'SiteOrigin_Widget_Base_Slider' ) ) include_once plugin_dir_path(SOW_BUNDLE_BASE_FILE) . '/base/inc/widgets/base-slider.class.php';

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -5,6 +5,7 @@ Widget Name: Social Media Buttons
 Description: Customizable buttons which link to all your social media profiles.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/social-media-buttons-widget/
 */
 
 

--- a/widgets/tabs/tabs.php
+++ b/widgets/tabs/tabs.php
@@ -4,6 +4,7 @@ Widget Name: Tabs
 Description: A tabby widget to switch between tabbed content panels.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/tabs-widget/
 */
 
 class SiteOrigin_Widget_Tabs_Widget extends SiteOrigin_Widget {

--- a/widgets/taxonomy/taxonomy.php
+++ b/widgets/taxonomy/taxonomy.php
@@ -5,6 +5,7 @@ Widget Name: Taxonomy
 Description: Displays the selected taxonomy for the current post.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/taxonomy-widget/
 */
 
 class SiteOrigin_Widget_Taxonomy_Widget extends SiteOrigin_Widget {

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -4,6 +4,7 @@ Widget Name: Testimonials
 Description: Display some testimonials.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/testimonials-widget/
 */
 
 class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -5,6 +5,7 @@ Widget Name: Video Player
 Description: Play all your self or externally hosted videos in a customizable video player.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
+Documentation: https://siteorigin.com/widgets-bundle/video-player-widget/
 */
 
 


### PR DESCRIPTION
Resolves #678

Third party widgets can add links to their documentation by adding a documentation header.  A valid example of this is:
```
Documentation: https://siteorigin.com/widgets-bundle/example-widget/
```