### PR TITLE
#885: Improved reliability of widget description translations.

### DIFF
--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 			'sow-accordion',
 			__( 'SiteOrigin Accordion', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'An accordion widget.', 'so-widgets-bundle' ),
+				'description' => __( 'An accordion to squeeze a lot of content into a small space.', 'so-widgets-bundle' ),
 				'help' => 'https://siteorigin.com/widgets-bundle/accordion-widget/',
 			),
 			array(),

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'sow-button',
 			__('SiteOrigin Button', 'so-widgets-bundle'),
 			array(
-				'description' => __('A customizable button widget.', 'so-widgets-bundle'),
+				'description' => __('A powerful yet simple button widget for your sidebars or Page Builder pages.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/button-widget-documentation/'
 			),
 			array(

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -2,7 +2,7 @@
 
 /*
 Widget Name: Contact Form
-Description: A light weight contact form builder.
+Description: A lightweight contact form builder.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/contact-form-widget/
@@ -16,7 +16,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'sow-contact-form',
 			__( 'SiteOrigin Contact Form', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A light weight contact form builder.', 'so-widgets-bundle' ),
+				'description' => __( 'A lightweight contact form builder.', 'so-widgets-bundle' ),
 			),
 			array(),
 			false,

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'sow-contact-form',
 			__( 'SiteOrigin Contact Form', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'Create a simple contact form for your users to get hold of you.', 'so-widgets-bundle' ),
+				'description' => __( 'A light weight contact form builder.', 'so-widgets-bundle' ),
 			),
 			array(),
 			false,

--- a/widgets/cta/cta.php
+++ b/widgets/cta/cta.php
@@ -15,7 +15,7 @@ class SiteOrigin_Widget_Cta_Widget extends SiteOrigin_Widget {
 			'sow-cta',
 			__('SiteOrigin Call-to-action', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple call-to-action widget with massive power.', 'so-widgets-bundle'),
+				'description' => __('A simple call-to-action widget. You can do what ever you want with a call-to-action widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/call-action-widget/'
 			),
 			array(

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			'sow-editor',
 			__('SiteOrigin Editor', 'so-widgets-bundle'),
 			array(
-				'description' => __('A rich-text, text editor.', 'so-widgets-bundle'),
+				'description' => __('A widget which allows editing of content using the TinyMCE editor.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/editor-widget/'
 			),
 			array(),

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 			'sow-features',
 			__( 'SiteOrigin Features', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'Displays a list of features.', 'so-widgets-bundle' ),
+				'description' => __( 'Displays a block of features with icons.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/features-widget-documentation/'
 			),
 			array(),

--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 			'sow-google-map',
 			__( 'SiteOrigin Google Maps', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A Google Maps widget.', 'so-widgets-bundle' ),
+				'description' => __( 'A highly customisable Google Maps widget. Help your site find its place and give it some direction.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/google-maps-widget/'
 			),
 			array(),

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			'sow-headline',
 			__( 'SiteOrigin Headline', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A headline widget.', 'so-widgets-bundle' )
+				'description' => __( 'A headline to headline all headlines.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/icon/icon.php
+++ b/widgets/icon/icon.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Icon_Widget extends SiteOrigin_Widget {
 			'sow-icon',
 			__( 'SiteOrigin Icon', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'An icon widget.', 'so-widgets-bundle' )
+				'description' => __( 'An iconic icon.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -20,7 +20,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			'sow-image-grid',
 			__('SiteOrigin Image Grid', 'so-widgets-bundle'),
 			array(
-				'description' => __('Display a grid of images.', 'so-widgets-bundle'),
+				'description' => __('Display a grid of images. Also useful for displaying client logos.', 'so-widgets-bundle'),
 			),
 			array(),
 			false,

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			'sow-image',
 			__('SiteOrigin Image', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple image widget with massive power.', 'so-widgets-bundle'),
+				'description' => __('A very simple image widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/image-widget-documentation/'
 			),
 			array(

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Image
-Description: A very simple image widget.
+Description: A simple image widget with massive power.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/image-widget-documentation/
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			'sow-image',
 			__('SiteOrigin Image', 'so-widgets-bundle'),
 			array(
-				'description' => __('A very simple image widget.', 'so-widgets-bundle'),
+				'description' => __('A simple image widget with massive power.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/image-widget-documentation/'
 			),
 			array(

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -49,7 +49,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget {
 			'sow-post-carousel',
 			__('SiteOrigin Post Carousel', 'so-widgets-bundle'),
 			array(
-				'description' => __('Display your posts as a carousel.', 'so-widgets-bundle'),
+				'description' => __('Gives you a widget to display your posts as a carousel.', 'so-widgets-bundle'),
 				'instance_storage' => true,
 				'help' => 'https://siteorigin.com/widgets-bundle/post-carousel-widget/'
 			),

--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 			'sow-price-table',
 			__( 'SiteOrigin Price Table', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A simple Price Table.', 'so-widgets-bundle' ),
+				'description' => __( 'A powerful yet simple price table widget for your sidebars or Page Builder pages.', 'so-widgets-bundle' ),
 				'help'        => 'https://siteorigin.com/widgets-bundle/price-table-widget/'
 			),
 			array(),

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 			'sow-simple-masonry',
 			__('SiteOrigin Simple Masonry', 'so-widgets-bundle'),
 			array(
-				'description' => __('A simple masonry layout widget.', 'so-widgets-bundle'),
+				'description' => __('A masonry layout for images. Images can link to your posts.', 'so-widgets-bundle'),
 //				'help' => 'https://siteorigin.com/widgets-bundle/simple-masonry-widget-documentation/'
 			),
 			array(),

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -15,7 +15,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 			'sow-slider',
 			__('SiteOrigin Slider', 'so-widgets-bundle'),
 			array(
-				'description' => __('A responsive slider widget that supports images and video.', 'so-widgets-bundle'),
+				'description' => __('A very simple slider widget.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/slider-widget-documentation/',
 				'panels_title' => false,
 			),

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Image Slider
-Description: A very simple slider widget.
+Description: A responsive slider widget that supports images and video.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/slider-widget-documentation/
@@ -15,7 +15,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 			'sow-slider',
 			__('SiteOrigin Slider', 'so-widgets-bundle'),
 			array(
-				'description' => __('A very simple slider widget.', 'so-widgets-bundle'),
+				'description' => __('A responsive slider widget that supports images and video.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/slider-widget-documentation/',
 				'panels_title' => false,
 			),

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -18,7 +18,7 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 			'sow-social-media-buttons',
 			__( 'SiteOrigin Social Media Buttons', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A social media buttons widget.', 'so-widgets-bundle' )
+				'description' => __( 'Customizable buttons which link to all your social media profiles.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/tabs/tabs.php
+++ b/widgets/tabs/tabs.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Tabs_Widget extends SiteOrigin_Widget {
 			'sow-tabs',
 			__( 'SiteOrigin Tabs', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A tabs widget.', 'so-widgets-bundle' ),
+				'description' => __( 'A tabby widget to switch between tabbed content panels.', 'so-widgets-bundle' ),
 				'help' => 'https://siteorigin.com/widgets-bundle/tabs-widget/',
 			),
 			array(),

--- a/widgets/taxonomy/taxonomy.php
+++ b/widgets/taxonomy/taxonomy.php
@@ -16,7 +16,7 @@ class SiteOrigin_Widget_Taxonomy_Widget extends SiteOrigin_Widget {
 			'sow-taxonomy',
 			__( 'SiteOrigin Taxonomy', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A taxonomy widget.', 'so-widgets-bundle' )
+				'description' => __( 'Displays the selected taxonomy for the current post.', 'so-widgets-bundle' )
 			),
 			array(),
 			false,

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Testimonials
-Description: Display some testimonials.
+Description: Share your product or service testimonials in a variety of different ways.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/testimonials-widget/
@@ -14,7 +14,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			'sow-testimonials',
 			__('SiteOrigin Testimonials', 'so-widgets-bundle'),
 			array(
-				'description' => __('Display some testimonials.', 'so-widgets-bundle'),
+				'description' => __('Share your product or service testimonials in a variety of different ways.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/testimonial-widget-documentation/'
 			),
 			array(

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			'sow-testimonials',
 			__('SiteOrigin Testimonials', 'so-widgets-bundle'),
 			array(
-				'description' => __('Share your product/service testimonials in a variety of different ways.', 'so-widgets-bundle'),
+				'description' => __('Display some testimonials.', 'so-widgets-bundle'),
 				'help' => 'https://siteorigin.com/widgets-bundle/testimonial-widget-documentation/'
 			),
 			array(

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -17,7 +17,7 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'sow-video',
 			__( 'SiteOrigin Video Player', 'so-widgets-bundle' ),
 			array(
-				'description' => __( 'A video player widget.', 'so-widgets-bundle' ),
+				'description' => __( 'Play all your self or externally hosted videos in a customizable video player.', 'so-widgets-bundle' ),
 				'help'        => 'http://siteorigin.com/widgets-bundle/video-widget-documentation/'
 			),
 			array(),


### PR DESCRIPTION
Unlike what was described in #885, I was able to find all of the Widget descriptions in the POT file. The problem was that most widgets had two descriptions:

1. The PHP comment description, which is used to describe widget in the Page Builder editor.
2. The description in the post options array in the constructor that is sent to the parent constructor, which is used to describe widgets in the Wordpress Appearance/Widgets screen.

I was surprised to see that the POT file generator picks up the PHP comment description, and I have confirmed that the translations all work perfectly on that value.

The problem that I encountered when trying to test this issue was that the number 1 and number 2 descriptions from the list above were usually different. I would create a translation for what looked like the button widget and it wouldn't appear when administering SO widgets.

I've therefore made the widget descriptions uniform for each widget and they appear correctly in both views when translated. Unfortunately, both descriptions are required to service the two different views.