### PR TITLE
#885 Make description translations more reliable.

### DIFF
--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 			'sow-accordion',
 			__( 'SiteOrigin Accordion', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'An accordion widget.', 'so-widgets-bundle' ),
+				'description' => __( 'An accordion to squeeze a lot of content into a small space.', 'so-widgets-bundle' ),
 				'help' => 'https://siteorigin.com/widgets-bundle/accordion-widget/',
 			),
 			array(),

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'sow-button',
 			__('SiteOrigin Button', 'so-widgets-bundle'),
 			array(
-				'description' => __('A customizable button widget.', 'so-widgets-bundle'),
+				'description' => __('A powerful yet simple button widget for your sidebars or Page Builder pages.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/button-widget-documentation/'
 			),
 			array(

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'sow-contact-form',
 			__( 'SiteOrigin Contact Form', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'Create a simple contact form for your users to get hold of you.', 'so-widgets-bundle' ),
+				'description' => __( 'A light weight contact form builder.', 'so-widgets-bundle' ),
 			),
 			array(),
 			false,

--- a/widgets/cta/cta.php
+++ b/widgets/cta/cta.php
@@ -15,7 +15,7 @@ class SiteOrigin_Widget_Cta_Widget extends SiteOrigin_Widget {
 			'sow-cta',
 			__('SiteOrigin Call-to-action', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple call-to-action widget with massive power.', 'so-widgets-bundle'),
+				'description' => __('A simple call-to-action widget. You can do what ever you want with a call-to-action widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/call-action-widget/'
 			),
 			array(

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			'sow-editor',
 			__('SiteOrigin Editor', 'so-widgets-bundle'),
 			array(
-				'description' => __('A rich-text, text editor.', 'so-widgets-bundle'),
+				'description' => __('A widget which allows editing of content using the TinyMCE editor.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/editor-widget/'
 			),
 			array(),

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -115,7 +115,9 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 
 	private function process_more_quicktag( $content ) {
 		$post = get_post();
-		$panels_content = get_post_meta( $post->ID, 'panels_data', true );
+		if(!is_null($post)){
+			$panels_content = get_post_meta( $post->ID, 'panels_data', true );
+		}
 		// We only want to do this processing if on archive pages for posts with non-PB layouts.
 		if ( ! is_singular() && empty( $panels_content ) && ! $this->is_block_editor_page() && empty( $GLOBALS['SO_WIDGETS_BUNDLE_PREVIEW_RENDER'] ) ) {
 			if ( preg_match( '/<!--more(.*?)?-->/', $content, $matches ) ) {

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 			'sow-features',
 			__( 'SiteOrigin Features', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'Displays a list of features.', 'so-widgets-bundle' ),
+				'description' => __( 'Displays a block of features with icons.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/features-widget-documentation/'
 			),
 			array(),

--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 			'sow-google-map',
 			__( 'SiteOrigin Google Maps', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A Google Maps widget.', 'so-widgets-bundle' ),
+				'description' => __( 'A highly customisable Google Maps widget. Help your site find its place and give it some direction.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/google-maps-widget/'
 			),
 			array(),

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			'sow-headline',
 			__( 'SiteOrigin Headline', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A headline widget.', 'so-widgets-bundle' )
+				'description' => __( 'A headline to headline all headlines.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/icon/icon.php
+++ b/widgets/icon/icon.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Icon_Widget extends SiteOrigin_Widget {
 			'sow-icon',
 			__( 'SiteOrigin Icon', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'An icon widget.', 'so-widgets-bundle' )
+				'description' => __( 'An iconic icon.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -20,7 +20,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			'sow-image-grid',
 			__('SiteOrigin Image Grid', 'so-widgets-bundle'),
 			array(
-				'description' => __('Display a grid of images.', 'so-widgets-bundle'),
+				'description' => __('Display a grid of images. Also useful for displaying client logos.', 'so-widgets-bundle'),
 			),
 			array(),
 			false,

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			'sow-image',
 			__('SiteOrigin Image', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple image widget with massive power.', 'so-widgets-bundle'),
+				'description' => __('A very simple image widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/image-widget-documentation/'
 			),
 			array(

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -49,7 +49,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget {
 			'sow-post-carousel',
 			__('SiteOrigin Post Carousel', 'so-widgets-bundle'),
 			array(
-				'description' => __('Display your posts as a carousel.', 'so-widgets-bundle'),
+				'description' => __('Gives you a widget to display your posts as a carousel.', 'so-widgets-bundle'),
 				'instance_storage' => true,
 				'help' => 'https://siteorigin.com/widgets-bundle/post-carousel-widget/'
 			),

--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 			'sow-price-table',
 			__( 'SiteOrigin Price Table', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A simple Price Table.', 'so-widgets-bundle' ),
+				'description' => __( 'A powerful yet simple price table widget for your sidebars or Page Builder pages.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/price-table-widget/'
 			),
 			array(),

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 			'sow-simple-masonry',
 			__('SiteOrigin Simple Masonry', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple masonry layout widget.', 'so-widgets-bundle'),
+				'description' => __('A masonry layout for images. Images can link to your posts.', 'so-widgets-bundle'),
 //				'help' => 'https://siteorigin.com/widgets-bundle/simple-masonry-widget-documentation/'
 			),
 			array(),

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -15,7 +15,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 			'sow-slider',
 			__('SiteOrigin Slider', 'so-widgets-bundle'),
 			array(
-				'description' => __('A responsive slider widget that supports images and video.', 'so-widgets-bundle'),
+				'description' => __('A very simple slider widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/slider-widget-documentation/',
 				'panels_title' => false,
 			),

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -18,7 +18,7 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 			'sow-social-media-buttons',
 			__( 'SiteOrigin Social Media Buttons', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A social media buttons widget.', 'so-widgets-bundle' )
+				'description' => __( 'Customizable buttons which link to all your social media profiles.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/tabs/tabs.php
+++ b/widgets/tabs/tabs.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Tabs_Widget extends SiteOrigin_Widget {
 			'sow-tabs',
 			__( 'SiteOrigin Tabs', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A tabs widget.', 'so-widgets-bundle' ),
+				'description' => __( 'A tabby widget to switch between tabbed content panels.', 'so-widgets-bundle' ),
 				'help' => 'https://siteorigin.com/widgets-bundle/tabs-widget/',
 			),
 			array(),

--- a/widgets/taxonomy/taxonomy.php
+++ b/widgets/taxonomy/taxonomy.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Taxonomy_Widget extends SiteOrigin_Widget {
 			'sow-taxonomy',
 			__( 'SiteOrigin Taxonomy', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A taxonomy widget.', 'so-widgets-bundle' )
+				'description' => __( 'Displays the selected taxonomy for the current post.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			'sow-testimonials',
 			__('SiteOrigin Testimonials', 'so-widgets-bundle'),
 			array(
-				'description' => __('Share your product/service testimonials in a variety of different ways.', 'so-widgets-bundle'),
+				'description' => __('Display some testimonials.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/testimonial-widget-documentation/'
 			),
 			array(

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -17,7 +17,7 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'sow-video',
 			__( 'SiteOrigin Video Player', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A video player widget.', 'so-widgets-bundle' ),
+				'description' => __( 'Play all your self or externally hosted videos in a customizable video player.', 'so-widgets-bundle' ),
 				'help'        => 'http://siteorigin.com/widgets-bundle/video-widget-documentation/'
 			),
 			array(),


### PR DESCRIPTION
This issue is based on the fact that the widgets are given descriptions in two places:

1. In the PHP comment that comprises the Widget file header.
2. In the Widget constructor where the description is set manually in an array passed as the 3rd parameter to the parent constructor.

The POT file in the latest distribution includes both of these description settings. However, any translation will only be applied to number 1 in the list above. The problem is that there are obvious Widget headers in the POT file that come from number 2 in the list above that are different from the headers that come from number 1. Any translations associated with these number 2 descriptions will never be displayed because the $widget object passed into the admin.php file will always use the description set in number 1.

Therefore, the basic problem of the number 1 descriptions showing up in the POT file was already solved. The secondary problem of translations not showing up was being caused by translations being associated with the unused number 2 descriptions. The solution is to make number 1 and number 2 headers identical for all Widget files to eliminate the confusing extra entries in the POT file. #885