### PR TITLE
Update enqueue dependencies for the Block Editor

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -27,7 +27,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		wp_enqueue_script(
 			'sowb-widget-block',
 			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.js', __FILE__ ),
-			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose' ),
+			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'underscore ),
 			SOW_BUNDLE_VERSION
 		);
 		


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/uncaught-typeerror-cannot-read-property-reduce-of-undefined/)


```
widget-block.min.js?ver=1.14.0:1 Uncaught TypeError: Cannot read property 'reduce' of undefined
    at widget-block.min.js?ver=1.14.0:1
    at widget-block.min.js?ver=1.14.0:1
```