### PR TITLE
#994: Fixed PHP Notice on Editor Widget previews.

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -115,7 +115,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 
 	private function process_more_quicktag( $content ) {
 		$post = get_post();
-		if ( ! empty($post) ) {
+		if ( ! empty( $post ) ) {
 			$panels_content = get_post_meta( $post->ID, 'panels_data', true );
 		}
 		// We only want to do this processing if on archive pages for posts with non-PB layouts.

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -115,7 +115,9 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 
 	private function process_more_quicktag( $content ) {
 		$post = get_post();
-		$panels_content = get_post_meta( $post->ID, 'panels_data', true );
+		if(!is_null($post)){
+			$panels_content = get_post_meta( $post->ID, 'panels_data', true );
+		}
 		// We only want to do this processing if on archive pages for posts with non-PB layouts.
 		if ( ! is_singular() && empty( $panels_content ) && ! $this->is_block_editor_page() && empty( $GLOBALS['SO_WIDGETS_BUNDLE_PREVIEW_RENDER'] ) ) {
 			if ( preg_match( '/<!--more(.*?)?-->/', $content, $matches ) ) {

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -115,7 +115,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 
 	private function process_more_quicktag( $content ) {
 		$post = get_post();
-		if(!is_null($post)){
+		if ( ! empty($post) ) {
 			$panels_content = get_post_meta( $post->ID, 'panels_data', true );
 		}
 		// We only want to do this processing if on archive pages for posts with non-PB layouts.


### PR DESCRIPTION
The PHP Notice message in #994 is coming from the situation where the get_post() function returns a null value. This happens under two conditions:

1. The post is previewed before it has been saved for the first time, immediately after creation.
2. Every time the TinyMCE editor's preview function is used.

To resolve this I have simple wrapped the return of the get_post() function in a null check.

The $post->ID is still used later on in the code and may give a similar message. However, since this only applies to Classic Editor pages, that have "more" link functionality, I suspect that all pages hitting that code would already be saved and that the error will therefore not occur. I have, at least, not been able to reproduce the error with widgets in the Classic Editor. Since it only shows up with WP_DEBUG on, it wouldn't be a show-stopping error anyway.