### PR TITLE
Specify label styling

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -59,6 +59,8 @@
 
 		> label {
 			display: block;
+			font-size: 13px;
+			font-weight: 400;
 			margin-bottom: 3px;
 
 			&.siteorigin-widget-field-label {


### PR DESCRIPTION
Resolves label styling issue.

<img width="550" alt="Edit_Page_‹_SiteOrigin_—_WordPress" src="https://user-images.githubusercontent.com/789159/72084297-e651d180-330b-11ea-8e92-da38be1716dd.png">
