### PR TITLE
Added a description for the Hero Heading Size

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -212,6 +212,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 					'heading_size' => array(
 						'type' => 'measurement',
 						'label' => __('Heading size', 'so-widgets-bundle'),
+						'description' => __( 'Enter the h1 font size. h2 - h6 will be proportionally sized based on this value.', 'so-widgets-bundle' ),
 						'default' => '38px',
 					),
 


### PR DESCRIPTION
Resolves #453.

The objective of this PR is to let users know that the Heading Size setting will set h1 and that h2-h6 font size will be based on this value. I can't let users know what the scale is because I don't think there is a consistent scale in use:

```
h1 {
	font-size: @heading_size;
}

h2 {
	font-size: @heading_size * 0.85;
}

h3 {
	font-size: @heading_size * 0.7;
}

h4 {
	font-size: @heading_size * 0.6;
}

h5 {
	font-size: @heading_size * 0.5;
}

h6 {
	font-size: @heading_size * 0.4;
}
```