### PR TITLE
Icon accessibility

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -67,7 +67,7 @@ add_action('wp_ajax_siteorigin_widgets_get_icons', 'siteorigin_widget_get_icon_l
  *
  * @return bool|string
  */
-function siteorigin_widget_get_icon($icon_value, $icon_styles = false) {
+function siteorigin_widget_get_icon($icon_value, $icon_styles = false, $icon_title = false) {
 	if( empty( $icon_value ) ) return false;
 	$value_parts = SiteOrigin_Widget_Field_Icon::get_value_parts( $icon_value );
 	$family = $value_parts['family'];
@@ -99,7 +99,8 @@ function siteorigin_widget_get_icon($icon_value, $icon_styles = false) {
 		} else if ( is_string( $icon_data ) ) {
 			$unicode = $icon_data;
 		}
-		return '<span class="' . esc_attr( $family_style ) . '" data-sow-icon="' . $unicode . '" ' . ( ! empty( $icon_styles ) ? 'style="' . implode( '; ', $icon_styles ) . '"' : '' ) . '></span>';
+
+		return '<span class="' . esc_attr( $family_style ) . '" data-sow-icon="' . $unicode . '" ' . ( ! empty( $icon_styles ) ? 'style="' . implode( '; ', $icon_styles ) . '"' : '' ) . ' aria-hidden '. ( ( ! $icon_title ) ? '' : 'title="'. esc_attr( $icon_title ) .'"' ) .'></span>'. ( ( ! $icon_title ) ? '' : '<span class="sr-only">'. esc_attr( $icon_title ) .'</span>' );
 	}
 	else {
 		return false;

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -77,6 +77,12 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 						'description' => __('Replaces the icon with your own image icon.', 'so-widgets-bundle'),
 					),
 
+					'icon_title' => array(
+						'type'  => 'text',
+						'label' => __( 'Icon Title', 'so-widgets-bundle' ),
+						'description' => __( 'The icon title is used to tell users the meaning behind the use of this icon.', 'so-widgets-bundle' ),
+					),
+
 					'icon_placement' => array(
 						'type' => 'select',
 						'label' => __( 'Icon Placement', 'so-widgets-bundle' ),
@@ -294,6 +300,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'align' => $instance['design']['align'],
 			'icon_image_url' => $icon_image_url,
 			'icon' => $instance['button_icon']['icon_selected'],
+			'icon_title' => ! empty( $instance['button_icon']['icon_title'] ) ? $instance['button_icon']['icon_title'] : '',
 			'icon_color' => $instance['button_icon']['icon_color'],
 			'text' => $instance['text'],
 		);

--- a/widgets/button/tpl/default.php
+++ b/widgets/button/tpl/default.php
@@ -8,6 +8,7 @@
  * @var string $icon
  * @var string $icon_color
  * @var string $text
+ * @var string $icon_title
  */
 
 ?>
@@ -22,7 +23,7 @@
 				else {
 					$icon_styles = array();
 					if ( ! empty( $icon_color ) ) $icon_styles[] = 'color: ' . $icon_color;
-					echo siteorigin_widget_get_icon( $icon, $icon_styles );
+					echo siteorigin_widget_get_icon( $icon, $icon_styles, $icon_title );
 				}
 			?>
 

--- a/widgets/features/tpl/default.php
+++ b/widgets/features/tpl/default.php
@@ -12,8 +12,7 @@ $last_row = floor( ( count($instance['features']) - 1 ) / $instance['per_row'] )
 				<?php if( !empty( $feature['more_url'] ) && $instance['icon_link'] ) echo '<a href="' . sow_esc_url( $feature['more_url'] ) . '" ' . ( $instance['new_window'] ? 'target="_blank" rel="noopener noreferrer"' : '' ) . '>'; ?>
 				<div
 					class="sow-icon-container <?php echo !empty($instance['container_shape']) ? 'sow-container-' . esc_attr($instance['container_shape']) : 'sow-container-none'?>"
-                    style="color: <?php echo esc_attr($feature['container_color']) ?>; "
-					<?php  echo ( ! empty( $feature['icon_title'] ) ? 'title="' . esc_attr( $feature['icon_title'] ) . '"' : '' ); ?>>
+                    style="color: <?php echo esc_attr( $feature['container_color'] ) ?>; ">
 					<?php
 					$icon_styles = array();
 					if( !empty($feature['icon_image']) ) {
@@ -23,14 +22,16 @@ $last_row = floor( ( count($instance['features']) - 1 ) / $instance['per_row'] )
 							$icon_styles[] = 'background-image: url(' . sow_esc_url($attachment[0]) . ')';
 							if(!empty($instance['icon_size'])) $icon_styles[] = 'font-size: '.intval($instance['icon_size']) . esc_attr( $instance['icon_size_unit'] );
 
-							?><div class="sow-icon-image" style="<?php echo implode('; ', $icon_styles) ?>"></div><?php
+							?><div class="sow-icon-image" style="<?php echo implode( '; ', $icon_styles ) ?>" 
+								<?php  echo ( ! empty( $feature['icon_title'] ) ? 'title="' . esc_attr( $feature['icon_title'] ) . '"' : '' ); ?>>
+								</div><?php
 						}
 					}
 					else {
 						if(!empty($instance['icon_size'])) $icon_styles[] = 'font-size: '.intval($instance['icon_size']) . esc_attr( $instance['icon_size_unit'] );
 						if(!empty($feature['icon_color'])) $icon_styles[] = 'color: '.$feature['icon_color'];
 
-						echo siteorigin_widget_get_icon($feature['icon'], $icon_styles);
+						echo siteorigin_widget_get_icon( $feature['icon'], $icon_styles, $feature['icon_title'] );
 					}
 					?>
 				</div>

--- a/widgets/icon/icon.php
+++ b/widgets/icon/icon.php
@@ -31,6 +31,12 @@ class SiteOrigin_Widget_Icon_Widget extends SiteOrigin_Widget {
 				'label' => __( 'Icon', 'so-widgets-bundle' ),
 			),
 
+			'icon_title' => array(
+				'type'  => 'text',
+				'label' => __( 'Icon Title', 'so-widgets-bundle' ),
+				'description' => __( 'The icon title is used to tell users the meaning behind the use of this icon.', 'so-widgets-bundle' ),
+			),
+
 			'color' => array(
 				'type'  => 'color',
 				'label' => __( 'Color', 'so-widgets-bundle' ),
@@ -84,6 +90,7 @@ class SiteOrigin_Widget_Icon_Widget extends SiteOrigin_Widget {
 	function get_template_variables( $instance, $args ) {
 		return array(
 			'icon' => $instance['icon'],
+			'icon_title' =>  ! empty( $instance['icon_title'] ) ? $instance['icon_title'] : '',
 			'url' => $instance['url'],
 			'new_window' => $instance['new_window'],
 		);

--- a/widgets/icon/tpl/default.php
+++ b/widgets/icon/tpl/default.php
@@ -3,6 +3,7 @@
  * @var $icon
  * @var $url
  * @var $new_window
+ * @var $icon_title
  */
 ?>
 
@@ -10,7 +11,7 @@
 	<?php if ( ! empty( $url ) ) : ?>
 		<a href="<?php echo sow_esc_url( $url ) ?>" <?php if ( ! empty( $new_window ) ) echo 'target="_blank" rel="noopener noreferrer"'; ?>>
 	<?php endif; ?>
-		<?php echo siteorigin_widget_get_icon( $icon ); ?>
+		<?php echo siteorigin_widget_get_icon( $icon, false, $icon_title ); ?>
 	<?php if ( ! empty( $url ) ) : ?>
 		</a>
 	<?php endif; ?>

--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -118,6 +118,11 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 								'type'  => 'icon',
 								'label' => __( 'Icon', 'so-widgets-bundle' ),
 							),
+							'icon_title' => array(
+								'type'  => 'text',
+								'label' => __( 'Icon Title', 'so-widgets-bundle' ),
+								'description' => __( 'The icon title is used to tell users the meaning behind the use of this icon.', 'so-widgets-bundle' ),
+							),
 							'icon_color' => array(
 								'type'  => 'color',
 								'label' => __( 'Icon color', 'so-widgets-bundle' ),
@@ -230,6 +235,7 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 				if ( ! empty( $column['features'] ) ) {
 					foreach ( $column['features'] as &$feature ) {
 						$feature['text'] = do_shortcode( $feature['text'] );
+						$feature['icon_title'] = ! empty( $feature['icon_title'] ) ? $feature['icon_title'] : '';
 					}
 				}
 				$columns[] = $column;

--- a/widgets/price-table/tpl/atom.php
+++ b/widgets/price-table/tpl/atom.php
@@ -48,7 +48,7 @@
 								if ( ! empty( $feature['icon_color'] ) ) {
 									$icon_styles[] = 'color: ' . $feature['icon_color'];
 								}
-								echo siteorigin_widget_get_icon( $feature['icon_new'], $icon_styles );
+								echo siteorigin_widget_get_icon( $feature['icon_new'], $icon_styles, $feature['icon_title'] );
 								?>
                             </div>
 						<?php endif; ?>

--- a/widgets/social-media-buttons/tpl/default.php
+++ b/widgets/social-media-buttons/tpl/default.php
@@ -41,6 +41,8 @@
 				<?php if( !empty( $network['is_custom'] ) ) echo '<!-- premium-' . $network['name'] . ' -->'; ?>
 				<?php echo siteorigin_widget_get_icon( $network['icon_name'] ); ?>
 				<?php if( !empty( $network['is_custom'] ) ) echo '<!-- endpremium -->'; ?>
+
+				<span class="sr-only"><?php esc_attr( $title ) ?></span>
 			</span>
 		</a>
 	<?php endforeach; ?>


### PR DESCRIPTION
This PR usage of the icon form field to be responsive and updates SiteOrigin widgets to either make use of it or to at least account for the changes made (such as in in the case of the SiteOrigin Social Media Buttons widget.

Notes:

- The Accordion and tab widget close/open, should we set a default title? I feel this is better than asking the user to set one
- Currently using the FontAwesome sr-only class to hide the fallback HTML and allow it to be readable by screen readers. Do you want me to repeat this CSS in each of the fonts CSS files or do you want to add a copy of this CSS in a central location? If central location, where?
- The Social Media Buttons widget is handled differently due to how the button is structured as can't apply it directly to the icon or you end up with a large amount of spacing)
