### PR TITLE
BE fix media button

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -11,7 +11,7 @@
 		float: left;
 		font-size: 13px;
 		height: 32px;
-		line-height: 1.4;
+		line-height: 18.2px;
 		margin-right: 25px;
 		overflow: auto;
 		position: relative;

--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -9,8 +9,11 @@
 		.box-shadow(~"0 1px 2px rgba(0,0,0,0.1)");
 		display: block;
 		float: left;
+		font-size: 13px;
 		height: 32px;
+		line-height: 1.4;
 		margin-right: 25px;
+		overflow: auto;
 		position: relative;
 
 		&:hover {


### PR DESCRIPTION
The media button styling is currently slightly broken in the Block Editor:

<img width="259" alt="be-media" src="https://user-images.githubusercontent.com/789159/72207729-5eeb9600-34a4-11ea-8a52-6e2f608cb2ea.png">

Below is how the button looks in the Classic Editor:

<img width="256" alt="media-classic" src="https://user-images.githubusercontent.com/789159/72207735-66ab3a80-34a4-11ea-8222-f6247f6b4934.png">

This PR aims to resolve this problem. From my testing, it seems to without issue.