### PR TITLE
Use first element in $widget_icon_families instead of raw string.

### DIFF
--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -24,7 +24,7 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			$value = $value_parts['family'] . $value_style . '-' . $value_parts['icon'];
 			
 		} else {
-			$value_family = key($widget_icon_families);//return the first element in the font families array, instead of raw string value.
+			$value_family = key($widget_icon_families);
 		}
 		?>
 

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -24,7 +24,7 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			$value = $value_parts['family'] . $value_style . '-' . $value_parts['icon'];
 			
 		} else {
-			$value_family = 'fontawesome';
+			$value_family = key($widget_icon_families);//return the first element in the font families array, instead of raw string value.
 		}
 		?>
 

--- a/icons/icons.php
+++ b/icons/icons.php
@@ -4,7 +4,7 @@ define( 'SITEORIGIN_WIDGETS_ICONS', true );
 
 function siteorigin_widgets_icon_families_filter( $families ){
 	$bundled = array(
-        'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),//moved first to fit old behavior of default fonts.
+        'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),
 		'elegantline' => __( 'Elegant Themes Line Icons', 'so-widgets-bundle' ),
 		'genericons' => __( 'Genericons', 'so-widgets-bundle' ),
 		'icomoon' => __( 'Icomoon Free', 'so-widgets-bundle' ),

--- a/icons/icons.php
+++ b/icons/icons.php
@@ -4,8 +4,8 @@ define( 'SITEORIGIN_WIDGETS_ICONS', true );
 
 function siteorigin_widgets_icon_families_filter( $families ){
 	$bundled = array(
+        'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),//moved first to fit old behavior of default fonts.
 		'elegantline' => __( 'Elegant Themes Line Icons', 'so-widgets-bundle' ),
-		'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),
 		'genericons' => __( 'Genericons', 'so-widgets-bundle' ),
 		'icomoon' => __( 'Icomoon Free', 'so-widgets-bundle' ),
 		'typicons' => __( 'Typicons', 'so-widgets-bundle' ),

--- a/icons/icons.php
+++ b/icons/icons.php
@@ -4,7 +4,7 @@ define( 'SITEORIGIN_WIDGETS_ICONS', true );
 
 function siteorigin_widgets_icon_families_filter( $families ){
 	$bundled = array(
-        'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),
+		'fontawesome' => __( 'Font Awesome', 'so-widgets-bundle' ),
 		'elegantline' => __( 'Elegant Themes Line Icons', 'so-widgets-bundle' ),
 		'genericons' => __( 'Genericons', 'so-widgets-bundle' ),
 		'icomoon' => __( 'Icomoon Free', 'so-widgets-bundle' ),


### PR DESCRIPTION
I'm currently adding fontawesome pro to this field. And I'm removing other font available to the user. So if fontawesome doesn't exist in the array, my custom font was not rendering.

Tested on debian and php 7.2 