### PR TITLE
Accordion - Resolve issue with number titles instantly closing upon opening a panel

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -129,7 +129,7 @@ jQuery( function ( $ ) {
 						var panel = panels[ i ];
 						var anchor = $( panel ).data( 'anchor' );
 						var anchors = window.location.hash.substring(1).split( ',' ); 
-						if ( anchor && $.inArray( anchor, anchors ) > -1 ) {
+						if ( anchor && $.inArray( anchor.toString(), anchors ) > -1 ) {
 							openPanel( panel, true );
 						} else {
 							closePanel( panel, true );


### PR DESCRIPTION
Accordion items with number titles will instantly close on open due to a type difference.

![](https://vgy.me/9vGA1J.gif)

[Test layout here](https://drive.google.com/a/siteorigin.com/uc?id=1RL6D0R7rdW66hYffXylJQI2vF9iKV6eM)