### PR TITLE
Added padding to slider navigation arrows

### DIFF
--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -159,7 +159,6 @@
 			display: block;
 			
 			padding: 15px;
-			position: relative;
 	
 			text-align: center;
 			text-decoration: none;

--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -159,6 +159,8 @@
 			display: block;
 
 			height: 1em;
+			margin: -15px;
+			padding: 15px;
 
 			text-align: center;
 			text-decoration: none;

--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -148,20 +148,19 @@
 		z-index: 1001;
 		position: absolute;
 		top: 50%;
+		transform: translateY(-50%);
 		opacity: 0.75;
 
 		font-size: 25px;
-		margin-top: -0.5em;
 
 		.user-select(none);
 
 		a{
 			display: block;
-
-			height: 1em;
-			margin: -15px;
+			
 			padding: 15px;
-
+			position: relative;
+	
 			text-align: center;
 			text-decoration: none;
 			color: #FFFFFF;
@@ -172,7 +171,8 @@
 		}
 
 		&.sow-slide-nav-next {
-			right: 20px;
+			right: 5px;
+			
 
 			a {
 				background-position: top right;
@@ -180,7 +180,7 @@
 		}
 
 		&.sow-slide-nav-prev {
-			left: 20px;
+			left: 5px;
 
 			a {
 				background-position: top left;


### PR DESCRIPTION
This PR adds padding around the slider navigation arrows to hopefully, make them a little easier to select.

@braamgenis Are you happy with the selector the padding has been added to and the negative margin to maintain the arrow position? Should we rather use ems?

Which CSS property order convention are we using? [Outside In](https://webdesign.tutsplus.com/articles/outside-in-ordering-css-properties-by-importance--cms-21685)?

Resolves #445.