### PR TITLE
Contact Form: Prevent SiteOrigin Support email from being used as a To Email Address

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1252,9 +1252,9 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		}
 		$body = wpautop( trim( $body ) );
 
-		if ( $instance['settings']['to'] == 'ibrossiter@gmail.com' || $instance['settings']['to'] == 'test@example.com' || empty( $instance['settings']['to'] ) ) {
+		if ( $instance['settings']['to'] == 'ibrossiter@gmail.com' || $instance['settings']['to'] == 'test@example.com' || $instance['settings']['to'] == 'support@siteorigin.com' || empty( $instance['settings']['to'] ) ) {
 			// Replace default and empty email address.
-			// Also replaces the email address that comes from the prebuilt layout directory
+			// Also replaces the email address that comes from the prebuilt layout directory and SiteOrigin Support Email
 			$instance['settings']['to'] = get_option( 'admin_email' );
 		}
 		


### PR DESCRIPTION
At one stage we released a layout that had the support@siteorigin.com as the To Email Address. This has been fixed but there are still a few users who're using the older version with our email. Unfortunately, we also didn't enable any anti-spam features with the base layout.

This PR excludes support@siteorigin.com from being used as a To Email Address to hopefully reduce the amount of spam we're getting.