### PR TITLE
#924: Change item label to image title if item

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -733,23 +733,21 @@ var sowbForms = window.sowbForms || {};
 				var $parentRepeater = $el.closest('.siteorigin-widget-field-repeater');
 				var itemTop = $el.find('> .siteorigin-widget-field-repeater-item-top');
 				var itemLabel = $parentRepeater.data('item-label');
-				if (itemLabel && itemLabel.selector) {
+				if ( itemLabel && ( itemLabel.hasOwnProperty( 'selector' ) || itemLabel.hasOwnProperty( 'selectorArray' ) ) ) {
 					var updateLabel = function () {
-						var functionName;
-						var txt;
-						if ( itemLabel.hasOwnProperty('selectorArray') ) {
-							var selectorRow;
+						var functionName, txt, selectorRow;
+						if ( itemLabel.hasOwnProperty( 'selectorArray' ) ) {
 							for ( var i = 0 ; i < itemLabel.selectorArray.length ; i++ ) {
-								selectorRow = itemLabel.selectorArray[i];
-								functionName = ( selectorRow.hasOwnProperty('valueMethod') && selectorRow.valueMethod ) ? selectorRow.valueMethod : 'val';
-								txt = $el.find(selectorRow.selector)[functionName]();
+								selectorRow = itemLabel.selectorArray[ i ];
+								functionName = ( selectorRow.hasOwnProperty( 'valueMethod' ) && selectorRow.valueMethod ) ? selectorRow.valueMethod : 'val';
+								txt = $el.find( selectorRow.selector )[ functionName ]();
 								if ( txt ) {
 									break;
 								}
 							}
 						} else {
-							functionName = ( itemLabel.hasOwnProperty('valueMethod') && itemLabel.valueMethod ) ? itemLabel.valueMethod : 'val';
-							txt = $el.find(itemLabel.selector)[functionName]();
+							functionName = ( itemLabel.hasOwnProperty( 'valueMethod' ) && itemLabel.valueMethod ) ? itemLabel.valueMethod : 'val';
+							txt = $el.find( itemLabel.selector )[ functionName ]();
 						}
 						if (txt) {
 							if (txt.length > 80) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -735,8 +735,22 @@ var sowbForms = window.sowbForms || {};
 				var itemLabel = $parentRepeater.data('item-label');
 				if (itemLabel && itemLabel.selector) {
 					var updateLabel = function () {
-						var functionName = ( itemLabel.hasOwnProperty('valueMethod') && itemLabel.valueMethod ) ? itemLabel.valueMethod : 'val';
-						var txt = $el.find(itemLabel.selector)[functionName]();
+						var functionName;
+						var txt;
+						if ( itemLabel.hasOwnProperty('selectorArray') ) {
+							var selectorRow;
+							for ( var i = 0 ; i < itemLabel.selectorArray.length ; i++ ) {
+								selectorRow = itemLabel.selectorArray[i];
+								functionName = ( selectorRow.hasOwnProperty('valueMethod') && selectorRow.valueMethod ) ? selectorRow.valueMethod : 'val';
+								txt = $el.find(selectorRow.selector)[functionName]();
+								if ( txt ) {
+									break;
+								}
+							}
+						} else {
+							functionName = ( itemLabel.hasOwnProperty('valueMethod') && itemLabel.valueMethod ) ? itemLabel.valueMethod : 'val';
+							txt = $el.find(itemLabel.selector)[functionName]();
+						}
 						if (txt) {
 							if (txt.length > 80) {
 								txt = txt.substr(0, 79) + '...';

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -47,7 +47,16 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 				'type' => 'repeater',
 				'label' => __( 'Images', 'so-widgets-bundle' ),
 				'item_label' => array(
-					'selector'     => "[id*='title']"
+					'selectorArray' => array(
+						array(
+							'selector' => "[id*='title']",
+							'valueMethod' => 'val',
+						),
+						array(
+							'selector' => '.media-field-wrapper .current .title',
+							'valueMethod' => 'html'
+						),
+					),
 				),
 				'fields' => array(
 					'image' => array(


### PR DESCRIPTION
Implemented fallback system for masonry form item labels where the Wordpress media tag will be used as the item label when the form's title field is not populated.