### PR TITLE
Add fallback URL for testimonial images

### DIFF
--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -70,6 +70,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 					'image' => array(
 						'type' => 'media',
 						'label' => __('Image', 'so-widgets-bundle'),
+						'fallback' => true,
 					),
 
 					'link_image' => array(


### PR DESCRIPTION
Add the ability to add a fallback/external image for Testimonial images. 

<img width="659" alt="Edit_Page_‹_SiteOrigin_—_WordPress" src="https://user-images.githubusercontent.com/789159/67397463-7dc74400-f5a9-11e9-9098-ef78ce161111.png">
