### PR TITLE
Accordion: When hiding panels, only search current accordion and not nested accordions

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -12,7 +12,7 @@ jQuery( function ( $ ) {
 			}
 
 			var $accordionPanels = $( element ).find( '> .sow-accordion-panel' );
-			$accordionPanels.not( '.sow-accordion-panel-open' ).find( '.sow-accordion-panel-content' ).hide();
+			$accordionPanels.not( '.sow-accordion-panel-open' ).children( '.sow-accordion-panel-content' ).hide();
 			var openPanels = $accordionPanels.filter( '.sow-accordion-panel-open' ).toArray();
 
 			var updateHash = function () {

--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -11,7 +11,7 @@ jQuery( function ( $ ) {
 				return $( this );
 			}
 
-			var $accordionPanels = $( element ).children( '> .sow-accordion-panel' );
+			var $accordionPanels = $( element ).find( '> .sow-accordion-panel' );
 			$accordionPanels.not( '.sow-accordion-panel-open' ).find( '.sow-accordion-panel-content' ).hide();
 			var openPanels = $accordionPanels.filter( '.sow-accordion-panel-open' ).toArray();
 

--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -11,7 +11,7 @@ jQuery( function ( $ ) {
 				return $( this );
 			}
 
-			var $accordionPanels = $( element ).find( '> .sow-accordion-panel' );
+			var $accordionPanels = $( element ).children( '> .sow-accordion-panel' );
 			$accordionPanels.not( '.sow-accordion-panel-open' ).find( '.sow-accordion-panel-content' ).hide();
 			var openPanels = $accordionPanels.filter( '.sow-accordion-panel-open' ).toArray();
 


### PR DESCRIPTION
This PR prevents potential visability issues if the user is nesting accodions inside of an accordion that's not open by default.