### PR TITLE
Features: Change selector to target .textwidget rather than p specifically

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -160,16 +160,14 @@
 
         .textwidget {
             margin: auto;
+            .font(@text_font, @text_font_weight);
+            font-size: @text_size;
+            color: @text_color;
+            
             > h5 {
                 .font(@title_font, @title_font_weight);
                 font-size: @title_size;
                 color: @title_color;
-            }
-
-            > p {
-                .font(@text_font, @text_font_weight);
-                font-size: @text_size;
-                color: @text_color;
             }
 
             > p.sow-more-text {


### PR DESCRIPTION
Before:
![](https://vgy.me/Eqfb6K.png)

After:
![](https://vgy.me/Vc74gR.png)

It's possible to replicate this issue by not adding multiple paragraphs of text or by adding something that doesn't add a paragraph (like a list).

[Test Layout](https://drive.google.com/a/siteorigin.com/uc?id=1i_yvMOud1Ll_kgWaO2nEnuvBfia0FhUV)