### PR TITLE
Unset widget selection input max-width

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -709,6 +709,10 @@
 			.so-widget-block-container {
 				width: 100%;
 				
+				.components-base-control__field select {
+					max-width: unset;
+				}
+
 				.siteorigin-widget-form.siteorigin-widget-form-main {
 					min-width: unset;
 				}


### PR DESCRIPTION
The new admin styles set a max-width which we weren’t accounting for in the widget select field styles.

Resolves https://github.com/siteorigin/so-widgets-bundle/issues/931.