### PR TITLE
Social Media Buttons: Prevent the Phone Network from Opening in a new window

### DIFF
--- a/widgets/social-media-buttons/tpl/default.php
+++ b/widgets/social-media-buttons/tpl/default.php
@@ -29,7 +29,7 @@
 			'title' => $title,
 			'aria-label' => $title,
 		);
-		if( !empty( $instance['design']['new_window'] ) ) {
+		if ( !empty( $instance['design']['new_window'] ) && $network['name'] != 'phone' ) {
 			$button_attributes['target'] = '_blank';
 			$button_attributes['rel'] = 'noopener noreferrer';
 		}


### PR DESCRIPTION
This PR resolves an issue on Android devices using Chrome. If the **Open in new window** setting is enabled, clicking a phone network button on an Android device, Chrome will open a new tab but not open the phone app. It appears there's a general issue with using `noopener noreferrer` alongside `target="_blank". Without them, it works without issue.

I tested this PR on a Pixel 2 XL and an iPhone 7 and saw no issues as a result of making this change.