### PR TITLE
Changed the date range label width to `min-width`

### DIFF
--- a/base/inc/fields/css/date-range-field.less
+++ b/base/inc/fields/css/date-range-field.less
@@ -5,7 +5,7 @@
 
 		span {
 			display: inline-block;
-			width: 35px;
+			min-width: 35px;
 
 			&:last-child {
 				margin-left: 10px;


### PR DESCRIPTION
The fixed width label size currently used causes translated strings to overflow and run behind the date field.

![Editar_página_‹_Fondo_de_Mujeres_del_Sur_—_WordPress](https://user-images.githubusercontent.com/789159/62051060-d8533d00-b212-11e9-85a8-a75997ba2fec.png)
