### PR TITLE
FitText Description Typo Correction

### DIFF
--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -257,7 +257,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			'fittext_compressor' => array(
 				'type' => 'number',
 				'label' => __( 'FitText Compressor Strength', 'so-widgets-bundle' ),
-				'description' => __( 'The lower the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
+				'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 				'default' => 0.85,
 				'state_handler' => array(
 					'use_fittext[show]' => array( 'show' ),

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -230,7 +230,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 					'fittext_compressor' => array(
 						'type' => 'number',
 						'label' => __( 'FitText Compressor Strength', 'so-widgets-bundle' ),
-						'description' => __( 'The lower the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
+						'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 						'default' => 0.85,
 						'state_handler' => array(
 							'use_fittext[show]' => array( 'show' ),


### PR DESCRIPTION
The higher the value, the more the text is scaled.

Example:
![](https://vgy.me/GXcRCH.png)

The first paragraph is 0.50
The second Paragraph is 0.75
The third Paragraph is 1.25