### PR TITLE
Remove slider slide number from output

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -197,7 +197,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				?>
 				<ol class="sow-slider-pagination">
 					<?php foreach($frames as $i => $frame) : ?>
-						<li><a href="#" data-goto="<?php echo $i ?>" aria-label="<?php printf( __( 'display slide %s', 'so-widgets-bundle' ), $i+1 ) ?>"><?php echo $i+1 ?></a></li>
+						<li><a href="#" data-goto="<?php echo $i ?>" aria-label="<?php printf( __( 'display slide %s', 'so-widgets-bundle' ), $i+1 ) ?>"></a></li>
 					<?php endforeach; ?>
 				</ol>
 


### PR DESCRIPTION
Related #747.

This PR prevents the output of the slide numbers to prevent an issue where they'll appear in post excerpts. Previously, it was argued that these slide numbers should be retained for accessibility reasons but there's already `aira-label` in place which is sufficient for accessibility. The previously decided solution was to implement functionality that automatically generates an excerpt from the first SiteOrigin Editor widget. While useful, we've run into situations where an editor isn't being used.