### PR TITLE
SO Features: Container Position: Swap Right and Left values

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -57,6 +57,8 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 						'default' => '#404040',
 					),
 
+					// Left and right array keys are swapped due to a mistake that couldn't be corrected without disturbing existing users.
+
                     'container_position' => array(
                         'type' => 'select',
                         'label' => __( 'Icon container position', 'so-widgets-bundle' ),

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -62,9 +62,9 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
                         'label' => __( 'Icon container position', 'so-widgets-bundle' ),
                         'options' => array(
                             'top'    => __( 'Top', 'so-widgets-bundle' ),
-                            'right'  => __( 'Right', 'so-widgets-bundle' ),
+                            'left'  => __( 'Right', 'so-widgets-bundle' ),
                             'bottom' => __( 'Bottom', 'so-widgets-bundle' ),
-                            'left'   => __( 'Left', 'so-widgets-bundle' ),
+                            'right'   => __( 'Left', 'so-widgets-bundle' ),
                         ),
                         'default' => 'top',
                     ),


### PR DESCRIPTION
The SiteOrigin Features Widget Container Position Icon Horizontal options control the container position while the top and bottom settings affect the icon placement. This is problematic as left actually means right and right means left. This PR will swap the left and right values,  but will still internally refer to them as the left and right for backwards compatibility.