### PR TITLE
Auto open Google Maps settings modal

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -165,7 +165,7 @@ jQuery( function( $ ){
         $( '#widgets-list .so-widget-settings' ).prop('disabled', false);
     } );
 
-    // Automatically open settings model based on hash
+    // Automatically open settings modal based on hash
     if( window.location.hash && window.location.hash.substring(0, 10) === '#settings-' ) {
         var openSettingsId = window.location.hash.substring(10);
         $('div[data-id="' + openSettingsId +  '"] button.so-widget-settings').click();

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -165,4 +165,10 @@ jQuery( function( $ ){
         $( '#widgets-list .so-widget-settings' ).prop('disabled', false);
     } );
 
+    // Automatically open settings model based on hash
+    if( window.location.hash && window.location.hash.substring(0, 10) === '#settings-' ) {
+        var openSettingsId = window.location.hash.substring(10);
+        $('div[data-id="' + openSettingsId +  '"] button.so-widget-settings').click();
+    }
+
 } );

--- a/widgets/google-map/fields/location.class.php
+++ b/widgets/google-map/fields/location.class.php
@@ -63,7 +63,7 @@ class SiteOrigin_Widget_Field_Location extends SiteOrigin_Widget_Field_Base {
 					'</a>'
 				),
 				'globalSettingsButtonLabel' => __( 'Go to Google Maps Widget settings', 'so-widgets-bundle' ),
-				'globalSettingsButtonUrl' => admin_url( 'plugins.php?page=so-widgets-plugins' ),
+				'globalSettingsButtonUrl' => admin_url( 'plugins.php?page=so-widgets-plugins#settings-google-map' ),
 			)
 		);
 	}


### PR DESCRIPTION
This PR adds a method of auto opening a widget settings modal, and implements that feature into the Google Maps widget form.

Resolves https://github.com/siteorigin/so-widgets-bundle/issues/898