### PR TITLE
Ensure correct alignment of Pixabay search button

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -151,13 +151,17 @@
 
 		.so-widgets-search-button {
 			position: absolute;
-			padding: 9px 14px;
+			padding: 0 14px;
 			font-size: 1.2em;
 			height: 100%;
 			top: 0;
 			right: 320px;
 			border-width: 1px;
 			box-shadow: none;
+
+			.dashicons-search {
+				vertical-align: middle;
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue this PR resolves:

<img width="553" alt="pixabay" src="https://user-images.githubusercontent.com/789159/71544723-86fad580-298b-11ea-82ec-f71c5764b52b.png">
