### PR TITLE
Switch media field and external URL margin

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -6,6 +6,7 @@
 		position: relative;
 		display: block;
 		float: left;
+		margin-right: 25px;
 
 		.gradient( #f9f9f9, #f2f2f2, #f9f9f9 );
 		.box-shadow(~"0 1px 2px rgba(0,0,0,0.1)");
@@ -112,7 +113,6 @@
 	.media-fallback-external {
 		float: left;
 		margin-top: 2px !important;
-		margin-left: 25px !important;
 		max-width: 320px;
 	}
 }


### PR DESCRIPTION
When the Block Editor is under about 690px in width, the external URL field collapses.

<img width="800" alt="image-grid" src="https://user-images.githubusercontent.com/789159/72157360-66d20a00-33c0-11ea-90d2-61851191b7fd.png">

I'm not sure how to detect the width of the Block Editor with CSS to set breakpoints for different behavior so I've just switched the margin from the external URL field to the media field. If you have any better ideas, let me know. I think this is sufficient but I am open to ideas.