### PR TITLE
Added line-height to section heading

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -428,6 +428,7 @@
 		> label {
 			background: #F0F0F0;
 			border: 1px solid #D0D0D0;
+			line-height: 1.4;
 			padding: 10px;
 			display: block;
 			margin-bottom: 0;


### PR DESCRIPTION
The section heading alignment relies on a line-height that changes in the Block Editor. The result is seen below.

<img width="590" alt="widget-block" src="https://user-images.githubusercontent.com/789159/72156676-caf3ce80-33be-11ea-89b0-ce6c6bf73896.png">

By stating the line height we're expecting in the Classic Editor we can fix this.

@AlexGStapleton Is `.siteorigin-widget-field-type-widget` used in Beaver Builder? I've only tested this targeting `.siteorigin-widget-field-type-section`. Can you test this PR in BB?