### PR TITLE
Contact: Add note to Default Subject about overriding Subject field types set to required.

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -74,7 +74,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					'default_subject'                  => array(
 						'type'        => 'text',
 						'label'       => __( 'Default subject', 'so-widgets-bundle' ),
-						'description' => __( "Subject to use when there isn't one supplied by the user. This setting prevents Subject field types from being set to required as a Default Subject will always be used if no subject is input.", 'so-widgets-bundle' ),
+						'description' => __( "Subject to use when there isn't one supplied by the user. If you make use of this option it won't be possible to set the Subject field as required because the default subject will be used as a fallback.", 'so-widgets-bundle' ),
 					),
 					'subject_prefix'                   => array(
 						'type'        => 'text',

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -74,7 +74,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					'default_subject'                  => array(
 						'type'        => 'text',
 						'label'       => __( 'Default subject', 'so-widgets-bundle' ),
-						'description' => __( "Subject to use when there isn't one available.", 'so-widgets-bundle' ),
+						'description' => __( "Subject to use when there isn't one supplied by the user. This setting prevents Subject field types from being set to required as a Default Subject will always be used if no subject is input.", 'so-widgets-bundle' ),
 					),
 					'subject_prefix'                   => array(
 						'type'        => 'text',


### PR DESCRIPTION
A User emailed us and was confused why the Subject field wasn't respecting the Required setting. Turns out they had said a Default Subject set so that was being used when the user didn't input a subject. This, in hindsight, makes sense but it isn't mentioned anywhere. This PR will add a note to the Default Subject description to make this more apparent.