### PR TITLE
Removed media fallback field padding

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -111,7 +111,6 @@
 	}
 	.media-fallback-external {
 		float: left;
-		padding: 4px 8px;
 		margin-top: 2px !important;
 		margin-left: 25px !important;
 		max-width: 320px;


### PR DESCRIPTION
* Falling back on core input field styling.

Resolves external media field height incorrect after WP 5.3.

![hero](https://user-images.githubusercontent.com/789159/70863979-6d529a80-1f56-11ea-9a0b-fa6b1237d730.png)
