### PR TITLE
Add .sow-masonry-grid-image class to Simple Masonry Images

### DIFF
--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -29,7 +29,10 @@
 					<?php endforeach; ?>>
 				<?php endif; ?>
 
-				<?php echo wp_get_attachment_image( $item['image'], 'full', false, array( 'title' => esc_attr( $title ) ) ); ?>
+				<?php echo wp_get_attachment_image( $item['image'], 'full', false, array(
+					'title' => esc_attr( $title ),
+					'class' => 'sow-masonry-grid-image',
+				) ); ?>
 
 				<?php if ( ! empty( $url ) ) : ?>
 					</a>


### PR DESCRIPTION
This PR resolves #942 by giving each SiteOrigin Simple Masonry Image image the .sow-masonry-grid-image class. I also tested Litespeed Cache to ensure this would be enough to exclude the image from the Lazy Load and it was.

Be sure to exclude the proceeding period for the class during testing.