### PR TITLE
Correct name of SiteOrigin Widget Bundle object in admin.js

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1318,7 +1318,7 @@ var sowbForms = window.sowbForms || {};
 	if ( $body.hasClass('block-editor-page') ) {
 		// Setup new widgets when they're previewed in the block editor.
 		$(document).on('panels_setup_preview', function () {
-			$( sowb ).trigger( 'setup_widgets', { preview: true } );
+			$( sowbForms ).trigger( 'setup_widgets', { preview: true } );
 		});
 	}
 


### PR DESCRIPTION
If you go to a page/post and insert a layout/widget and press `preview` then it is possible to end up in a scenario where the block will return `This block has encountered an error and cannot be previewed.` because the `sowb` object do not exist.

Looking at other component like `widgets/accordion/js/accordion.js` then it defines the following at the top: `var sowb = window.sowb || {};`.

based on the way `sowb` is normally used, I'm assuming the object is meant to be named `sowbForms` in `admin.js`.