### PR TITLE
Accordion: Account for Open/close icon location being set to Left in Title Spacing

### DIFF
--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -65,7 +65,7 @@
 
 			.sow-accordion-title {
 				display: inline-block;
-				width: ~"calc(100% - 20px)";
+				width: ~"calc(100% - 25px)";
 				& when ( @show_open_close_icon = true ) and ( @heading_title_align = @open_close_location ) {
 					margin-@{open_close_location}: 5px;
 				}


### PR DESCRIPTION
Before:
![](https://i.imgur.com/NqX6jk7.png)

After:
![](https://i.imgur.com/oM7TGYt.png)

[Test Layout](https://drive.google.com/a/siteorigin.com/uc?id=1k_Wmr7xg_1BdyF2mShAg-yTvOrQPgnUf)