### PR TITLE
Slider: Add class to slide images

### DIFF
--- a/base/inc/attachments.php
+++ b/base/inc/attachments.php
@@ -32,21 +32,18 @@ function siteorigin_widgets_get_attachment_image_src( $attachment, $size, $fallb
 	return false;
 }
 
-function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback, $class = false ){
+function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback, $atts = array() ){
 	if( !empty( $attachment ) ) {
-		if ( ! empty( $class ) ) {
-			$class = array( 'class' => $class );
-		}
-
-		return wp_get_attachment_image( $attachment, $size, false, $class );
+		return wp_get_attachment_image( $attachment, $size, false, $atts );
 	}
 	else {
 		$src = siteorigin_widgets_get_attachment_image_src( $attachment, $size, $fallback );
 		if( empty($src[0]) ) return '';
 
-		$atts = array(
-			'src' => $src[0],
-		);
+		if ( ! empty( $atts ) ) {
+			$atts['class'] = $class;
+		}
+
 
 		if ( function_exists( 'wp_get_attachment_image_srcset' ) ) {
 			$atts['srcset'] = wp_get_attachment_image_srcset( $attachment, $size );
@@ -55,9 +52,7 @@ function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback,
 			$atts['sizes'] = wp_get_attachment_image_sizes( $attachment, $size );
 		}
 
-		if ( ! empty( $class ) ) {
-			$atts['class'] = $class;
-		}
+		$atts['src'] = $src[0];
 
 		if( !empty($src[1]) ) $atts['width'] = $src[1];
 		if( !empty($src[2]) ) $atts['height'] = $src[2];

--- a/base/inc/attachments.php
+++ b/base/inc/attachments.php
@@ -32,9 +32,13 @@ function siteorigin_widgets_get_attachment_image_src( $attachment, $size, $fallb
 	return false;
 }
 
-function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback ){
+function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback, $class = false ){
 	if( !empty( $attachment ) ) {
-		return wp_get_attachment_image( $attachment, $size );
+		if ( ! empty( $class ) ) {
+			$class = array( 'class' => $class );
+		}
+
+		return wp_get_attachment_image( $attachment, $size, false, $class );
 	}
 	else {
 		$src = siteorigin_widgets_get_attachment_image_src( $attachment, $size, $fallback );
@@ -49,6 +53,10 @@ function siteorigin_widgets_get_attachment_image( $attachment, $size, $fallback 
 		}
 		if ( function_exists( 'wp_get_attachment_image_sizes' ) ) {
 			$atts['sizes'] = wp_get_attachment_image_sizes( $attachment, $size );
+		}
+
+		if ( ! empty( $class ) ) {
+			$atts['class'] = $class;
 		}
 
 		if( !empty($src[1]) ) $atts['width'] = $src[1];

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -155,7 +155,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						$frame['foreground_image'],
 						'full',
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-						'sow-slider-forground-image'
+						'sow-slider-foreground-image'
 					);
 					?>
 					<?php if ( ! empty( $frame['url'] ) ) : ?>

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -154,7 +154,8 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 					echo siteorigin_widgets_get_attachment_image(
 						$frame['foreground_image'],
 						'full',
-						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : ''
+						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
+						'sow-slider-forground-image'
 					);
 					?>
 					<?php if ( ! empty( $frame['url'] ) ) : ?>
@@ -180,7 +181,8 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 			echo siteorigin_widgets_get_attachment_image(
 				$frame['background_image'],
 				'full',
-				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : ''
+				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
+				'sow-slider-background-image'
 			);
 
 			?>

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -155,7 +155,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						$frame['foreground_image'],
 						'full',
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-						array( 'class' => 'sow-slider-forground-image' )
+						array( 'class' => 'sow-slider-foreground-image' )
 					);
 					?>
 					<?php if ( ! empty( $frame['url'] ) ) : ?>

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -155,7 +155,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						$frame['foreground_image'],
 						'full',
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-						'sow-slider-foreground-image'
+						array( 'class' => 'sow-slider-forground-image' )
 					);
 					?>
 					<?php if ( ! empty( $frame['url'] ) ) : ?>
@@ -182,7 +182,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				$frame['background_image'],
 				'full',
 				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
-				'sow-slider-background-image'
+				array( 'class' => 'sow-slider-background-image' )
 			);
 
 			?>


### PR DESCRIPTION
This PR will allow users to exclude the SiteOrigin Slider slide images from lazy load plugins. This was directly in response to a report about a display issue the SiteOrigin Slider widget has with the Jetpack Lazy Load.

This PR also extends the `siteorigin_widgets_get_attachment_image` function by adding a `class` parameter that allows developers to easily give images a class.