### PR TITLE
Add support for custom icon styles

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -69,18 +69,23 @@ add_action('wp_ajax_siteorigin_widgets_get_icons', 'siteorigin_widget_get_icon_l
  */
 function siteorigin_widget_get_icon($icon_value, $icon_styles = false) {
 	if( empty( $icon_value ) ) return false;
-	$value_parts = SiteOrigin_Widget_Field_Icon::get_value_parts( $icon_value );
-	$family = $value_parts['family'];
-	$style = empty( $value_parts['style'] ) ? null : $value_parts['style'];
-	$icon = $value_parts['icon'];
-	if( empty( $family ) || empty( $icon ) ) return false;
 
-	static $widget_icon_families;
+  static $widget_icon_families;
 	static $widget_icons_enqueued = array();
 	
 	if ( empty( $widget_icon_families ) ) {
 		$widget_icon_families = apply_filters('siteorigin_widgets_icon_families', array() );
 	}
+  
+  // Get an array of available icon families styles to pass to SiteOrigin_Widget_Field_Icon::get_value_parts()
+  $icon_families_styles = SiteOrigin_Widget_Field_Icon::get_icon_families_styles( $widget_icon_families );
+  
+	$value_parts = SiteOrigin_Widget_Field_Icon::get_value_parts( $icon_value, $icon_families_styles );
+	$family = $value_parts['family'];
+	$style = empty( $value_parts['style'] ) ? null : $value_parts['style'];
+	$icon = $value_parts['icon'];
+	if( empty( $family ) || empty( $icon ) ) return false;
+  
 	if ( empty( $widget_icon_families[ $family ] ) ||
 		 empty( $widget_icon_families[ $family ]['icons'][ $icon ] ) ) {
 		return false;

--- a/base/base.php
+++ b/base/base.php
@@ -70,15 +70,15 @@ add_action('wp_ajax_siteorigin_widgets_get_icons', 'siteorigin_widget_get_icon_l
 function siteorigin_widget_get_icon($icon_value, $icon_styles = false) {
 	if( empty( $icon_value ) ) return false;
 
-  static $widget_icon_families;
+	static $widget_icon_families;
 	static $widget_icons_enqueued = array();
 	
 	if ( empty( $widget_icon_families ) ) {
 		$widget_icon_families = apply_filters('siteorigin_widgets_icon_families', array() );
 	}
   
-  // Get an array of available icon families styles to pass to SiteOrigin_Widget_Field_Icon::get_value_parts()
-  $icon_families_styles = SiteOrigin_Widget_Field_Icon::get_icon_families_styles( $widget_icon_families );
+	// Get an array of available icon families styles to pass to SiteOrigin_Widget_Field_Icon::get_value_parts()
+	$icon_families_styles = SiteOrigin_Widget_Field_Icon::get_icon_families_styles( $widget_icon_families );
   
 	$value_parts = SiteOrigin_Widget_Field_Icon::get_value_parts( $icon_value, $icon_families_styles );
 	$family = $value_parts['family'];

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -16,12 +16,12 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 	protected $icons_callback;
 
 	protected function render_field( $value, $instance ) {
-    $widget_icon_families = $this->get_widget_icon_families();
+		$widget_icon_families = $this->get_widget_icon_families();
 
-    // Get an array of available icon families styles to pass to self::get_value_parts()
-    $icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
+		// Get an array of available icon families styles to pass to self::get_value_parts()
+		$icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
 
-    $value_parts = self::get_value_parts( $value, $icon_families_styles );
+		$value_parts = self::get_value_parts( $value, $icon_families_styles );
 
 		if ( ! empty( $value ) ) {
 			$value_family = $value_parts['family'];
@@ -87,11 +87,11 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			$sanitized_value = '';
 		}
 		
-    $widget_icon_families = $this->get_widget_icon_families();
+		$widget_icon_families = $this->get_widget_icon_families();
 
-    $icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
+		$icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
 
-    $value_parts = self::get_value_parts( $sanitized_value, $icon_families_styles );
+		$value_parts = self::get_value_parts( $sanitized_value, $icon_families_styles );
 
 		if( ! ( isset( $widget_icon_families[$value_parts['family']] ) && isset( $widget_icon_families[$value_parts['family']]['icons'][$value_parts['icon']] ) ) ) {
 			$sanitized_value = isset( $this->default ) ? $this->default : '';
@@ -126,24 +126,24 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 		
 		list( $value_family, $value_icon ) = ( ! empty( $value ) && strpos( $value, '-' ) !== false ) ? explode( '-', $value, 2 ) : array('', '');
 		
-    // Check if icon families have styles
-    // See $this->sanitize_field_input()
-    if ( $icon_families_styles !== null ) {
-      // Loop over all the available styles
-      foreach ( $icon_families_styles as $icon_family => $icon_family_styles ) {
-        foreach ( $icon_family_styles as $icon_family_style => $icon_family_style_name ) {
-          // Check the icon value for matching styles
-          if ( substr( $value_icon, 0, strlen( $icon_family_style ) ) === $icon_family_style ) {
-            // Store the icon name and icon style name
-            $value_icon = substr( $value_icon, strlen( $icon_family_style . '-' ) );
-            $value_style = $icon_family_style;
+		// Check if icon families have styles
+		// See $this->sanitize_field_input()
+		if ( $icon_families_styles !== null ) {
+			// Loop over all the available styles
+			foreach ( $icon_families_styles as $icon_family => $icon_family_styles ) {
+				foreach ( $icon_family_styles as $icon_family_style => $icon_family_style_name ) {
+					// Check the icon value for matching styles
+					if ( substr( $value_icon, 0, strlen( $icon_family_style ) ) === $icon_family_style ) {
+						// Store the icon name and icon style name
+						$value_icon = substr( $value_icon, strlen( $icon_family_style . '-' ) );
+						$value_style = $icon_family_style;
 
-            // Exit both foreach loops
-            break 2;
-          }
-        }
-      }
-    }
+						// Exit both foreach loops
+						break 2;
+					}
+				}
+			}
+		}
 		
 		// Trigger loading of the icon families and their filters. This isn't ideal, but necessary to ensure possible
 		// migrations are available.
@@ -156,21 +156,21 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 		) );
 	}
 
-  public static function get_icon_families_styles( $widget_icon_families ) {
-    // Store an array of icon family styles to pass to self::get_value_parts()
-    $icon_families_styles = [];
+	public static function get_icon_families_styles( $widget_icon_families ) {
+		// Store an array of icon family styles to pass to self::get_value_parts()
+		$icon_families_styles = [];
 
-    // Loop through the icon families
-    foreach ( $widget_icon_families as $key => $val ) {
-      // Check if the family has available styles
-      if ( array_key_exists( 'styles', $val ) ) {
-        // Add the family and styles to the $styles array
-        $icon_families_styles[ $key ] = $val[ 'styles' ];
-      }
-    }
+		// Loop through the icon families
+		foreach ( $widget_icon_families as $key => $val ) {
+			// Check if the family has available styles
+			if ( array_key_exists( 'styles', $val ) ) {
+				// Add the family and styles to the $styles array
+				$icon_families_styles[ $key ] = $val[ 'styles' ];
+			}
+		}
 
-    return $icon_families_styles;
-  }
+		return $icon_families_styles;
+	}
 
 	public function enqueue_scripts(){
 		wp_enqueue_script( 'so-icon-field', plugin_dir_url( __FILE__ ) . 'js/icon-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -16,15 +16,20 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 	protected $icons_callback;
 
 	protected function render_field( $value, $instance ) {
-		$widget_icon_families = $this->get_widget_icon_families();
-		$value_parts = self::get_value_parts( $value );
+    $widget_icon_families = $this->get_widget_icon_families();
+
+    // Get an array of available icon families styles to pass to self::get_value_parts()
+    $icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
+
+    $value_parts = self::get_value_parts( $value, $icon_families_styles );
+
 		if ( ! empty( $value ) ) {
 			$value_family = $value_parts['family'];
 			$value_style = empty( $value_parts['style'] ) ? '' : ( '-' . $value_parts['style'] );
 			$value = $value_parts['family'] . $value_style . '-' . $value_parts['icon'];
 			
 		} else {
-			$value_family = key($widget_icon_families);
+			$value_family = 'fontawesome';
 		}
 		?>
 
@@ -82,8 +87,12 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			$sanitized_value = '';
 		}
 		
-		$value_parts = self::get_value_parts( $sanitized_value );
-		$widget_icon_families = $this->get_widget_icon_families();
+    $widget_icon_families = $this->get_widget_icon_families();
+
+    $icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
+
+    $value_parts = self::get_value_parts( $sanitized_value, $icon_families_styles );
+
 		if( ! ( isset( $widget_icon_families[$value_parts['family']] ) && isset( $widget_icon_families[$value_parts['family']]['icons'][$value_parts['icon']] ) ) ) {
 			$sanitized_value = isset( $this->default ) ? $this->default : '';
 		}
@@ -113,15 +122,28 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 		return $widget_icon_families;
 	}
 	
-	static function get_value_parts( $value ) {
+	static function get_value_parts( $value, $icon_families_styles = null ) {
 		
 		list( $value_family, $value_icon ) = ( ! empty( $value ) && strpos( $value, '-' ) !== false ) ? explode( '-', $value, 2 ) : array('', '');
 		
-		$matched = preg_match( '/(sow\-fa\w?)\-/', $value_icon, $style_matches );
-		if ( ! empty( $matched ) ) {
-			$value_icon = str_replace( $style_matches[0], '', $value_icon );
-			$value_style = $style_matches[1];
-		}
+    // Check if icon families have styles
+    // See $this->sanitize_field_input()
+    if ( $icon_families_styles !== null ) {
+      // Loop over all the available styles
+      foreach ( $icon_families_styles as $icon_family => $icon_family_styles ) {
+        foreach ( $icon_family_styles as $icon_family_style => $icon_family_style_name ) {
+          // Check the icon value for matching styles
+          if ( substr( $value_icon, 0, strlen( $icon_family_style ) ) === $icon_family_style ) {
+            // Store the icon name and icon style name
+            $value_icon = substr( $value_icon, strlen( $icon_family_style . '-' ) );
+            $value_style = $icon_family_style;
+
+            // Exit both foreach loops
+            break 2;
+          }
+        }
+      }
+    }
 		
 		// Trigger loading of the icon families and their filters. This isn't ideal, but necessary to ensure possible
 		// migrations are available.
@@ -133,6 +155,22 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			'icon' => $value_icon,
 		) );
 	}
+
+  public static function get_icon_families_styles( $widget_icon_families ) {
+    // Store an array of icon family styles to pass to self::get_value_parts()
+    $icon_families_styles = [];
+
+    // Loop through the icon families
+    foreach ( $widget_icon_families as $key => $val ) {
+      // Check if the family has available styles
+      if ( array_key_exists( 'styles', $val ) ) {
+        // Add the family and styles to the $styles array
+        $icon_families_styles[ $key ] = $val[ 'styles' ];
+      }
+    }
+
+    return $icon_families_styles;
+  }
 
 	public function enqueue_scripts(){
 		wp_enqueue_script( 'so-icon-field', plugin_dir_url( __FILE__ ) . 'js/icon-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -29,7 +29,7 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 			$value = $value_parts['family'] . $value_style . '-' . $value_parts['icon'];
 			
 		} else {
-			$value_family = 'fontawesome';
+			$value_family = key($widget_icon_families);
 		}
 		?>
 

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -126,19 +126,15 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 		
 		list( $value_family, $value_icon ) = ( ! empty( $value ) && strpos( $value, '-' ) !== false ) ? explode( '-', $value, 2 ) : array('', '');
 		
-		// Check if icon families have styles
-		// See $this->sanitize_field_input()
+		// Check if icon families have styles. See $this->sanitize_field_input()
 		if ( $icon_families_styles !== null ) {
-			// Loop over all the available styles
 			foreach ( $icon_families_styles as $icon_family => $icon_family_styles ) {
 				foreach ( $icon_family_styles as $icon_family_style => $icon_family_style_name ) {
 					// Check the icon value for matching styles
 					if ( substr( $value_icon, 0, strlen( $icon_family_style ) ) === $icon_family_style ) {
-						// Store the icon name and icon style name
 						$value_icon = substr( $value_icon, strlen( $icon_family_style . '-' ) );
 						$value_style = $icon_family_style;
 
-						// Exit both foreach loops
 						break 2;
 					}
 				}
@@ -160,11 +156,8 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 		// Store an array of icon family styles to pass to self::get_value_parts()
 		$icon_families_styles = [];
 
-		// Loop through the icon families
 		foreach ( $widget_icon_families as $key => $val ) {
-			// Check if the family has available styles
 			if ( array_key_exists( 'styles', $val ) ) {
-				// Add the family and styles to the $styles array
 				$icon_families_styles[ $key ] = $val[ 'styles' ];
 			}
 		}


### PR DESCRIPTION
While trying to create [this plugin](https://github.com/ridgekuhn/so-widgets-icon-fap) which adds Font Awesome Pro support, I ran into the issue described here: https://siteorigin.com/thread/getting-a-custom-icon-to-save-in-icon-widget/

The `siteorigin_widgets_icon_families` filter hook is flexible enough to let you add an array of styles to `$icon_families['my_icons']['styles']`, and will create the dropdown menu in the widget for you, etc; but when `SiteOrigin_Widget_Field_Icon::get_value_parts()` tries to get the value parts to save or render the widget, it's hard-coded to look for a style key beginning with `sow-fa*`, instead of the style keys that were stored in `$icon_families['my_icons']['styles']` in the filter hook. 

This pull request adds a `SiteOrigin_Widget_Field_Icon::get_icon_families_styles()` method which gets any $icon_families['my_icons']['styles'] set in the `siteorigin_widgets_icon_families` filter hook, and rewrites `SiteOrigin_Widget_Field_Icon::get_value_parts()` to take advantage of it. 

***

The [Icons and Fonts](https://siteorigin.com/docs/widgets-bundle/form-building/icons-and-fonts/) documentation could be updated to something like this:

Filtering icons

To filter the icon families, you use the 'siteorigin_widgets_icon_families' filter. An icon family is then added by including an associative array with the following properties:

* name: string The name of the icon family to be displayed when selecting an icon family.
* style_uri string The path of a CSS stylesheet to be enqueued when the icon family is to be displayed. This typically contains the @font-face declaration.
* icons: array An associative array containing string values, where the key is the name of the icon to be used and the value is it's unicode value.
* styles: array Optional. An associative array containing string values, where the key is the class name of the icon style set, and the value is its human-readable name. 

```
function my_icon_families_filter( $icon_families ) {
    $icon_families['radicons'] = array(
        'name' => __( 'My Rad Icons', 'example-text-domain' ),
        'style_uri' => plugin_dir_url( __FILE__ ) . '/icons/style.css',
        'icons' => array(
            'my-rad-search-icon' => '&#xf101;',
            'my-rad-close-icon' => '&#xf101;'
            // Etc.
        ),
        // Optional
        'styles' => array(
            'radicons-solid' => __( 'My Rad Icons - Solid', 'example-text-domain' ),
            'radicons-light' => __( 'My Rad Icons - Light', 'example-text-domain' ),
        ),
        'icons' => array (
            'my-rad-search-icon' => array( 
                'unicode' => '&#xf101;', 
                'styles' => array( 'radicons-solid' ), 
             ),
            'my-rad-close-icon' => array( 
                'unicode' => '&#xf101;', 
                'styles' => array( 'radicons-solid', 'radicons-light' ), 
             ),
             'my-rad-other-icon' => array( 
                'unicode' => '&#xf101;', 
                'styles' => array( 'radicons-light' ), 
             ),
        )
    );
    return $icon_families;
}
add_filter( 'siteorigin_widgets_icon_families', 'my_icon_families_filter' );
```