### PR TITLE
Update jquery.touchSwipe.js (SO Post Carousel)

### DIFF
--- a/js/jquery.touchSwipe.js
+++ b/js/jquery.touchSwipe.js
@@ -1,12 +1,12 @@
-/*
+/*!
  * @fileOverview TouchSwipe - jQuery Plugin
- * @version 1.6.6
+ * @version 1.6.18
  *
  * @author Matt Bryson http://www.github.com/mattbryson
  * @see https://github.com/mattbryson/TouchSwipe-Jquery-Plugin
  * @see http://labs.rampinteractive.co.uk/touchSwipe/
  * @see http://plugins.jquery.com/project/touchSwipe
- *
+ * @license
  * Copyright (c) 2010-2015 Matt Bryson
  * Dual licensed under the MIT or GPL Version 2 licenses.
  *
@@ -55,13 +55,13 @@
  * 			- Added "all" fingers value to the fingers property, so any combination of fingers triggers the swipe, allowing event handlers to check the finger count
  *
  * $Date: 2012-09-08 (Thurs, 9 Aug 2012) $
- * $version: 1.3.3	- Code tidy prep for minefied version
+ * $version: 1.3.3	- Code tidy prep for min version
  *
  * $Date: 2012-04-10 (wed, 4 Oct 2012) $
  * $version: 1.4.0	- Added pinch support, pinchIn and pinchOut
  *
  * $Date: 2012-11-10 (Thurs, 11 Oct 2012) $
- * $version: 1.5.0	- Added excludedElements, a jquery selector that specifies child elements that do NOT trigger swipes. By default, this is one select that removes all form, input select, button and anchor elements.
+ * $version: 1.5.0	- Added excludedElements, a jquery selector that specifies child elements that do NOT trigger swipes. By default, this is .noSwipe
  *
  * $Date: 2012-22-10 (Mon, 22 Oct 2012) $
  * $version: 1.5.1	- Fixed bug with jQuery 1.8 and trailing comma in excludedElements
@@ -101,8 +101,36 @@
  * $version 1.6.7    - Added patch from https://github.com/mattbryson/TouchSwipe-Jquery-Plugin/issues/206 to fix memory leak
  *
  * $Date: 2015-2-2 (Mon, 2 Feb 2015) $
- * $version 1.6.7    - Added preventDefaultEvents option to proxy events regardless.
+ * $version 1.6.8    - Added preventDefaultEvents option to proxy events regardless.
  *					- Fixed issue with swipe and pinch not triggering at the same time
+ *
+ * $Date: 2015-9-6 (Tues, 9 June 2015) $
+ * $version 1.6.9    - Added PR from jdalton/hybrid to fix pointer events
+ *					- Added scrolling demo
+ *					- Added version property to plugin
+ *
+ * $Date: 2015-1-10 (Wed, 1 October 2015) $
+ * $version 1.6.10    - Added PR from beatspace to fix tap events
+ * $version 1.6.11    - Added PRs from indri-indri ( Doc tidyup), kkirsche ( Bower tidy up ), UziTech (preventDefaultEvents fixes )
+ *					 - Allowed setting multiple options via .swipe("options", options_hash) and more simply .swipe(options_hash) or exisitng instances
+ * $version 1.6.12    - Fixed bug with multi finger releases above 2 not triggering events
+ *
+ * $Date: 2015-12-18 (Fri, 18 December 2015) $
+ * $version 1.6.13    - Added PRs
+ *                    - Fixed #267 allowPageScroll not working correctly
+ * $version 1.6.14    - Fixed #220 / #248 doubletap not firing with swipes, #223 commonJS compatible
+ * $version 1.6.15    - More bug fixes
+ *
+ * $Date: 2016-04-29 (Fri, 29 April 2016) $
+ * $version 1.6.16    - Swipes with 0 distance now allow default events to trigger.  So tapping any form elements or A tags will allow default interaction, but swiping will trigger a swipe.
+ *                       Removed the a, input, select etc from the excluded Children list as the 0 distance tap solves that issue.
+ * $Date: 2016-05-19  (Fri, 29 April 2016) $
+ * $version 1.6.17     - Fixed context issue when calling instance methods via $("selector").swipe("method");
+ * $version 1.6.18     - now honors fallbackToMouseEvents=false for MS Pointer events when a Mouse is used.
+ * 
+ * $Date: 2018-09-17  (Mon, 17 September 2018) $
+ * $version 1.6.19     - replaced jQuery bind with on, replaced deprecated `navigator.pointerEvents` with `window.PointerEvents`
+
  */
 
 /**
@@ -123,1935 +151,1962 @@
  */
 
 
+(function(factory) {
+  if (typeof define === 'function' && define.amd && define.amd.jQuery) {
+    // AMD. Register as anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module !== 'undefined' && module.exports) {
+    // CommonJS Module
+    factory(require("jquery"));
+  } else {
+    // Browser globals.
+    factory(jQuery);
+  }
+}(function($) {
+  "use strict";
 
-(function (factory) {
-    if (typeof define === 'function' && define.amd && define.amd.jQuery) {
-        // AMD. Register as anonymous module.
-        define(['jquery.touchSwipe.js'], factory);
-    } else {
-        // Browser globals.
-        factory(jQuery);
+  //Constants
+  var VERSION = "1.6.18",
+    LEFT = "left",
+    RIGHT = "right",
+    UP = "up",
+    DOWN = "down",
+    IN = "in",
+    OUT = "out",
+
+    NONE = "none",
+    AUTO = "auto",
+
+    SWIPE = "swipe",
+    PINCH = "pinch",
+    TAP = "tap",
+    DOUBLE_TAP = "doubletap",
+    LONG_TAP = "longtap",
+    HOLD = "hold",
+
+    HORIZONTAL = "horizontal",
+    VERTICAL = "vertical",
+
+    ALL_FINGERS = "all",
+
+    DOUBLE_TAP_THRESHOLD = 10,
+
+    PHASE_START = "start",
+    PHASE_MOVE = "move",
+    PHASE_END = "end",
+    PHASE_CANCEL = "cancel",
+
+    SUPPORTS_TOUCH = 'ontouchstart' in window,
+
+    SUPPORTS_POINTER_IE10 = window.navigator.msPointerEnabled && !window.PointerEvent && !SUPPORTS_TOUCH,
+
+    SUPPORTS_POINTER = (window.PointerEvent || window.navigator.msPointerEnabled) && !SUPPORTS_TOUCH,
+
+    PLUGIN_NS = 'TouchSwipe';
+
+
+
+  /**
+  * The default configuration, and available options to configure touch swipe with.
+  * You can set the default values by updating any of the properties prior to instantiation.
+  * @name $.fn.swipe.defaults
+  * @namespace
+  * @property {int} [fingers=1] The number of fingers to detect in a swipe. Any swipes that do not meet this requirement will NOT trigger swipe handlers.
+  * @property {int} [threshold=75] The number of pixels that the user must move their finger by before it is considered a swipe.
+  * @property {int} [cancelThreshold=null] The number of pixels that the user must move their finger back from the original swipe direction to cancel the gesture.
+  * @property {int} [pinchThreshold=20] The number of pixels that the user must pinch their finger by before it is considered a pinch.
+  * @property {int} [maxTimeThreshold=null] Time, in milliseconds, between touchStart and touchEnd must NOT exceed in order to be considered a swipe.
+  * @property {int} [fingerReleaseThreshold=250] Time in milliseconds between releasing multiple fingers.  If 2 fingers are down, and are released one after the other, if they are within this threshold, it counts as a simultaneous release.
+  * @property {int} [longTapThreshold=500] Time in milliseconds between tap and release for a long tap
+  * @property {int} [doubleTapThreshold=200] Time in milliseconds between 2 taps to count as a double tap
+  * @property {function} [swipe=null] A handler to catch all swipes. See {@link $.fn.swipe#event:swipe}
+  * @property {function} [swipeLeft=null] A handler that is triggered for "left" swipes. See {@link $.fn.swipe#event:swipeLeft}
+  * @property {function} [swipeRight=null] A handler that is triggered for "right" swipes. See {@link $.fn.swipe#event:swipeRight}
+  * @property {function} [swipeUp=null] A handler that is triggered for "up" swipes. See {@link $.fn.swipe#event:swipeUp}
+  * @property {function} [swipeDown=null] A handler that is triggered for "down" swipes. See {@link $.fn.swipe#event:swipeDown}
+  * @property {function} [swipeStatus=null] A handler triggered for every phase of the swipe. See {@link $.fn.swipe#event:swipeStatus}
+  * @property {function} [pinchIn=null] A handler triggered for pinch in events. See {@link $.fn.swipe#event:pinchIn}
+  * @property {function} [pinchOut=null] A handler triggered for pinch out events. See {@link $.fn.swipe#event:pinchOut}
+  * @property {function} [pinchStatus=null] A handler triggered for every phase of a pinch. See {@link $.fn.swipe#event:pinchStatus}
+  * @property {function} [tap=null] A handler triggered when a user just taps on the item, rather than swipes it. If they do not move, tap is triggered, if they do move, it is not.
+  * @property {function} [doubleTap=null] A handler triggered when a user double taps on the item. The delay between taps can be set with the doubleTapThreshold property. See {@link $.fn.swipe.defaults#doubleTapThreshold}
+  * @property {function} [longTap=null] A handler triggered when a user long taps on the item. The delay between start and end can be set with the longTapThreshold property. See {@link $.fn.swipe.defaults#longTapThreshold}
+  * @property (function) [hold=null] A handler triggered when a user reaches longTapThreshold on the item. See {@link $.fn.swipe.defaults#longTapThreshold}
+  * @property {boolean} [triggerOnTouchEnd=true] If true, the swipe events are triggered when the touch end event is received (user releases finger).  If false, it will be triggered on reaching the threshold, and then cancel the touch event automatically.
+  * @property {boolean} [triggerOnTouchLeave=false] If true, then when the user leaves the swipe object, the swipe will end and trigger appropriate handlers.
+  * @property {string|undefined} [allowPageScroll='auto'] How the browser handles page scrolls when the user is swiping on a touchSwipe object. See {@link $.fn.swipe.pageScroll}.  <br/><br/>
+                    <code>"auto"</code> : all undefined swipes will cause the page to scroll in that direction. <br/>
+                    <code>"none"</code> : the page will not scroll when user swipes. <br/>
+                    <code>"horizontal"</code> : will force page to scroll on horizontal swipes. <br/>
+                    <code>"vertical"</code> : will force page to scroll on vertical swipes. <br/>
+  * @property {boolean} [fallbackToMouseEvents=true] If true mouse events are used when run on a non touch device, false will stop swipes being triggered by mouse events on non touch devices.
+  * @property {string} [excludedElements=".noSwipe"] A jquery selector that specifies child elements that do NOT trigger swipes. By default this excludes elements with the class .noSwipe .
+  * @property {boolean} [preventDefaultEvents=true] by default default events are cancelled, so the page doesn't move.  You can disable this so both native events fire as well as your handlers.
+
+  */
+  var defaults = {
+    fingers: 1,
+    threshold: 75,
+    cancelThreshold: null,
+    pinchThreshold: 20,
+    maxTimeThreshold: null,
+    fingerReleaseThreshold: 250,
+    longTapThreshold: 500,
+    doubleTapThreshold: 200,
+    swipe: null,
+    swipeLeft: null,
+    swipeRight: null,
+    swipeUp: null,
+    swipeDown: null,
+    swipeStatus: null,
+    pinchIn: null,
+    pinchOut: null,
+    pinchStatus: null,
+    click: null, //Deprecated since 1.6.2
+    tap: null,
+    doubleTap: null,
+    longTap: null,
+    hold: null,
+    triggerOnTouchEnd: true,
+    triggerOnTouchLeave: false,
+    allowPageScroll: "auto",
+    fallbackToMouseEvents: true,
+    excludedElements: ".noSwipe",
+    preventDefaultEvents: true
+  };
+
+
+
+  /**
+   * Applies TouchSwipe behaviour to one or more jQuery objects.
+   * The TouchSwipe plugin can be instantiated via this method, or methods within
+   * TouchSwipe can be executed via this method as per jQuery plugin architecture.
+   * An existing plugin can have its options changed simply by re calling .swipe(options)
+   * @see TouchSwipe
+   * @class
+   * @param {Mixed} method If the current DOMNode is a TouchSwipe object, and <code>method</code> is a TouchSwipe method, then
+   * the <code>method</code> is executed, and any following arguments are passed to the TouchSwipe method.
+   * If <code>method</code> is an object, then the TouchSwipe class is instantiated on the current DOMNode, passing the
+   * configuration properties defined in the object. See TouchSwipe
+   *
+   */
+  $.fn.swipe = function(method) {
+    var $this = $(this),
+      plugin = $this.data(PLUGIN_NS);
+
+    //Check if we are already instantiated and trying to execute a method
+    if (plugin && typeof method === 'string') {
+      if (plugin[method]) {
+        return plugin[method].apply(plugin, Array.prototype.slice.call(arguments, 1));
+      } else {
+        $.error('Method ' + method + ' does not exist on jQuery.swipe');
+      }
     }
-}(function ($) {
-    "use strict";
 
-    //Constants
-    var LEFT = "left",
-        RIGHT = "right",
-        UP = "up",
-        DOWN = "down",
-        IN = "in",
-        OUT = "out",
+    //Else update existing plugin with new options hash
+    else if (plugin && typeof method === 'object') {
+      plugin['option'].apply(plugin, arguments);
+    }
 
-        NONE = "none",
-        AUTO = "auto",
+    //Else not instantiated and trying to pass init object (or nothing)
+    else if (!plugin && (typeof method === 'object' || !method)) {
+      return init.apply(this, arguments);
+    }
 
-        SWIPE = "swipe",
-        PINCH = "pinch",
-        TAP = "tap",
-        DOUBLE_TAP = "doubletap",
-        LONG_TAP = "longtap",
-        HOLD = "hold",
+    return $this;
+  };
 
-        HORIZONTAL = "horizontal",
-        VERTICAL = "vertical",
-
-        ALL_FINGERS = "all",
-
-        DOUBLE_TAP_THRESHOLD = 10,
-
-        PHASE_START = "start",
-        PHASE_MOVE = "move",
-        PHASE_END = "end",
-        PHASE_CANCEL = "cancel",
-
-        SUPPORTS_TOUCH = 'ontouchstart' in window,
-
-        SUPPORTS_POINTER_IE10 = window.navigator.msPointerEnabled && !window.navigator.pointerEnabled,
-
-        SUPPORTS_POINTER = window.navigator.pointerEnabled || window.navigator.msPointerEnabled,
-
-        PLUGIN_NS = 'TouchSwipe';
+  /**
+   * The version of the plugin
+   * @readonly
+   */
+  $.fn.swipe.version = VERSION;
 
 
+
+  //Expose our defaults so a user could override the plugin defaults
+  $.fn.swipe.defaults = defaults;
+
+  /**
+   * The phases that a touch event goes through.  The <code>phase</code> is passed to the event handlers.
+   * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
+   * @namespace
+   * @readonly
+   * @property {string} PHASE_START Constant indicating the start phase of the touch event. Value is <code>"start"</code>.
+   * @property {string} PHASE_MOVE Constant indicating the move phase of the touch event. Value is <code>"move"</code>.
+   * @property {string} PHASE_END Constant indicating the end phase of the touch event. Value is <code>"end"</code>.
+   * @property {string} PHASE_CANCEL Constant indicating the cancel phase of the touch event. Value is <code>"cancel"</code>.
+   */
+  $.fn.swipe.phases = {
+    PHASE_START: PHASE_START,
+    PHASE_MOVE: PHASE_MOVE,
+    PHASE_END: PHASE_END,
+    PHASE_CANCEL: PHASE_CANCEL
+  };
+
+  /**
+   * The direction constants that are passed to the event handlers.
+   * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
+   * @namespace
+   * @readonly
+   * @property {string} LEFT Constant indicating the left direction. Value is <code>"left"</code>.
+   * @property {string} RIGHT Constant indicating the right direction. Value is <code>"right"</code>.
+   * @property {string} UP Constant indicating the up direction. Value is <code>"up"</code>.
+   * @property {string} DOWN Constant indicating the down direction. Value is <code>"cancel"</code>.
+   * @property {string} IN Constant indicating the in direction. Value is <code>"in"</code>.
+   * @property {string} OUT Constant indicating the out direction. Value is <code>"out"</code>.
+   */
+  $.fn.swipe.directions = {
+    LEFT: LEFT,
+    RIGHT: RIGHT,
+    UP: UP,
+    DOWN: DOWN,
+    IN: IN,
+    OUT: OUT
+  };
+
+  /**
+   * The page scroll constants that can be used to set the value of <code>allowPageScroll</code> option
+   * These properties are read only
+   * @namespace
+   * @readonly
+   * @see $.fn.swipe.defaults#allowPageScroll
+   * @property {string} NONE Constant indicating no page scrolling is allowed. Value is <code>"none"</code>.
+   * @property {string} HORIZONTAL Constant indicating horizontal page scrolling is allowed. Value is <code>"horizontal"</code>.
+   * @property {string} VERTICAL Constant indicating vertical page scrolling is allowed. Value is <code>"vertical"</code>.
+   * @property {string} AUTO Constant indicating either horizontal or vertical will be allowed, depending on the swipe handlers registered. Value is <code>"auto"</code>.
+   */
+  $.fn.swipe.pageScroll = {
+    NONE: NONE,
+    HORIZONTAL: HORIZONTAL,
+    VERTICAL: VERTICAL,
+    AUTO: AUTO
+  };
+
+  /**
+   * Constants representing the number of fingers used in a swipe.  These are used to set both the value of <code>fingers</code> in the
+   * options object, as well as the value of the <code>fingers</code> event property.
+   * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
+   * @namespace
+   * @readonly
+   * @see $.fn.swipe.defaults#fingers
+   * @property {string} ONE Constant indicating 1 finger is to be detected / was detected. Value is <code>1</code>.
+   * @property {string} TWO Constant indicating 2 fingers are to be detected / were detected. Value is <code>2</code>.
+   * @property {string} THREE Constant indicating 3 finger are to be detected / were detected. Value is <code>3</code>.
+   * @property {string} FOUR Constant indicating 4 finger are to be detected / were detected. Not all devices support this. Value is <code>4</code>.
+   * @property {string} FIVE Constant indicating 5 finger are to be detected / were detected. Not all devices support this. Value is <code>5</code>.
+   * @property {string} ALL Constant indicating any combination of finger are to be detected.  Value is <code>"all"</code>.
+   */
+  $.fn.swipe.fingers = {
+    ONE: 1,
+    TWO: 2,
+    THREE: 3,
+    FOUR: 4,
+    FIVE: 5,
+    ALL: ALL_FINGERS
+  };
+
+  /**
+   * Initialise the plugin for each DOM element matched
+   * This creates a new instance of the main TouchSwipe class for each DOM element, and then
+   * saves a reference to that instance in the elements data property.
+   * @internal
+   */
+  function init(options) {
+    //Prep and extend the options
+    if (options && (options.allowPageScroll === undefined && (options.swipe !== undefined || options.swipeStatus !== undefined))) {
+      options.allowPageScroll = NONE;
+    }
+
+    //Check for deprecated options
+    //Ensure that any old click handlers are assigned to the new tap, unless we have a tap
+    if (options.click !== undefined && options.tap === undefined) {
+      options.tap = options.click;
+    }
+
+    if (!options) {
+      options = {};
+    }
+
+    //pass empty object so we dont modify the defaults
+    options = $.extend({}, $.fn.swipe.defaults, options);
+
+    //For each element instantiate the plugin
+    return this.each(function() {
+      var $this = $(this);
+
+      //Check we havent already initialised the plugin
+      var plugin = $this.data(PLUGIN_NS);
+
+      if (!plugin) {
+        plugin = new TouchSwipe(this, options);
+        $this.data(PLUGIN_NS, plugin);
+      }
+    });
+  }
+
+  /**
+   * Main TouchSwipe Plugin Class.
+   * Do not use this to construct your TouchSwipe object, use the jQuery plugin method $.fn.swipe(); {@link $.fn.swipe}
+   * @private
+   * @name TouchSwipe
+   * @param {DOMNode} element The HTML DOM object to apply to plugin to
+   * @param {Object} options The options to configure the plugin with.  @link {$.fn.swipe.defaults}
+   * @see $.fh.swipe.defaults
+   * @see $.fh.swipe
+   * @class
+   */
+  function TouchSwipe(element, options) {
+
+    //take a local/instacne level copy of the options - should make it this.options really...
+    var options = $.extend({}, options);
+
+    var useTouchEvents = (SUPPORTS_TOUCH || SUPPORTS_POINTER || !options.fallbackToMouseEvents),
+      START_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerDown' : 'pointerdown') : 'touchstart') : 'mousedown',
+      MOVE_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerMove' : 'pointermove') : 'touchmove') : 'mousemove',
+      END_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerUp' : 'pointerup') : 'touchend') : 'mouseup',
+      LEAVE_EV = useTouchEvents ? (SUPPORTS_POINTER ? 'mouseleave' : null) : 'mouseleave', //we manually detect leave on touch devices, so null event here
+      CANCEL_EV = (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerCancel' : 'pointercancel') : 'touchcancel');
+
+
+
+    //touch properties
+    var distance = 0,
+      direction = null,
+      currentDirection = null,
+      duration = 0,
+      startTouchesDistance = 0,
+      endTouchesDistance = 0,
+      pinchZoom = 1,
+      pinchDistance = 0,
+      pinchDirection = 0,
+      maximumsMap = null;
+
+
+
+    //jQuery wrapped element for this instance
+    var $element = $(element);
+
+    //Current phase of th touch cycle
+    var phase = "start";
+
+    // the current number of fingers being used.
+    var fingerCount = 0;
+
+    //track mouse points / delta
+    var fingerData = {};
+
+    //track times
+    var startTime = 0,
+      endTime = 0,
+      previousTouchEndTime = 0,
+      fingerCountAtRelease = 0,
+      doubleTapStartTime = 0;
+
+    //Timeouts
+    var singleTapTimeout = null,
+      holdTimeout = null;
+
+    // Add gestures to all swipable areas if supported
+    try {
+      $element.on(START_EV, touchStart);
+      $element.on(CANCEL_EV, touchCancel);
+    } catch (e) {
+      $.error('events not supported ' + START_EV + ',' + CANCEL_EV + ' on jQuery.swipe');
+    }
+
+    //
+    //Public methods
+    //
 
     /**
-     * The default configuration, and available options to configure touch swipe with.
-     * You can set the default values by updating any of the properties prior to instantiation.
-     * @name $.fn.swipe.defaults
-     * @namespace
-     * @property {int} [fingers=1] The number of fingers to detect in a swipe. Any swipes that do not meet this requirement will NOT trigger swipe handlers.
-     * @property {int} [threshold=75] The number of pixels that the user must move their finger by before it is considered a swipe.
-     * @property {int} [cancelThreshold=null] The number of pixels that the user must move their finger back from the original swipe direction to cancel the gesture.
-     * @property {int} [pinchThreshold=20] The number of pixels that the user must pinch their finger by before it is considered a pinch.
-     * @property {int} [maxTimeThreshold=null] Time, in milliseconds, between touchStart and touchEnd must NOT exceed in order to be considered a swipe.
-     * @property {int} [fingerReleaseThreshold=250] Time in milliseconds between releasing multiple fingers.  If 2 fingers are down, and are released one after the other, if they are within this threshold, it counts as a simultaneous release.
-     * @property {int} [longTapThreshold=500] Time in milliseconds between tap and release for a long tap
-     * @property {int} [doubleTapThreshold=200] Time in milliseconds between 2 taps to count as a double tap
-     * @property {function} [swipe=null] A handler to catch all swipes. See {@link $.fn.swipe#event:swipe}
-     * @property {function} [swipeLeft=null] A handler that is triggered for "left" swipes. See {@link $.fn.swipe#event:swipeLeft}
-     * @property {function} [swipeRight=null] A handler that is triggered for "right" swipes. See {@link $.fn.swipe#event:swipeRight}
-     * @property {function} [swipeUp=null] A handler that is triggered for "up" swipes. See {@link $.fn.swipe#event:swipeUp}
-     * @property {function} [swipeDown=null] A handler that is triggered for "down" swipes. See {@link $.fn.swipe#event:swipeDown}
-     * @property {function} [swipeStatus=null] A handler triggered for every phase of the swipe. See {@link $.fn.swipe#event:swipeStatus}
-     * @property {function} [pinchIn=null] A handler triggered for pinch in events. See {@link $.fn.swipe#event:pinchIn}
-     * @property {function} [pinchOut=null] A handler triggered for pinch out events. See {@link $.fn.swipe#event:pinchOut}
-     * @property {function} [pinchStatus=null] A handler triggered for every phase of a pinch. See {@link $.fn.swipe#event:pinchStatus}
-     * @property {function} [tap=null] A handler triggered when a user just taps on the item, rather than swipes it. If they do not move, tap is triggered, if they do move, it is not.
-     * @property {function} [doubleTap=null] A handler triggered when a user double taps on the item. The delay between taps can be set with the doubleTapThreshold property. See {@link $.fn.swipe.defaults#doubleTapThreshold}
-     * @property {function} [longTap=null] A handler triggered when a user long taps on the item. The delay between start and end can be set with the longTapThreshold property. See {@link $.fn.swipe.defaults#longTapThreshold}
-     * @property (function) [hold=null] A handler triggered when a user reaches longTapThreshold on the item. See {@link $.fn.swipe.defaults#longTapThreshold}
-     * @property {boolean} [triggerOnTouchEnd=true] If true, the swipe events are triggered when the touch end event is received (user releases finger).  If false, it will be triggered on reaching the threshold, and then cancel the touch event automatically.
-     * @property {boolean} [triggerOnTouchLeave=false] If true, then when the user leaves the swipe object, the swipe will end and trigger appropriate handlers.
-     * @property {string|undefined} [allowPageScroll='auto'] How the browser handles page scrolls when the user is swiping on a touchSwipe object. See {@link $.fn.swipe.pageScroll}.  <br/><br/>
-     <code>"auto"</code> : all undefined swipes will cause the page to scroll in that direction. <br/>
-     <code>"none"</code> : the page will not scroll when user swipes. <br/>
-     <code>"horizontal"</code> : will force page to scroll on horizontal swipes. <br/>
-     <code>"vertical"</code> : will force page to scroll on vertical swipes. <br/>
-     * @property {boolean} [fallbackToMouseEvents=true] If true mouse events are used when run on a non touch device, false will stop swipes being triggered by mouse events on non tocuh devices.
-     * @property {string} [excludedElements="button, input, select, textarea, a, .noSwipe"] A jquery selector that specifies child elements that do NOT trigger swipes. By default this excludes all form, input, select, button, anchor and .noSwipe elements.
-     * @property {boolean} [preventDefaultEvents=true] by default default events are cancelled, so the page doesn't move.  You can dissable this so both native events fire as well as your handlers.
-
+     * re-enables the swipe plugin with the previous configuration
+     * @function
+     * @name $.fn.swipe#enable
+     * @return {DOMNode} The Dom element that was registered with TouchSwipe
+     * @example $("#element").swipe("enable");
      */
-    var defaults = {
-        fingers: 1,
-        threshold: 75,
-        cancelThreshold:null,
-        pinchThreshold:20,
-        maxTimeThreshold: null,
-        fingerReleaseThreshold:250,
-        longTapThreshold:500,
-        doubleTapThreshold:200,
-        swipe: null,
-        swipeLeft: null,
-        swipeRight: null,
-        swipeUp: null,
-        swipeDown: null,
-        swipeStatus: null,
-        pinchIn:null,
-        pinchOut:null,
-        pinchStatus:null,
-        click:null, //Deprecated since 1.6.2
-        tap:null,
-        doubleTap:null,
-        longTap:null,
-        hold:null,
-        triggerOnTouchEnd: true,
-        triggerOnTouchLeave:false,
-        allowPageScroll: "auto",
-        fallbackToMouseEvents: true,
-        excludedElements:"label, button, input, select, textarea, a, .noSwipe",
-        preventDefaultEvents:true
+    this.enable = function() {
+      //Incase we are already enabled, clean up...
+      this.disable();
+      $element.on(START_EV, touchStart);
+      $element.on(CANCEL_EV, touchCancel);
+      return $element;
+    };
+
+    /**
+     * disables the swipe plugin
+     * @function
+     * @name $.fn.swipe#disable
+     * @return {DOMNode} The Dom element that is now registered with TouchSwipe
+     * @example $("#element").swipe("disable");
+     */
+    this.disable = function() {
+      removeListeners();
+      return $element;
+    };
+
+    /**
+     * Destroy the swipe plugin completely. To use any swipe methods, you must re initialise the plugin.
+     * @function
+     * @name $.fn.swipe#destroy
+     * @example $("#element").swipe("destroy");
+     */
+    this.destroy = function() {
+      removeListeners();
+      $element.data(PLUGIN_NS, null);
+      $element = null;
     };
 
 
-
     /**
-     * Applies TouchSwipe behaviour to one or more jQuery objects.
-     * The TouchSwipe plugin can be instantiated via this method, or methods within
-     * TouchSwipe can be executed via this method as per jQuery plugin architecture.
-     * @see TouchSwipe
-     * @class
-     * @param {Mixed} method If the current DOMNode is a TouchSwipe object, and <code>method</code> is a TouchSwipe method, then
-     * the <code>method</code> is executed, and any following arguments are passed to the TouchSwipe method.
-     * If <code>method</code> is an object, then the TouchSwipe class is instantiated on the current DOMNode, passing the
-     * configuration properties defined in the object. See TouchSwipe
+     * Allows run time updating of the swipe configuration options.
+     * @function
+     * @name $.fn.swipe#option
+     * @param {String} property The option property to get or set, or a has of multiple options to set
+     * @param {Object} [value] The value to set the property to
+     * @return {Object} If only a property name is passed, then that property value is returned. If nothing is passed the current options hash is returned.
+     * @example $("#element").swipe("option", "threshold"); // return the threshold
+     * @example $("#element").swipe("option", "threshold", 100); // set the threshold after init
+     * @example $("#element").swipe("option", {threshold:100, fingers:3} ); // set multiple properties after init
+     * @example $("#element").swipe({threshold:100, fingers:3} ); // set multiple properties after init - the "option" method is optional!
+     * @example $("#element").swipe("option"); // Return the current options hash
+     * @see $.fn.swipe.defaults
      *
      */
-    $.fn.swipe = function (method) {
-        var $this = $(this),
-            plugin = $this.data(PLUGIN_NS);
+    this.option = function(property, value) {
 
-        //Check if we are already instantiated and trying to execute a method
-        if (plugin && typeof method === 'string') {
-            if (plugin[method]) {
-                return plugin[method].apply(this, Array.prototype.slice.call(arguments, 1));
-            } else {
-                $.error('Method ' + method + ' does not exist on jQuery.swipe');
-            }
+      if (typeof property === 'object') {
+        options = $.extend(options, property);
+      } else if (options[property] !== undefined) {
+        if (value === undefined) {
+          return options[property];
+        } else {
+          options[property] = value;
         }
-        //Else not instantiated and trying to pass init object (or nothing)
-        else if (!plugin && (typeof method === 'object' || !method)) {
-            return init.apply(this, arguments);
-        }
+      } else if (!property) {
+        return options;
+      } else {
+        $.error('Option ' + property + ' does not exist on jQuery.swipe.options');
+      }
 
-        return $this;
-    };
-
-    //Expose our defaults so a user could override the plugin defaults
-    $.fn.swipe.defaults = defaults;
-
-    /**
-     * The phases that a touch event goes through.  The <code>phase</code> is passed to the event handlers.
-     * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
-     * @namespace
-     * @readonly
-     * @property {string} PHASE_START Constant indicating the start phase of the touch event. Value is <code>"start"</code>.
-     * @property {string} PHASE_MOVE Constant indicating the move phase of the touch event. Value is <code>"move"</code>.
-     * @property {string} PHASE_END Constant indicating the end phase of the touch event. Value is <code>"end"</code>.
-     * @property {string} PHASE_CANCEL Constant indicating the cancel phase of the touch event. Value is <code>"cancel"</code>.
-     */
-    $.fn.swipe.phases = {
-        PHASE_START: PHASE_START,
-        PHASE_MOVE: PHASE_MOVE,
-        PHASE_END: PHASE_END,
-        PHASE_CANCEL: PHASE_CANCEL
-    };
-
-    /**
-     * The direction constants that are passed to the event handlers.
-     * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
-     * @namespace
-     * @readonly
-     * @property {string} LEFT Constant indicating the left direction. Value is <code>"left"</code>.
-     * @property {string} RIGHT Constant indicating the right direction. Value is <code>"right"</code>.
-     * @property {string} UP Constant indicating the up direction. Value is <code>"up"</code>.
-     * @property {string} DOWN Constant indicating the down direction. Value is <code>"cancel"</code>.
-     * @property {string} IN Constant indicating the in direction. Value is <code>"in"</code>.
-     * @property {string} OUT Constant indicating the out direction. Value is <code>"out"</code>.
-     */
-    $.fn.swipe.directions = {
-        LEFT: LEFT,
-        RIGHT: RIGHT,
-        UP: UP,
-        DOWN: DOWN,
-        IN : IN,
-        OUT: OUT
-    };
-
-    /**
-     * The page scroll constants that can be used to set the value of <code>allowPageScroll</code> option
-     * These properties are read only
-     * @namespace
-     * @readonly
-     * @see $.fn.swipe.defaults#allowPageScroll
-     * @property {string} NONE Constant indicating no page scrolling is allowed. Value is <code>"none"</code>.
-     * @property {string} HORIZONTAL Constant indicating horizontal page scrolling is allowed. Value is <code>"horizontal"</code>.
-     * @property {string} VERTICAL Constant indicating vertical page scrolling is allowed. Value is <code>"vertical"</code>.
-     * @property {string} AUTO Constant indicating either horizontal or vertical will be allowed, depending on the swipe handlers registered. Value is <code>"auto"</code>.
-     */
-    $.fn.swipe.pageScroll = {
-        NONE: NONE,
-        HORIZONTAL: HORIZONTAL,
-        VERTICAL: VERTICAL,
-        AUTO: AUTO
-    };
-
-    /**
-     * Constants representing the number of fingers used in a swipe.  These are used to set both the value of <code>fingers</code> in the
-     * options object, as well as the value of the <code>fingers</code> event property.
-     * These properties are read only, attempting to change them will not alter the values passed to the event handlers.
-     * @namespace
-     * @readonly
-     * @see $.fn.swipe.defaults#fingers
-     * @property {string} ONE Constant indicating 1 finger is to be detected / was detected. Value is <code>1</code>.
-     * @property {string} TWO Constant indicating 2 fingers are to be detected / were detected. Value is <code>1</code>.
-     * @property {string} THREE Constant indicating 3 finger are to be detected / were detected. Value is <code>1</code>.
-     * @property {string} ALL Constant indicating any combination of finger are to be detected.  Value is <code>"all"</code>.
-     */
-    $.fn.swipe.fingers = {
-        ONE: 1,
-        TWO: 2,
-        THREE: 3,
-        ALL: ALL_FINGERS
-    };
-
-    /**
-     * Initialise the plugin for each DOM element matched
-     * This creates a new instance of the main TouchSwipe class for each DOM element, and then
-     * saves a reference to that instance in the elements data property.
-     * @internal
-     */
-    function init(options) {
-        //Prep and extend the options
-        if (options && (options.allowPageScroll === undefined && (options.swipe !== undefined || options.swipeStatus !== undefined))) {
-            options.allowPageScroll = NONE;
-        }
-
-        //Check for deprecated options
-        //Ensure that any old click handlers are assigned to the new tap, unless we have a tap
-        if(options.click!==undefined && options.tap===undefined) {
-            options.tap = options.click;
-        }
-
-        if (!options) {
-            options = {};
-        }
-
-        //pass empty object so we dont modify the defaults
-        options = $.extend({}, $.fn.swipe.defaults, options);
-
-        //For each element instantiate the plugin
-        return this.each(function () {
-            var $this = $(this);
-
-            //Check we havent already initialised the plugin
-            var plugin = $this.data(PLUGIN_NS);
-
-            if (!plugin) {
-                plugin = new TouchSwipe(this, options);
-                $this.data(PLUGIN_NS, plugin);
-            }
-        });
+      return null;
     }
 
+
+
+    //
+    // Private methods
+    //
+
+    //
+    // EVENTS
+    //
     /**
-     * Main TouchSwipe Plugin Class.
-     * Do not use this to construct your TouchSwipe object, use the jQuery plugin method $.fn.swipe(); {@link $.fn.swipe}
-     * @private
-     * @name TouchSwipe
-     * @param {DOMNode} element The HTML DOM object to apply to plugin to
-     * @param {Object} options The options to configure the plugin with.  @link {$.fn.swipe.defaults}
-     * @see $.fh.swipe.defaults
-     * @see $.fh.swipe
-     * @class
+     * Event handler for a touch start event.
+     * Stops the default click event from triggering and stores where we touched
+     * @inner
+     * @param {object} jqEvent The normalised jQuery event object.
      */
-    function TouchSwipe(element, options) {
-        var useTouchEvents = (SUPPORTS_TOUCH || SUPPORTS_POINTER || !options.fallbackToMouseEvents),
-            START_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerDown' : 'pointerdown') : 'touchstart') : 'mousedown',
-            MOVE_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerMove' : 'pointermove') : 'touchmove') : 'mousemove',
-            END_EV = useTouchEvents ? (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerUp' : 'pointerup') : 'touchend') : 'mouseup',
-            LEAVE_EV = useTouchEvents ? null : 'mouseleave', //we manually detect leave on touch devices, so null event here
-            CANCEL_EV = (SUPPORTS_POINTER ? (SUPPORTS_POINTER_IE10 ? 'MSPointerCancel' : 'pointercancel') : 'touchcancel');
+    function touchStart(jqEvent) {
+
+      //If we already in a touch event (a finger already in use) then ignore subsequent ones..
+      if (getTouchInProgress()) {
+        return;
+      }
+
+      //Check if this element matches any in the excluded elements selectors,  or its parent is excluded, if so, DON'T swipe
+      if ($(jqEvent.target).closest(options.excludedElements, $element).length > 0) {
+        return;
+      }
+
+      //As we use Jquery bind for events, we need to target the original event object
+      //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+      var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 
 
+      //If we have a pointer event, whoes type is 'mouse' and we have said NO mouse events, then dont do anything.
+      if(event.pointerType && event.pointerType=="mouse" && options.fallbackToMouseEvents==false) {
+        return;
+      };
 
-        //touch properties
-        var distance = 0,
-            direction = null,
-            duration = 0,
-            startTouchesDistance = 0,
-            endTouchesDistance = 0,
-            pinchZoom = 1,
-            pinchDistance = 0,
-            pinchDirection = 0,
-            maximumsMap=null;
+      var ret,
+        touches = event.touches,
+        evt = touches ? touches[0] : event;
 
+      phase = PHASE_START;
 
+      //If we support touches, get the finger count
+      if (touches) {
+        // get the total number of fingers touching the screen
+        fingerCount = touches.length;
+      }
+      //Else this is the desktop, so stop the browser from dragging content
+      else if (options.preventDefaultEvents !== false) {
+        jqEvent.preventDefault(); //call this on jq event so we are cross browser
+      }
 
-        //jQuery wrapped element for this instance
-        var $element = $(element);
+      //clear vars..
+      distance = 0;
+      direction = null;
+      currentDirection=null;
+      pinchDirection = null;
+      duration = 0;
+      startTouchesDistance = 0;
+      endTouchesDistance = 0;
+      pinchZoom = 1;
+      pinchDistance = 0;
+      maximumsMap = createMaximumsData();
+      cancelMultiFingerRelease();
 
-        //Current phase of th touch cycle
-        var phase = "start";
+      //Create the default finger data
+      createFingerData(0, evt);
 
-        // the current number of fingers being used.
-        var fingerCount = 0;
+      // check the number of fingers is what we are looking for, or we are capturing pinches
+      if (!touches || (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches()) {
+        // get the coordinates of the touch
+        startTime = getTimeStamp();
 
-        //track mouse points / delta
-        var fingerData=null;
-
-        //track times
-        var startTime = 0,
-            endTime = 0,
-            previousTouchEndTime=0,
-            previousTouchFingerCount=0,
-            doubleTapStartTime=0;
-
-        //Timeouts
-        var singleTapTimeout=null,
-            holdTimeout=null;
-
-        // Add gestures to all swipable areas if supported
-        try {
-            $element.bind(START_EV, touchStart);
-            $element.bind(CANCEL_EV, touchCancel);
+        if (fingerCount == 2) {
+          //Keep track of the initial pinch distance, so we can calculate the diff later
+          //Store second finger data as start
+          createFingerData(1, touches[1]);
+          startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
         }
-        catch (e) {
-            $.error('events not supported ' + START_EV + ',' + CANCEL_EV + ' on jQuery.swipe');
+
+        if (options.swipeStatus || options.pinchStatus) {
+          ret = triggerHandler(event, phase);
         }
+      } else {
+        //A touch with more or less than the fingers we are looking for, so cancel
+        ret = false;
+      }
 
-        //
-        //Public methods
-        //
-
-        /**
-         * re-enables the swipe plugin with the previous configuration
-         * @function
-         * @name $.fn.swipe#enable
-         * @return {DOMNode} The Dom element that was registered with TouchSwipe
-         * @example $("#element").swipe("enable");
-         */
-        this.enable = function () {
-            $element.bind(START_EV, touchStart);
-            $element.bind(CANCEL_EV, touchCancel);
-            return $element;
-        };
-
-        /**
-         * disables the swipe plugin
-         * @function
-         * @name $.fn.swipe#disable
-         * @return {DOMNode} The Dom element that is now registered with TouchSwipe
-         * @example $("#element").swipe("disable");
-         */
-        this.disable = function () {
-            removeListeners();
-            return $element;
-        };
-
-        /**
-         * Destroy the swipe plugin completely. To use any swipe methods, you must re initialise the plugin.
-         * @function
-         * @name $.fn.swipe#destroy
-         * @example $("#element").swipe("destroy");
-         */
-        this.destroy = function () {
-            removeListeners();
-            $element.data(PLUGIN_NS, null);
-            $element = null;
-        };
-
-
-        /**
-         * Allows run time updating of the swipe configuration options.
-         * @function
-         * @name $.fn.swipe#option
-         * @param {String} property The option property to get or set
-         * @param {Object} [value] The value to set the property to
-         * @return {Object} If only a property name is passed, then that property value is returned.
-         * @example $("#element").swipe("option", "threshold"); // return the threshold
-         * @example $("#element").swipe("option", "threshold", 100); // set the threshold after init
-         * @see $.fn.swipe.defaults
-         *
-         */
-        this.option = function (property, value) {
-            if(options[property]!==undefined) {
-                if(value===undefined) {
-                    return options[property];
-                } else {
-                    options[property] = value;
-                }
-            } else {
-                $.error('Option ' + property + ' does not exist on jQuery.swipe.options');
+      //If we have a return value from the users handler, then return and cancel
+      if (ret === false) {
+        phase = PHASE_CANCEL;
+        triggerHandler(event, phase);
+        return ret;
+      } else {
+        if (options.hold) {
+          holdTimeout = setTimeout($.proxy(function() {
+            //Trigger the event
+            $element.trigger('hold', [event.target]);
+            //Fire the callback
+            if (options.hold) {
+              ret = options.hold.call($element, event, event.target);
             }
-
-            return null;
+          }, this), options.longTapThreshold);
         }
 
-        //
-        // Private methods
-        //
+        setTouchInProgress(true);
+      }
 
-        //
-        // EVENTS
-        //
-        /**
-         * Event handler for a touch start event.
-         * Stops the default click event from triggering and stores where we touched
-         * @inner
-         * @param {object} jqEvent The normalised jQuery event object.
-         */
-        function touchStart(jqEvent) {
-            //If we already in a touch event (a finger already in use) then ignore subsequent ones..
-            if( getTouchInProgress() )
-                return;
-
-            //Check if this element matches any in the excluded elements selectors,  or its parent is excluded, if so, DON'T swipe
-            if( $(jqEvent.target).closest( options.excludedElements, $element ).length>0 )
-                return;
-
-            //As we use Jquery bind for events, we need to target the original event object
-            //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
-            var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
-
-            var ret,
-                evt = SUPPORTS_TOUCH ? event.touches[0] : event;
-
-            phase = PHASE_START;
-
-            //If we support touches, get the finger count
-            if (SUPPORTS_TOUCH) {
-                // get the total number of fingers touching the screen
-                fingerCount = event.touches.length;
-            }
-            //Else this is the desktop, so stop the browser from dragging content
-            else {
-                jqEvent.preventDefault(); //call this on jq event so we are cross browser
-            }
-
-            //clear vars..
-            distance = 0;
-            direction = null;
-            pinchDirection=null;
-            duration = 0;
-            startTouchesDistance=0;
-            endTouchesDistance=0;
-            pinchZoom = 1;
-            pinchDistance = 0;
-            fingerData=createAllFingerData();
-            maximumsMap=createMaximumsData();
-            cancelMultiFingerRelease();
-
-
-            // check the number of fingers is what we are looking for, or we are capturing pinches
-            if (!SUPPORTS_TOUCH || (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches()) {
-                // get the coordinates of the touch
-                createFingerData( 0, evt );
-                startTime = getTimeStamp();
-
-                if(fingerCount==2) {
-                    //Keep track of the initial pinch distance, so we can calculate the diff later
-                    //Store second finger data as start
-                    createFingerData( 1, event.touches[1] );
-                    startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
-                }
-
-                if (options.swipeStatus || options.pinchStatus) {
-                    ret = triggerHandler(event, phase);
-                }
-            }
-            else {
-                //A touch with more or less than the fingers we are looking for, so cancel
-                ret = false;
-            }
-
-            //If we have a return value from the users handler, then return and cancel
-            if (ret === false) {
-                phase = PHASE_CANCEL;
-                triggerHandler(event, phase);
-                return ret;
-            }
-            else {
-                if (options.hold) {
-                    holdTimeout = setTimeout($.proxy(function() {
-                        //Trigger the event
-                        $element.trigger('hold', [event.target]);
-                        //Fire the callback
-                        if(options.hold) {
-                            ret = options.hold.call($element, event, event.target);
-                        }
-                    }, this), options.longTapThreshold );
-                }
-
-                setTouchInProgress(true);
-            }
-
-            return null;
-        };
+      return null;
+    };
 
 
 
-        /**
-         * Event handler for a touch move event.
-         * If we change fingers during move, then cancel the event
-         * @inner
-         * @param {object} jqEvent The normalised jQuery event object.
-         */
-        function touchMove(jqEvent) {
+    /**
+     * Event handler for a touch move event.
+     * If we change fingers during move, then cancel the event
+     * @inner
+     * @param {object} jqEvent The normalised jQuery event object.
+     */
+    function touchMove(jqEvent) {
 
-            //As we use Jquery bind for events, we need to target the original event object
-            //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
-            var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
+      //As we use Jquery bind for events, we need to target the original event object
+      //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+      var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 
-            //If we are ending, cancelling, or within the threshold of 2 fingers being released, don't track anything..
-            if (phase === PHASE_END || phase === PHASE_CANCEL || inMultiFingerRelease())
-                return;
+      //If we are ending, cancelling, or within the threshold of 2 fingers being released, don't track anything..
+      if (phase === PHASE_END || phase === PHASE_CANCEL || inMultiFingerRelease())
+        return;
 
-            var ret,
-                evt = SUPPORTS_TOUCH ? event.touches[0] : event;
-
-
-            //Update the  finger data
-            var currentFinger = updateFingerData(evt);
-            endTime = getTimeStamp();
-
-            if (SUPPORTS_TOUCH) {
-                fingerCount = event.touches.length;
-            }
-
-            if (options.hold)
-                clearTimeout(holdTimeout);
-
-            phase = PHASE_MOVE;
-
-            //If we have 2 fingers get Touches distance as well
-            if(fingerCount==2) {
-
-                //Keep track of the initial pinch distance, so we can calculate the diff later
-                //We do this here as well as the start event, in case they start with 1 finger, and the press 2 fingers
-                if(startTouchesDistance==0) {
-                    //Create second finger if this is the first time...
-                    createFingerData( 1, event.touches[1] );
-
-                    startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
-                } else {
-                    //Else just update the second finger
-                    updateFingerData(event.touches[1]);
-
-                    endTouchesDistance = calculateTouchesDistance(fingerData[0].end, fingerData[1].end);
-                    pinchDirection = calculatePinchDirection(fingerData[0].end, fingerData[1].end);
-                }
+      var ret,
+        touches = event.touches,
+        evt = touches ? touches[0] : event;
 
 
-                pinchZoom = calculatePinchZoom(startTouchesDistance, endTouchesDistance);
-                pinchDistance = Math.abs(startTouchesDistance - endTouchesDistance);
-            }
+      //Update the  finger data
+      var currentFinger = updateFingerData(evt);
+      endTime = getTimeStamp();
 
+      if (touches) {
+        fingerCount = touches.length;
+      }
 
+      if (options.hold) {
+        clearTimeout(holdTimeout);
+      }
 
+      phase = PHASE_MOVE;
 
-            if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !SUPPORTS_TOUCH || hasPinches() ) {
+      //If we have 2 fingers get Touches distance as well
+      if (fingerCount == 2) {
 
-                direction = calculateDirection(currentFinger.start, currentFinger.end);
+        //Keep track of the initial pinch distance, so we can calculate the diff later
+        //We do this here as well as the start event, in case they start with 1 finger, and the press 2 fingers
+        if (startTouchesDistance == 0) {
+          //Create second finger if this is the first time...
+          createFingerData(1, touches[1]);
 
-                //Check if we need to prevent default event (page scroll / pinch zoom) or not
-                validateDefaultEvent(jqEvent, direction);
+          startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
+        } else {
+          //Else just update the second finger
+          updateFingerData(touches[1]);
 
-                //Distance and duration are all off the main finger
-                distance = calculateDistance(currentFinger.start, currentFinger.end);
-                duration = calculateDuration();
-
-                //Cache the maximum distance we made in this direction
-                setMaxDistance(direction, distance);
-
-
-                if (options.swipeStatus || options.pinchStatus) {
-                    ret = triggerHandler(event, phase);
-                }
-
-
-                //If we trigger end events when threshold are met, or trigger events when touch leaves element
-                if(!options.triggerOnTouchEnd || options.triggerOnTouchLeave) {
-
-                    var inBounds = true;
-
-                    //If checking if we leave the element, run the bounds check (we can use touchleave as its not supported on webkit)
-                    if(options.triggerOnTouchLeave) {
-                        var bounds = getbounds( this );
-                        inBounds = isInBounds( currentFinger.end, bounds );
-                    }
-
-                    //Trigger end handles as we swipe if thresholds met or if we have left the element if the user has asked to check these..
-                    if(!options.triggerOnTouchEnd && inBounds) {
-                        phase = getNextPhase( PHASE_MOVE );
-                    }
-                    //We end if out of bounds here, so set current phase to END, and check if its modified
-                    else if(options.triggerOnTouchLeave && !inBounds ) {
-                        phase = getNextPhase( PHASE_END );
-                    }
-
-                    if(phase==PHASE_CANCEL || phase==PHASE_END)	{
-                        triggerHandler(event, phase);
-                    }
-                }
-            }
-            else {
-                phase = PHASE_CANCEL;
-                triggerHandler(event, phase);
-            }
-
-            if (ret === false) {
-                phase = PHASE_CANCEL;
-                triggerHandler(event, phase);
-            }
+          endTouchesDistance = calculateTouchesDistance(fingerData[0].end, fingerData[1].end);
+          pinchDirection = calculatePinchDirection(fingerData[0].end, fingerData[1].end);
         }
 
+        pinchZoom = calculatePinchZoom(startTouchesDistance, endTouchesDistance);
+        pinchDistance = Math.abs(startTouchesDistance - endTouchesDistance);
+      }
+
+      if ((fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !touches || hasPinches()) {
+
+        //The overall direction of the swipe. From start to now.
+        direction = calculateDirection(currentFinger.start, currentFinger.end);
+
+        //The immediate direction of the swipe, direction between the last movement and this one.
+        currentDirection = calculateDirection(currentFinger.last, currentFinger.end);
+
+        //Check if we need to prevent default event (page scroll / pinch zoom) or not
+        validateDefaultEvent(jqEvent, currentDirection);
+
+        //Distance and duration are all off the main finger
+        distance = calculateDistance(currentFinger.start, currentFinger.end);
+        duration = calculateDuration();
+
+        //Cache the maximum distance we made in this direction
+        setMaxDistance(direction, distance);
+
+        //Trigger status handler
+        ret = triggerHandler(event, phase);
 
 
-        /**
-         * Event handler for a touch end event.
-         * Calculate the direction and trigger events
-         * @inner
-         * @param {object} jqEvent The normalised jQuery event object.
-         */
-        function touchEnd(jqEvent) {
-            //As we use Jquery bind for events, we need to target the original event object
-            var event = jqEvent.originalEvent;
+        //If we trigger end events when threshold are met, or trigger events when touch leaves element
+        if (!options.triggerOnTouchEnd || options.triggerOnTouchLeave) {
 
+          var inBounds = true;
 
-            //If we are still in a touch with another finger return
-            //This allows us to wait a fraction and see if the other finger comes up, if it does within the threshold, then we treat it as a multi release, not a single release.
-            if (SUPPORTS_TOUCH) {
-                if(event.touches.length>0) {
-                    startMultiFingerRelease();
-                    return true;
-                }
-            }
+          //If checking if we leave the element, run the bounds check (we can use touchleave as its not supported on webkit)
+          if (options.triggerOnTouchLeave) {
+            var bounds = getbounds(this);
+            inBounds = isInBounds(currentFinger.end, bounds);
+          }
 
-            //If a previous finger has been released, check how long ago, if within the threshold, then assume it was a multifinger release.
-            //This is used to allow 2 fingers to release fractionally after each other, whilst maintainig the event as containg 2 fingers, not 1
-            if(inMultiFingerRelease()) {
-                fingerCount=previousTouchFingerCount;
-            }
+          //Trigger end handles as we swipe if thresholds met or if we have left the element if the user has asked to check these..
+          if (!options.triggerOnTouchEnd && inBounds) {
+            phase = getNextPhase(PHASE_MOVE);
+          }
+          //We end if out of bounds here, so set current phase to END, and check if its modified
+          else if (options.triggerOnTouchLeave && !inBounds) {
+            phase = getNextPhase(PHASE_END);
+          }
 
-            //Set end of swipe
-            endTime = getTimeStamp();
-
-            //Get duration incase move was never fired
-            duration = calculateDuration();
-
-            //If we trigger handlers at end of swipe OR, we trigger during, but they didnt trigger and we are still in the move phase
-            if(didSwipeBackToCancel() || !validateSwipeDistance()) {
-                phase = PHASE_CANCEL;
-                triggerHandler(event, phase);
-            } else if (options.triggerOnTouchEnd || (options.triggerOnTouchEnd == false && phase === PHASE_MOVE)) {
-                //call this on jq event so we are cross browser
-                jqEvent.preventDefault();
-                phase = PHASE_END;
-                triggerHandler(event, phase);
-            }
-            //Special cases - A tap should always fire on touch end regardless,
-            //So here we manually trigger the tap end handler by itself
-            //We dont run trigger handler as it will re-trigger events that may have fired already
-            else if (!options.triggerOnTouchEnd && hasTap()) {
-                //Trigger the pinch events...
-                phase = PHASE_END;
-                triggerHandlerForGesture(event, phase, TAP);
-            }
-            else if (phase === PHASE_MOVE) {
-                phase = PHASE_CANCEL;
-                triggerHandler(event, phase);
-            }
-
-            setTouchInProgress(false);
-
-            return null;
+          if (phase == PHASE_CANCEL || phase == PHASE_END) {
+            triggerHandler(event, phase);
+          }
         }
-
-
-
-        /**
-         * Event handler for a touch cancel event.
-         * Clears current vars
-         * @inner
-         */
-        function touchCancel() {
-            // reset the variables back to default values
-            fingerCount = 0;
-            endTime = 0;
-            startTime = 0;
-            startTouchesDistance=0;
-            endTouchesDistance=0;
-            pinchZoom=1;
-
-            //If we were in progress of tracking a possible multi touch end, then re set it.
-            cancelMultiFingerRelease();
-
-            setTouchInProgress(false);
-        }
-
-
-        /**
-         * Event handler for a touch leave event.
-         * This is only triggered on desktops, in touch we work this out manually
-         * as the touchleave event is not supported in webkit
-         * @inner
-         */
-        function touchLeave(jqEvent) {
-            var event = jqEvent.originalEvent;
-
-            //If we have the trigger on leave property set....
-            if(options.triggerOnTouchLeave) {
-                phase = getNextPhase( PHASE_END );
-                triggerHandler(event, phase);
-            }
-        }
-
-        /**
-         * Removes all listeners that were associated with the plugin
-         * @inner
-         */
-        function removeListeners() {
-            $element.unbind(START_EV, touchStart);
-            $element.unbind(CANCEL_EV, touchCancel);
-            $element.unbind(MOVE_EV, touchMove);
-            $element.unbind(END_EV, touchEnd);
-
-            //we only have leave events on desktop, we manually calculate leave on touch as its not supported in webkit
-            if(LEAVE_EV) {
-                $element.unbind(LEAVE_EV, touchLeave);
-            }
-
-            setTouchInProgress(false);
-        }
-
-
-        /**
-         * Checks if the time and distance thresholds have been met, and if so then the appropriate handlers are fired.
-         */
-        function getNextPhase(currentPhase) {
-
-            var nextPhase = currentPhase;
-
-            // Ensure we have valid swipe (under time and over distance  and check if we are out of bound...)
-            var validTime = validateSwipeTime();
-            var validDistance = validateSwipeDistance();
-            var didCancel = didSwipeBackToCancel();
-
-            //If we have exceeded our time, then cancel
-            if(!validTime || didCancel) {
-                nextPhase = PHASE_CANCEL;
-            }
-            //Else if we are moving, and have reached distance then end
-            else if (validDistance && currentPhase == PHASE_MOVE && (!options.triggerOnTouchEnd || options.triggerOnTouchLeave) ) {
-                nextPhase = PHASE_END;
-            }
-            //Else if we have ended by leaving and didn't reach distance, then cancel
-            else if (!validDistance && currentPhase==PHASE_END && options.triggerOnTouchLeave) {
-                nextPhase = PHASE_CANCEL;
-            }
-
-            return nextPhase;
-        }
-
-
-        /**
-         * Trigger the relevant event handler
-         * The handlers are passed the original event, the element that was swiped, and in the case of the catch all handler, the direction that was swiped, "left", "right", "up", or "down"
-         * @param {object} event the original event object
-         * @param {string} phase the phase of the swipe (start, end cancel etc) {@link $.fn.swipe.phases}
-         * @inner
-         */
-        function triggerHandler(event, phase) {
-
-            var ret = undefined;
-
-            //Swipes and pinches are not mutually exclusive - can happend at same time, so need to trigger 2 events potentially
-            if( (didSwipe() || hasSwipes()) || (didPinch() || hasPinches()) ) {
-                // SWIPE GESTURES
-                if(didSwipe() || hasSwipes()) { //hasSwipes as status needs to fire even if swipe is invalid
-                    //Trigger the swipe events...
-                    ret = triggerHandlerForGesture(event, phase, SWIPE);
-                }
-
-                // PINCH GESTURES (if the above didn't cancel)
-                if((didPinch() || hasPinches()) && ret!==false) {
-                    //Trigger the pinch events...
-                    ret = triggerHandlerForGesture(event, phase, PINCH);
-                }
-            } else {
-
-                // CLICK / TAP (if the above didn't cancel)
-                if(didDoubleTap() && ret!==false) {
-                    //Trigger the tap events...
-                    ret = triggerHandlerForGesture(event, phase, DOUBLE_TAP);
-                }
-
-                // CLICK / TAP (if the above didn't cancel)
-                else if(didLongTap() && ret!==false) {
-                    //Trigger the tap events...
-                    ret = triggerHandlerForGesture(event, phase, LONG_TAP);
-                }
-
-                // CLICK / TAP (if the above didn't cancel)
-                else if(didTap() && ret!==false) {
-                    //Trigger the tap event..
-                    ret = triggerHandlerForGesture(event, phase, TAP);
-                }
-            }
-
-
-
-            // If we are cancelling the gesture, then manually trigger the reset handler
-            if (phase === PHASE_CANCEL) {
-                touchCancel(event);
-            }
-
-            // If we are ending the gesture, then manually trigger the reset handler IF all fingers are off
-            if(phase === PHASE_END) {
-                //If we support touch, then check that all fingers are off before we cancel
-                if (SUPPORTS_TOUCH) {
-                    if(event.touches.length==0) {
-                        touchCancel(event);
-                    }
-                }
-                else {
-                    touchCancel(event);
-                }
-            }
-
-            return ret;
-        }
-
-
-
-        /**
-         * Trigger the relevant event handler
-         * The handlers are passed the original event, the element that was swiped, and in the case of the catch all handler, the direction that was swiped, "left", "right", "up", or "down"
-         * @param {object} event the original event object
-         * @param {string} phase the phase of the swipe (start, end cancel etc) {@link $.fn.swipe.phases}
-         * @param {string} gesture the gesture to trigger a handler for : PINCH or SWIPE {@link $.fn.swipe.gestures}
-         * @return Boolean False, to indicate that the event should stop propagation, or void.
-         * @inner
-         */
-        function triggerHandlerForGesture(event, phase, gesture) {
-
-            var ret=undefined;
-
-            //SWIPES....
-            if(gesture==SWIPE) {
-                //Trigger status every time..
-
-                //Trigger the event...
-                $element.trigger('swipeStatus', [phase, direction || null, distance || 0, duration || 0, fingerCount, fingerData]);
-
-                //Fire the callback
-                if (options.swipeStatus) {
-                    ret = options.swipeStatus.call($element, event, phase, direction || null, distance || 0, duration || 0, fingerCount, fingerData);
-                    //If the status cancels, then dont run the subsequent event handlers..
-                    if(ret===false) return false;
-                }
-
-
-
-
-                if (phase == PHASE_END && validateSwipe()) {
-                    //Fire the catch all event
-                    $element.trigger('swipe', [direction, distance, duration, fingerCount, fingerData]);
-
-                    //Fire catch all callback
-                    if (options.swipe) {
-                        ret = options.swipe.call($element, event, direction, distance, duration, fingerCount, fingerData);
-                        //If the status cancels, then dont run the subsequent event handlers..
-                        if(ret===false) return false;
-                    }
-
-                    //trigger direction specific event handlers
-                    switch (direction) {
-                        case LEFT:
-                            //Trigger the event
-                            $element.trigger('swipeLeft', [direction, distance, duration, fingerCount, fingerData]);
-
-                            //Fire the callback
-                            if (options.swipeLeft) {
-                                ret = options.swipeLeft.call($element, event, direction, distance, duration, fingerCount, fingerData);
-                            }
-                            break;
-
-                        case RIGHT:
-                            //Trigger the event
-                            $element.trigger('swipeRight', [direction, distance, duration, fingerCount, fingerData]);
-
-                            //Fire the callback
-                            if (options.swipeRight) {
-                                ret = options.swipeRight.call($element, event, direction, distance, duration, fingerCount, fingerData);
-                            }
-                            break;
-
-                        case UP:
-                            //Trigger the event
-                            $element.trigger('swipeUp', [direction, distance, duration, fingerCount, fingerData]);
-
-                            //Fire the callback
-                            if (options.swipeUp) {
-                                ret = options.swipeUp.call($element, event, direction, distance, duration, fingerCount, fingerData);
-                            }
-                            break;
-
-                        case DOWN:
-                            //Trigger the event
-                            $element.trigger('swipeDown', [direction, distance, duration, fingerCount, fingerData]);
-
-                            //Fire the callback
-                            if (options.swipeDown) {
-                                ret = options.swipeDown.call($element, event, direction, distance, duration, fingerCount, fingerData);
-                            }
-                            break;
-                    }
-                }
-            }
-
-
-            //PINCHES....
-            if(gesture==PINCH) {
-                //Trigger the event
-                $element.trigger('pinchStatus', [phase, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
-
-                //Fire the callback
-                if (options.pinchStatus) {
-                    ret = options.pinchStatus.call($element, event, phase, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
-                    //If the status cancels, then dont run the subsequent event handlers..
-                    if(ret===false) return false;
-                }
-
-                if(phase==PHASE_END && validatePinch()) {
-
-                    switch (pinchDirection) {
-                        case IN:
-                            //Trigger the event
-                            $element.trigger('pinchIn', [pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
-
-                            //Fire the callback
-                            if (options.pinchIn) {
-                                ret = options.pinchIn.call($element, event, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
-                            }
-                            break;
-
-                        case OUT:
-                            //Trigger the event
-                            $element.trigger('pinchOut', [pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
-
-                            //Fire the callback
-                            if (options.pinchOut) {
-                                ret = options.pinchOut.call($element, event, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
-                            }
-                            break;
-                    }
-                }
-            }
-
-
-
-
-
-            if(gesture==TAP) {
-                if(phase === PHASE_CANCEL || phase === PHASE_END) {
-
-
-                    //Cancel any existing double tap
-                    clearTimeout(singleTapTimeout);
-                    //Cancel hold timeout
-                    clearTimeout(holdTimeout);
-
-                    //If we are also looking for doubelTaps, wait incase this is one...
-                    if(hasDoubleTap() && !inDoubleTap()) {
-                        //Cache the time of this tap
-                        doubleTapStartTime = getTimeStamp();
-
-                        //Now wait for the double tap timeout, and trigger this single tap
-                        //if its not cancelled by a double tap
-                        singleTapTimeout = setTimeout($.proxy(function() {
-                            doubleTapStartTime=null;
-                            //Trigger the event
-                            $element.trigger('tap', [event.target]);
-
-
-                            //Fire the callback
-                            if(options.tap) {
-                                ret = options.tap.call($element, event, event.target);
-                            }
-                        }, this), options.doubleTapThreshold );
-
-                    } else {
-                        doubleTapStartTime=null;
-
-                        //Trigger the event
-                        $element.trigger('tap', [event.target]);
-
-
-                        //Fire the callback
-                        if(options.tap) {
-                            ret = options.tap.call($element, event, event.target);
-                        }
-                    }
-                }
-            }
-
-            else if (gesture==DOUBLE_TAP) {
-                if(phase === PHASE_CANCEL || phase === PHASE_END) {
-                    //Cancel any pending singletap
-                    clearTimeout(singleTapTimeout);
-                    doubleTapStartTime=null;
-
-                    //Trigger the event
-                    $element.trigger('doubletap', [event.target]);
-
-                    //Fire the callback
-                    if(options.doubleTap) {
-                        ret = options.doubleTap.call($element, event, event.target);
-                    }
-                }
-            }
-
-            else if (gesture==LONG_TAP) {
-                if(phase === PHASE_CANCEL || phase === PHASE_END) {
-                    //Cancel any pending singletap (shouldnt be one)
-                    clearTimeout(singleTapTimeout);
-                    doubleTapStartTime=null;
-
-                    //Trigger the event
-                    $element.trigger('longtap', [event.target]);
-
-                    //Fire the callback
-                    if(options.longTap) {
-                        ret = options.longTap.call($element, event, event.target);
-                    }
-                }
-            }
-
-            return ret;
-        }
-
-
-
-
-        //
-        // GESTURE VALIDATION
-        //
-
-        /**
-         * Checks the user has swipe far enough
-         * @return Boolean if <code>threshold</code> has been set, return true if the threshold was met, else false.
-         * If no threshold was set, then we return true.
-         * @inner
-         */
-        function validateSwipeDistance() {
-            var valid = true;
-            //If we made it past the min swipe distance..
-            if (options.threshold !== null) {
-                valid = distance >= options.threshold;
-            }
-
-            return valid;
-        }
-
-        /**
-         * Checks the user has swiped back to cancel.
-         * @return Boolean if <code>cancelThreshold</code> has been set, return true if the cancelThreshold was met, else false.
-         * If no cancelThreshold was set, then we return true.
-         * @inner
-         */
-        function didSwipeBackToCancel() {
-            var cancelled = false;
-            if(options.cancelThreshold !== null && direction !==null)  {
-                cancelled =  (getMaxDistance( direction ) - distance) >= options.cancelThreshold;
-            }
-
-            return cancelled;
-        }
-
-        /**
-         * Checks the user has pinched far enough
-         * @return Boolean if <code>pinchThreshold</code> has been set, return true if the threshold was met, else false.
-         * If no threshold was set, then we return true.
-         * @inner
-         */
-        function validatePinchDistance() {
-            if (options.pinchThreshold !== null) {
-                return pinchDistance >= options.pinchThreshold;
-            }
-            return true;
-        }
-
-        /**
-         * Checks that the time taken to swipe meets the minimum / maximum requirements
-         * @return Boolean
-         * @inner
-         */
-        function validateSwipeTime() {
-            var result;
-            //If no time set, then return true
-
-            if (options.maxTimeThreshold) {
-                if (duration >= options.maxTimeThreshold) {
-                    result = false;
-                } else {
-                    result = true;
-                }
-            }
-            else {
-                result = true;
-            }
-
-            return result;
-        }
-
-
-
-        /**
-         * Checks direction of the swipe and the value allowPageScroll to see if we should allow or prevent the default behaviour from occurring.
-         * This will essentially allow page scrolling or not when the user is swiping on a touchSwipe object.
-         * @param {object} jqEvent The normalised jQuery representation of the event object.
-         * @param {string} direction The direction of the event. See {@link $.fn.swipe.directions}
-         * @see $.fn.swipe.directions
-         * @inner
-         */
-        function validateDefaultEvent(jqEvent, direction) {
-
-
-            if( options.preventDefaultEvents === false ) {
-                return;
-            }
-
-            if (options.allowPageScroll === NONE) {
-                jqEvent.preventDefault();
-            } else {
-                var auto = options.allowPageScroll === AUTO;
-
-                switch (direction) {
-                    case LEFT:
-                        if ((options.swipeLeft && auto) || (!auto && options.allowPageScroll != HORIZONTAL)) {
-                            jqEvent.preventDefault();
-                        }
-                        break;
-
-                    case RIGHT:
-                        if ((options.swipeRight && auto) || (!auto && options.allowPageScroll != HORIZONTAL)) {
-                            jqEvent.preventDefault();
-                        }
-                        break;
-
-                    case UP:
-                        if ((options.swipeUp && auto) || (!auto && options.allowPageScroll != VERTICAL)) {
-                            jqEvent.preventDefault();
-                        }
-                        break;
-
-                    case DOWN:
-                        if ((options.swipeDown && auto) || (!auto && options.allowPageScroll != VERTICAL)) {
-                            jqEvent.preventDefault();
-                        }
-                        break;
-                }
-            }
-
-        }
-
-
-        // PINCHES
-        /**
-         * Returns true of the current pinch meets the thresholds
-         * @return Boolean
-         * @inner
-         */
-        function validatePinch() {
-            var hasCorrectFingerCount = validateFingers();
-            var hasEndPoint = validateEndPoint();
-            var hasCorrectDistance = validatePinchDistance();
-            return hasCorrectFingerCount && hasEndPoint && hasCorrectDistance;
-
-        }
-
-        /**
-         * Returns true if any Pinch events have been registered
-         * @return Boolean
-         * @inner
-         */
-        function hasPinches() {
-            //Enure we dont return 0 or null for false values
-            return !!(options.pinchStatus || options.pinchIn || options.pinchOut);
-        }
-
-        /**
-         * Returns true if we are detecting pinches, and have one
-         * @return Boolean
-         * @inner
-         */
-        function didPinch() {
-            //Enure we dont return 0 or null for false values
-            return !!(validatePinch() && hasPinches());
-        }
-
-
-
-
-        // SWIPES
-        /**
-         * Returns true if the current swipe meets the thresholds
-         * @return Boolean
-         * @inner
-         */
-        function validateSwipe() {
-            //Check validity of swipe
-            var hasValidTime = validateSwipeTime();
-            var hasValidDistance = validateSwipeDistance();
-            var hasCorrectFingerCount = validateFingers();
-            var hasEndPoint = validateEndPoint();
-            var didCancel = didSwipeBackToCancel();
-
-            // if the user swiped more than the minimum length, perform the appropriate action
-            // hasValidDistance is null when no distance is set
-            var valid =  !didCancel && hasEndPoint && hasCorrectFingerCount && hasValidDistance && hasValidTime;
-
-            return valid;
-        }
-
-        /**
-         * Returns true if any Swipe events have been registered
-         * @return Boolean
-         * @inner
-         */
-        function hasSwipes() {
-            //Enure we dont return 0 or null for false values
-            return !!(options.swipe || options.swipeStatus || options.swipeLeft || options.swipeRight || options.swipeUp || options.swipeDown);
-        }
-
-
-        /**
-         * Returns true if we are detecting swipes and have one
-         * @return Boolean
-         * @inner
-         */
-        function didSwipe() {
-            //Enure we dont return 0 or null for false values
-            return !!(validateSwipe() && hasSwipes());
-        }
-
-        /**
-         * Returns true if we have matched the number of fingers we are looking for
-         * @return Boolean
-         * @inner
-         */
-        function validateFingers() {
-            //The number of fingers we want were matched, or on desktop we ignore
-            return ((fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !SUPPORTS_TOUCH);
-        }
-
-        /**
-         * Returns true if we have an end point for the swipe
-         * @return Boolean
-         * @inner
-         */
-        function validateEndPoint() {
-            //We have an end value for the finger
-            return fingerData[0].end.x !== 0;
-        }
-
-        // TAP / CLICK
-        /**
-         * Returns true if a click / tap events have been registered
-         * @return Boolean
-         * @inner
-         */
-        function hasTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(options.tap) ;
-        }
-
-        /**
-         * Returns true if a double tap events have been registered
-         * @return Boolean
-         * @inner
-         */
-        function hasDoubleTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(options.doubleTap) ;
-        }
-
-        /**
-         * Returns true if any long tap events have been registered
-         * @return Boolean
-         * @inner
-         */
-        function hasLongTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(options.longTap) ;
-        }
-
-        /**
-         * Returns true if we could be in the process of a double tap (one tap has occurred, we are listening for double taps, and the threshold hasn't past.
-         * @return Boolean
-         * @inner
-         */
-        function validateDoubleTap() {
-            if(doubleTapStartTime==null){
-                return false;
-            }
-            var now = getTimeStamp();
-            return (hasDoubleTap() && ((now-doubleTapStartTime) <= options.doubleTapThreshold));
-        }
-
-        /**
-         * Returns true if we could be in the process of a double tap (one tap has occurred, we are listening for double taps, and the threshold hasn't past.
-         * @return Boolean
-         * @inner
-         */
-        function inDoubleTap() {
-            return validateDoubleTap();
-        }
-
-
-        /**
-         * Returns true if we have a valid tap
-         * @return Boolean
-         * @inner
-         */
-        function validateTap() {
-            return ((fingerCount === 1 || !SUPPORTS_TOUCH) && (isNaN(distance) || distance < options.threshold));
-        }
-
-        /**
-         * Returns true if we have a valid long tap
-         * @return Boolean
-         * @inner
-         */
-        function validateLongTap() {
-            //slight threshold on moving finger
-            return ((duration > options.longTapThreshold) && (distance < DOUBLE_TAP_THRESHOLD));
-        }
-
-        /**
-         * Returns true if we are detecting taps and have one
-         * @return Boolean
-         * @inner
-         */
-        function didTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(validateTap() && hasTap());
-        }
-
-
-        /**
-         * Returns true if we are detecting double taps and have one
-         * @return Boolean
-         * @inner
-         */
-        function didDoubleTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(validateDoubleTap() && hasDoubleTap());
-        }
-
-        /**
-         * Returns true if we are detecting long taps and have one
-         * @return Boolean
-         * @inner
-         */
-        function didLongTap() {
-            //Enure we dont return 0 or null for false values
-            return !!(validateLongTap() && hasLongTap());
-        }
-
-
-
-
-        // MULTI FINGER TOUCH
-        /**
-         * Starts tracking the time between 2 finger releases, and keeps track of how many fingers we initially had up
-         * @inner
-         */
-        function startMultiFingerRelease() {
-            previousTouchEndTime = getTimeStamp();
-            previousTouchFingerCount = event.touches.length+1;
-        }
-
-        /**
-         * Cancels the tracking of time between 2 finger releases, and resets counters
-         * @inner
-         */
-        function cancelMultiFingerRelease() {
-            previousTouchEndTime = 0;
-            previousTouchFingerCount = 0;
-        }
-
-        /**
-         * Checks if we are in the threshold between 2 fingers being released
-         * @return Boolean
-         * @inner
-         */
-        function inMultiFingerRelease() {
-
-            var withinThreshold = false;
-
-            if(previousTouchEndTime) {
-                var diff = getTimeStamp() - previousTouchEndTime
-                if( diff<=options.fingerReleaseThreshold ) {
-                    withinThreshold = true;
-                }
-            }
-
-            return withinThreshold;
-        }
-
-
-        /**
-         * gets a data flag to indicate that a touch is in progress
-         * @return Boolean
-         * @inner
-         */
-        function getTouchInProgress() {
-            //strict equality to ensure only true and false are returned
-            return !!($element.data(PLUGIN_NS+'_intouch') === true);
-        }
-
-        /**
-         * Sets a data flag to indicate that a touch is in progress
-         * @param {boolean} val The value to set the property to
-         * @inner
-         */
-        function setTouchInProgress(val) {
-
-            //Add or remove event listeners depending on touch status
-            if(val===true) {
-                $element.bind(MOVE_EV, touchMove);
-                $element.bind(END_EV, touchEnd);
-
-                //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
-                if(LEAVE_EV) {
-                    $element.bind(LEAVE_EV, touchLeave);
-                }
-            } else {
-                $element.unbind(MOVE_EV, touchMove, false);
-                $element.unbind(END_EV, touchEnd, false);
-
-                //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
-                if(LEAVE_EV) {
-                    $element.unbind(LEAVE_EV, touchLeave, false);
-                }
-            }
-
-
-            //strict equality to ensure only true and false can update the value
-            $element.data(PLUGIN_NS+'_intouch', val === true);
-        }
-
-
-        /**
-         * Creates the finger data for the touch/finger in the event object.
-         * @param {int} index The index in the array to store the finger data (usually the order the fingers were pressed)
-         * @param {object} evt The event object containing finger data
-         * @return finger data object
-         * @inner
-         */
-        function createFingerData( index, evt ) {
-            var id = evt.identifier!==undefined ? evt.identifier : 0;
-
-            fingerData[index].identifier = id;
-            fingerData[index].start.x = fingerData[index].end.x = evt.pageX||evt.clientX;
-            fingerData[index].start.y = fingerData[index].end.y = evt.pageY||evt.clientY;
-
-            return fingerData[index];
-        }
-
-        /**
-         * Updates the finger data for a particular event object
-         * @param {object} evt The event object containing the touch/finger data to upadte
-         * @return a finger data object.
-         * @inner
-         */
-        function updateFingerData(evt) {
-
-            var id = evt.identifier!==undefined ? evt.identifier : 0;
-            var f = getFingerData( id );
-
-            f.end.x = evt.pageX||evt.clientX;
-            f.end.y = evt.pageY||evt.clientY;
-
-            return f;
-        }
-
-        /**
-         * Returns a finger data object by its event ID.
-         * Each touch event has an identifier property, which is used
-         * to track repeat touches
-         * @param {int} id The unique id of the finger in the sequence of touch events.
-         * @return a finger data object.
-         * @inner
-         */
-        function getFingerData( id ) {
-            for(var i=0; i<fingerData.length; i++) {
-                if(fingerData[i].identifier == id) {
-                    return fingerData[i];
-                }
-            }
-        }
-
-        /**
-         * Creats all the finger onjects and returns an array of finger data
-         * @return Array of finger objects
-         * @inner
-         */
-        function createAllFingerData() {
-            var fingerData=[];
-            for (var i=0; i<=5; i++) {
-                fingerData.push({
-                    start:{ x: 0, y: 0 },
-                    end:{ x: 0, y: 0 },
-                    identifier:0
-                });
-            }
-
-            return fingerData;
-        }
-
-        /**
-         * Sets the maximum distance swiped in the given direction.
-         * If the new value is lower than the current value, the max value is not changed.
-         * @param {string}  direction The direction of the swipe
-         * @param {int}  distance The distance of the swipe
-         * @inner
-         */
-        function setMaxDistance(direction, distance) {
-            distance = Math.max(distance, getMaxDistance(direction) );
-            maximumsMap[direction].distance = distance;
-        }
-
-        /**
-         * gets the maximum distance swiped in the given direction.
-         * @param {string}  direction The direction of the swipe
-         * @return int  The distance of the swipe
-         * @inner
-         */
-        function getMaxDistance(direction) {
-            if (maximumsMap[direction]) return maximumsMap[direction].distance;
-            return undefined;
-        }
-
-        /**
-         * Creats a map of directions to maximum swiped values.
-         * @return Object A dictionary of maximum values, indexed by direction.
-         * @inner
-         */
-        function createMaximumsData() {
-            var maxData={};
-            maxData[LEFT]=createMaximumVO(LEFT);
-            maxData[RIGHT]=createMaximumVO(RIGHT);
-            maxData[UP]=createMaximumVO(UP);
-            maxData[DOWN]=createMaximumVO(DOWN);
-
-            return maxData;
-        }
-
-        /**
-         * Creates a map maximum swiped values for a given swipe direction
-         * @param {string} The direction that these values will be associated with
-         * @return Object Maximum values
-         * @inner
-         */
-        function createMaximumVO(dir) {
-            return {
-                direction:dir,
-                distance:0
-            }
-        }
-
-
-        //
-        // MATHS / UTILS
-        //
-
-        /**
-         * Calculate the duration of the swipe
-         * @return int
-         * @inner
-         */
-        function calculateDuration() {
-            return endTime - startTime;
-        }
-
-        /**
-         * Calculate the distance between 2 touches (pinch)
-         * @param {point} startPoint A point object containing x and y co-ordinates
-         * @param {point} endPoint A point object containing x and y co-ordinates
-         * @return int;
-         * @inner
-         */
-        function calculateTouchesDistance(startPoint, endPoint) {
-            var diffX = Math.abs(startPoint.x - endPoint.x);
-            var diffY = Math.abs(startPoint.y - endPoint.y);
-
-            return Math.round(Math.sqrt(diffX*diffX+diffY*diffY));
-        }
-
-        /**
-         * Calculate the zoom factor between the start and end distances
-         * @param {int} startDistance Distance (between 2 fingers) the user started pinching at
-         * @param {int} endDistance Distance (between 2 fingers) the user ended pinching at
-         * @return float The zoom value from 0 to 1.
-         * @inner
-         */
-        function calculatePinchZoom(startDistance, endDistance) {
-            var percent = (endDistance/startDistance) * 1;
-            return percent.toFixed(2);
-        }
-
-
-        /**
-         * Returns the pinch direction, either IN or OUT for the given points
-         * @return string Either {@link $.fn.swipe.directions.IN} or {@link $.fn.swipe.directions.OUT}
-         * @see $.fn.swipe.directions
-         * @inner
-         */
-        function calculatePinchDirection() {
-            if(pinchZoom<1) {
-                return OUT;
-            }
-            else {
-                return IN;
-            }
-        }
-
-
-        /**
-         * Calculate the length / distance of the swipe
-         * @param {point} startPoint A point object containing x and y co-ordinates
-         * @param {point} endPoint A point object containing x and y co-ordinates
-         * @return int
-         * @inner
-         */
-        function calculateDistance(startPoint, endPoint) {
-            return Math.round(Math.sqrt(Math.pow(endPoint.x - startPoint.x, 2) + Math.pow(endPoint.y - startPoint.y, 2)));
-        }
-
-        /**
-         * Calculate the angle of the swipe
-         * @param {point} startPoint A point object containing x and y co-ordinates
-         * @param {point} endPoint A point object containing x and y co-ordinates
-         * @return int
-         * @inner
-         */
-        function calculateAngle(startPoint, endPoint) {
-            var x = startPoint.x - endPoint.x;
-            var y = endPoint.y - startPoint.y;
-            var r = Math.atan2(y, x); //radians
-            var angle = Math.round(r * 180 / Math.PI); //degrees
-
-            //ensure value is positive
-            if (angle < 0) {
-                angle = 360 - Math.abs(angle);
-            }
-
-            return angle;
-        }
-
-        /**
-         * Calculate the direction of the swipe
-         * This will also call calculateAngle to get the latest angle of swipe
-         * @param {point} startPoint A point object containing x and y co-ordinates
-         * @param {point} endPoint A point object containing x and y co-ordinates
-         * @return string Either {@link $.fn.swipe.directions.LEFT} / {@link $.fn.swipe.directions.RIGHT} / {@link $.fn.swipe.directions.DOWN} / {@link $.fn.swipe.directions.UP}
-         * @see $.fn.swipe.directions
-         * @inner
-         */
-        function calculateDirection(startPoint, endPoint ) {
-            var angle = calculateAngle(startPoint, endPoint);
-
-            if ((angle <= 45) && (angle >= 0)) {
-                return LEFT;
-            } else if ((angle <= 360) && (angle >= 315)) {
-                return LEFT;
-            } else if ((angle >= 135) && (angle <= 225)) {
-                return RIGHT;
-            } else if ((angle > 45) && (angle < 135)) {
-                return DOWN;
-            } else {
-                return UP;
-            }
-        }
-
-
-        /**
-         * Returns a MS time stamp of the current time
-         * @return int
-         * @inner
-         */
-        function getTimeStamp() {
-            var now = new Date();
-            return now.getTime();
-        }
-
-
-
-        /**
-         * Returns a bounds object with left, right, top and bottom properties for the element specified.
-         * @param {DomNode} The DOM node to get the bounds for.
-         */
-        function getbounds( el ) {
-            el = $(el);
-            var offset = el.offset();
-
-            var bounds = {
-                left:offset.left,
-                right:offset.left+el.outerWidth(),
-                top:offset.top,
-                bottom:offset.top+el.outerHeight()
-            }
-
-            return bounds;
-        }
-
-
-        /**
-         * Checks if the point object is in the bounds object.
-         * @param {object} point A point object.
-         * @param {int} point.x The x value of the point.
-         * @param {int} point.y The x value of the point.
-         * @param {object} bounds The bounds object to test
-         * @param {int} bounds.left The leftmost value
-         * @param {int} bounds.right The righttmost value
-         * @param {int} bounds.top The topmost value
-         * @param {int} bounds.bottom The bottommost value
-         */
-        function isInBounds(point, bounds) {
-            return (point.x > bounds.left && point.x < bounds.right && point.y > bounds.top && point.y < bounds.bottom);
-        };
-
-
+      } else {
+        phase = PHASE_CANCEL;
+        triggerHandler(event, phase);
+      }
+
+      if (ret === false) {
+        phase = PHASE_CANCEL;
+        triggerHandler(event, phase);
+      }
     }
 
 
 
 
     /**
-     * A catch all handler that is triggered for all swipe directions.
-     * @name $.fn.swipe#swipe
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Event handler for a touch end event.
+     * Calculate the direction and trigger events
+     * @inner
+     * @param {object} jqEvent The normalised jQuery event object.
      */
+    function touchEnd(jqEvent) {
+      //As we use Jquery bind for events, we need to target the original event object
+      //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+      var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent,
+        touches = event.touches;
 
+      //If we are still in a touch with the device wait a fraction and see if the other finger comes up
+      //if it does within the threshold, then we treat it as a multi release, not a single release and end the touch / swipe
+      if (touches) {
+        if (touches.length && !inMultiFingerRelease()) {
+          startMultiFingerRelease(event);
+          return true;
+        } else if (touches.length && inMultiFingerRelease()) {
+          return true;
+        }
+      }
+
+      //If a previous finger has been released, check how long ago, if within the threshold, then assume it was a multifinger release.
+      //This is used to allow 2 fingers to release fractionally after each other, whilst maintaining the event as containing 2 fingers, not 1
+      if (inMultiFingerRelease()) {
+        fingerCount = fingerCountAtRelease;
+      }
+
+      //Set end of swipe
+      endTime = getTimeStamp();
+
+      //Get duration incase move was never fired
+      duration = calculateDuration();
+
+      //If we trigger handlers at end of swipe OR, we trigger during, but they didnt trigger and we are still in the move phase
+      if (didSwipeBackToCancel() || !validateSwipeDistance()) {
+        phase = PHASE_CANCEL;
+        triggerHandler(event, phase);
+      } else if (options.triggerOnTouchEnd || (options.triggerOnTouchEnd === false && phase === PHASE_MOVE)) {
+        //call this on jq event so we are cross browser
+        if (options.preventDefaultEvents !== false && jqEvent.cancelable !== false) {
+          jqEvent.preventDefault();
+        }
+        phase = PHASE_END;
+        triggerHandler(event, phase);
+      }
+      //Special cases - A tap should always fire on touch end regardless,
+      //So here we manually trigger the tap end handler by itself
+      //We dont run trigger handler as it will re-trigger events that may have fired already
+      else if (!options.triggerOnTouchEnd && hasTap()) {
+        //Trigger the pinch events...
+        phase = PHASE_END;
+        triggerHandlerForGesture(event, phase, TAP);
+      } else if (phase === PHASE_MOVE) {
+        phase = PHASE_CANCEL;
+        triggerHandler(event, phase);
+      }
+
+      setTouchInProgress(false);
+
+      return null;
+    }
 
 
 
     /**
-     * A handler that is triggered for "left" swipes.
-     * @name $.fn.swipe#swipeLeft
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Event handler for a touch cancel event.
+     * Clears current vars
+     * @inner
      */
+    function touchCancel() {
+      // reset the variables back to default values
+      fingerCount = 0;
+      endTime = 0;
+      startTime = 0;
+      startTouchesDistance = 0;
+      endTouchesDistance = 0;
+      pinchZoom = 1;
+
+      //If we were in progress of tracking a possible multi touch end, then re set it.
+      cancelMultiFingerRelease();
+
+      setTouchInProgress(false);
+    }
+
 
     /**
-     * A handler that is triggered for "right" swipes.
-     * @name $.fn.swipe#swipeRight
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Event handler for a touch leave event.
+     * This is only triggered on desktops, in touch we work this out manually
+     * as the touchleave event is not supported in webkit
+     * @inner
      */
+    function touchLeave(jqEvent) {
+      //If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+      var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
+
+      //If we have the trigger on leave property set....
+      if (options.triggerOnTouchLeave) {
+        phase = getNextPhase(PHASE_END);
+        triggerHandler(event, phase);
+      }
+    }
 
     /**
-     * A handler that is triggered for "up" swipes.
-     * @name $.fn.swipe#swipeUp
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Removes all listeners that were associated with the plugin
+     * @inner
      */
+    function removeListeners() {
+      $element.off(START_EV, touchStart);
+      $element.off(CANCEL_EV, touchCancel);
+      $element.off(MOVE_EV, touchMove);
+      $element.off(END_EV, touchEnd);
+
+      //we only have leave events on desktop, we manually calculate leave on touch as its not supported in webkit
+      if (LEAVE_EV) {
+        $element.off(LEAVE_EV, touchLeave);
+      }
+
+      setTouchInProgress(false);
+    }
+
 
     /**
-     * A handler that is triggered for "down" swipes.
-     * @name $.fn.swipe#swipeDown
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Checks if the time and distance thresholds have been met, and if so then the appropriate handlers are fired.
      */
+    function getNextPhase(currentPhase) {
+
+      var nextPhase = currentPhase;
+
+      // Ensure we have valid swipe (under time and over distance  and check if we are out of bound...)
+      var validTime = validateSwipeTime();
+      var validDistance = validateSwipeDistance();
+      var didCancel = didSwipeBackToCancel();
+
+      //If we have exceeded our time, then cancel
+      if (!validTime || didCancel) {
+        nextPhase = PHASE_CANCEL;
+      }
+      //Else if we are moving, and have reached distance then end
+      else if (validDistance && currentPhase == PHASE_MOVE && (!options.triggerOnTouchEnd || options.triggerOnTouchLeave)) {
+        nextPhase = PHASE_END;
+      }
+      //Else if we have ended by leaving and didn't reach distance, then cancel
+      else if (!validDistance && currentPhase == PHASE_END && options.triggerOnTouchLeave) {
+        nextPhase = PHASE_CANCEL;
+      }
+
+      return nextPhase;
+    }
+
 
     /**
-     * A handler triggered for every phase of the swipe. This handler is constantly fired for the duration of the pinch.
-     * This is triggered regardless of swipe thresholds.
-     * @name $.fn.swipe#swipeStatus
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {string} phase The phase of the swipe event. See {@link $.fn.swipe.phases}
-     * @param {string} direction The direction the user swiped in. This is null if the user has yet to move. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user swiped. This is 0 if the user has yet to move.
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {object} fingerData The coordinates of fingers in event
+     * Trigger the relevant event handler
+     * The handlers are passed the original event, the element that was swiped, and in the case of the catch all handler, the direction that was swiped, "left", "right", "up", or "down"
+     * @param {object} event the original event object
+     * @param {string} phase the phase of the swipe (start, end cancel etc) {@link $.fn.swipe.phases}
+     * @inner
      */
+    function triggerHandler(event, phase) {
+
+
+
+      var ret,
+        touches = event.touches;
+
+      // SWIPE GESTURES
+      if (didSwipe() || hasSwipes()) {
+          ret = triggerHandlerForGesture(event, phase, SWIPE);
+      }
+
+      // PINCH GESTURES (if the above didn't cancel)
+      if ((didPinch() || hasPinches()) && ret !== false) {
+          ret = triggerHandlerForGesture(event, phase, PINCH);
+      }
+
+      // CLICK / TAP (if the above didn't cancel)
+      if (didDoubleTap() && ret !== false) {
+        //Trigger the tap events...
+        ret = triggerHandlerForGesture(event, phase, DOUBLE_TAP);
+      }
+
+      // CLICK / TAP (if the above didn't cancel)
+      else if (didLongTap() && ret !== false) {
+        //Trigger the tap events...
+        ret = triggerHandlerForGesture(event, phase, LONG_TAP);
+      }
+
+      // CLICK / TAP (if the above didn't cancel)
+      else if (didTap() && ret !== false) {
+        //Trigger the tap event..
+        ret = triggerHandlerForGesture(event, phase, TAP);
+      }
+
+
+
+      // If we are cancelling the gesture, then manually trigger the reset handler
+      if (phase === PHASE_CANCEL) {
+
+        touchCancel(event);
+      }
+
+
+
+
+      // If we are ending the gesture, then manually trigger the reset handler IF all fingers are off
+      if (phase === PHASE_END) {
+        //If we support touch, then check that all fingers are off before we cancel
+        if (touches) {
+          if (!touches.length) {
+            touchCancel(event);
+          }
+        } else {
+          touchCancel(event);
+        }
+      }
+
+      return ret;
+    }
+
+
 
     /**
-     * A handler triggered for pinch in events.
-     * @name $.fn.swipe#pinchIn
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user pinched
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
-     * @param {object} fingerData The coordinates of fingers in event
+     * Trigger the relevant event handler
+     * The handlers are passed the original event, the element that was swiped, and in the case of the catch all handler, the direction that was swiped, "left", "right", "up", or "down"
+     * @param {object} event the original event object
+     * @param {string} phase the phase of the swipe (start, end cancel etc) {@link $.fn.swipe.phases}
+     * @param {string} gesture the gesture to trigger a handler for : PINCH or SWIPE {@link $.fn.swipe.gestures}
+     * @return Boolean False, to indicate that the event should stop propagation, or void.
+     * @inner
      */
+    function triggerHandlerForGesture(event, phase, gesture) {
+
+      var ret;
+
+      //SWIPES....
+      if (gesture == SWIPE) {
+        //Trigger status every time..
+        $element.trigger('swipeStatus', [phase, direction || null, distance || 0, duration || 0, fingerCount, fingerData, currentDirection]);
+
+        if (options.swipeStatus) {
+          ret = options.swipeStatus.call($element, event, phase, direction || null, distance || 0, duration || 0, fingerCount, fingerData, currentDirection);
+          //If the status cancels, then dont run the subsequent event handlers..
+          if (ret === false) return false;
+        }
+
+        if (phase == PHASE_END && validateSwipe()) {
+
+          //Cancel any taps that were in progress...
+          clearTimeout(singleTapTimeout);
+          clearTimeout(holdTimeout);
+
+          $element.trigger('swipe', [direction, distance, duration, fingerCount, fingerData, currentDirection]);
+
+          if (options.swipe) {
+            ret = options.swipe.call($element, event, direction, distance, duration, fingerCount, fingerData, currentDirection);
+            //If the status cancels, then dont run the subsequent event handlers..
+            if (ret === false) return false;
+          }
+
+          //trigger direction specific event handlers
+          switch (direction) {
+            case LEFT:
+              $element.trigger('swipeLeft', [direction, distance, duration, fingerCount, fingerData, currentDirection]);
+
+              if (options.swipeLeft) {
+                ret = options.swipeLeft.call($element, event, direction, distance, duration, fingerCount, fingerData, currentDirection);
+              }
+              break;
+
+            case RIGHT:
+              $element.trigger('swipeRight', [direction, distance, duration, fingerCount, fingerData, currentDirection]);
+
+              if (options.swipeRight) {
+                ret = options.swipeRight.call($element, event, direction, distance, duration, fingerCount, fingerData, currentDirection);
+              }
+              break;
+
+            case UP:
+              $element.trigger('swipeUp', [direction, distance, duration, fingerCount, fingerData, currentDirection]);
+
+              if (options.swipeUp) {
+                ret = options.swipeUp.call($element, event, direction, distance, duration, fingerCount, fingerData, currentDirection);
+              }
+              break;
+
+            case DOWN:
+              $element.trigger('swipeDown', [direction, distance, duration, fingerCount, fingerData, currentDirection]);
+
+              if (options.swipeDown) {
+                ret = options.swipeDown.call($element, event, direction, distance, duration, fingerCount, fingerData, currentDirection);
+              }
+              break;
+          }
+        }
+      }
+
+
+      //PINCHES....
+      if (gesture == PINCH) {
+        $element.trigger('pinchStatus', [phase, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
+
+        if (options.pinchStatus) {
+          ret = options.pinchStatus.call($element, event, phase, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
+          //If the status cancels, then dont run the subsequent event handlers..
+          if (ret === false) return false;
+        }
+
+        if (phase == PHASE_END && validatePinch()) {
+
+          switch (pinchDirection) {
+            case IN:
+              $element.trigger('pinchIn', [pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
+
+              if (options.pinchIn) {
+                ret = options.pinchIn.call($element, event, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
+              }
+              break;
+
+            case OUT:
+              $element.trigger('pinchOut', [pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData]);
+
+              if (options.pinchOut) {
+                ret = options.pinchOut.call($element, event, pinchDirection || null, pinchDistance || 0, duration || 0, fingerCount, pinchZoom, fingerData);
+              }
+              break;
+          }
+        }
+      }
+
+      if (gesture == TAP) {
+        if (phase === PHASE_CANCEL || phase === PHASE_END) {
+
+          clearTimeout(singleTapTimeout);
+          clearTimeout(holdTimeout);
+
+          //If we are also looking for doubelTaps, wait incase this is one...
+          if (hasDoubleTap() && !inDoubleTap()) {
+            doubleTapStartTime = getTimeStamp();
+
+            //Now wait for the double tap timeout, and trigger this single tap
+            //if its not cancelled by a double tap
+            singleTapTimeout = setTimeout($.proxy(function() {
+              doubleTapStartTime = null;
+              $element.trigger('tap', [event.target]);
+
+              if (options.tap) {
+                ret = options.tap.call($element, event, event.target);
+              }
+            }, this), options.doubleTapThreshold);
+
+          } else {
+            doubleTapStartTime = null;
+            $element.trigger('tap', [event.target]);
+            if (options.tap) {
+              ret = options.tap.call($element, event, event.target);
+            }
+          }
+        }
+      } else if (gesture == DOUBLE_TAP) {
+        if (phase === PHASE_CANCEL || phase === PHASE_END) {
+          clearTimeout(singleTapTimeout);
+          clearTimeout(holdTimeout);
+          doubleTapStartTime = null;
+          $element.trigger('doubletap', [event.target]);
+
+          if (options.doubleTap) {
+            ret = options.doubleTap.call($element, event, event.target);
+          }
+        }
+      } else if (gesture == LONG_TAP) {
+        if (phase === PHASE_CANCEL || phase === PHASE_END) {
+          clearTimeout(singleTapTimeout);
+          doubleTapStartTime = null;
+
+          $element.trigger('longtap', [event.target]);
+          if (options.longTap) {
+            ret = options.longTap.call($element, event, event.target);
+          }
+        }
+      }
+
+      return ret;
+    }
+
+
+    //
+    // GESTURE VALIDATION
+    //
 
     /**
-     * A handler triggered for pinch out events.
-     * @name $.fn.swipe#pinchOut
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user pinched
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
-     * @param {object} fingerData The coordinates of fingers in event
+     * Checks the user has swipe far enough
+     * @return Boolean if <code>threshold</code> has been set, return true if the threshold was met, else false.
+     * If no threshold was set, then we return true.
+     * @inner
      */
+    function validateSwipeDistance() {
+      var valid = true;
+      //If we made it past the min swipe distance..
+      if (options.threshold !== null) {
+        valid = distance >= options.threshold;
+      }
+
+      return valid;
+    }
 
     /**
-     * A handler triggered for all pinch events. This handler is constantly fired for the duration of the pinch. This is triggered regardless of thresholds.
-     * @name $.fn.swipe#pinchStatus
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
-     * @param {int} distance The distance the user pinched
-     * @param {int} duration The duration of the swipe in milliseconds
-     * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
-     * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
-     * @param {object} fingerData The coordinates of fingers in event
+     * Checks the user has swiped back to cancel.
+     * @return Boolean if <code>cancelThreshold</code> has been set, return true if the cancelThreshold was met, else false.
+     * If no cancelThreshold was set, then we return true.
+     * @inner
      */
+    function didSwipeBackToCancel() {
+      var cancelled = false;
+      if (options.cancelThreshold !== null && direction !== null) {
+        cancelled = (getMaxDistance(direction) - distance) >= options.cancelThreshold;
+      }
+
+      return cancelled;
+    }
 
     /**
-     * A click handler triggered when a user simply clicks, rather than swipes on an element.
-     * This is deprecated since version 1.6.2, any assignment to click will be assigned to the tap handler.
-     * You cannot use <code>on</code> to bind to this event as the default jQ <code>click</code> event will be triggered.
-     * Use the <code>tap</code> event instead.
-     * @name $.fn.swipe#click
-     * @event
-     * @deprecated since version 1.6.2, please use {@link $.fn.swipe#tap} instead
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {DomObject} target The element clicked on.
+     * Checks the user has pinched far enough
+     * @return Boolean if <code>pinchThreshold</code> has been set, return true if the threshold was met, else false.
+     * If no threshold was set, then we return true.
+     * @inner
      */
+    function validatePinchDistance() {
+      if (options.pinchThreshold !== null) {
+        return pinchDistance >= options.pinchThreshold;
+      }
+      return true;
+    }
 
     /**
-     * A click / tap handler triggered when a user simply clicks or taps, rather than swipes on an element.
-     * @name $.fn.swipe#tap
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {DomObject} target The element clicked on.
+     * Checks that the time taken to swipe meets the minimum / maximum requirements
+     * @return Boolean
+     * @inner
      */
+    function validateSwipeTime() {
+      var result;
+      //If no time set, then return true
+      if (options.maxTimeThreshold) {
+        if (duration >= options.maxTimeThreshold) {
+          result = false;
+        } else {
+          result = true;
+        }
+      } else {
+        result = true;
+      }
+
+      return result;
+    }
+
 
     /**
-     * A double tap handler triggered when a user double clicks or taps on an element.
-     * You can set the time delay for a double tap with the {@link $.fn.swipe.defaults#doubleTapThreshold} property.
-     * Note: If you set both <code>doubleTap</code> and <code>tap</code> handlers, the <code>tap</code> event will be delayed by the <code>doubleTapThreshold</code>
-     * as the script needs to check if its a double tap.
-     * @name $.fn.swipe#doubleTap
-     * @see  $.fn.swipe.defaults#doubleTapThreshold
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {DomObject} target The element clicked on.
+     * Checks direction of the swipe and the value allowPageScroll to see if we should allow or prevent the default behaviour from occurring.
+     * This will essentially allow page scrolling or not when the user is swiping on a touchSwipe object.
+     * @param {object} jqEvent The normalised jQuery representation of the event object.
+     * @param {string} direction The direction of the event. See {@link $.fn.swipe.directions}
+     * @see $.fn.swipe.directions
+     * @inner
      */
+    function validateDefaultEvent(jqEvent, direction) {
+
+      //If the option is set, allways allow the event to bubble up (let user handle weirdness)
+      if (options.preventDefaultEvents === false) {
+        return;
+      }
+
+      if (options.allowPageScroll === NONE) {
+        jqEvent.preventDefault();
+      } else {
+        var auto = options.allowPageScroll === AUTO;
+
+        switch (direction) {
+          case LEFT:
+            if ((options.swipeLeft && auto) || (!auto && options.allowPageScroll != HORIZONTAL)) {
+              jqEvent.preventDefault();
+            }
+            break;
+
+          case RIGHT:
+            if ((options.swipeRight && auto) || (!auto && options.allowPageScroll != HORIZONTAL)) {
+              jqEvent.preventDefault();
+            }
+            break;
+
+          case UP:
+            if ((options.swipeUp && auto) || (!auto && options.allowPageScroll != VERTICAL)) {
+              jqEvent.preventDefault();
+            }
+            break;
+
+          case DOWN:
+            if ((options.swipeDown && auto) || (!auto && options.allowPageScroll != VERTICAL)) {
+              jqEvent.preventDefault();
+            }
+            break;
+
+          case NONE:
+
+            break;
+        }
+      }
+    }
+
+
+    // PINCHES
+    /**
+     * Returns true of the current pinch meets the thresholds
+     * @return Boolean
+     * @inner
+     */
+    function validatePinch() {
+      var hasCorrectFingerCount = validateFingers();
+      var hasEndPoint = validateEndPoint();
+      var hasCorrectDistance = validatePinchDistance();
+      return hasCorrectFingerCount && hasEndPoint && hasCorrectDistance;
+
+    }
 
     /**
-     * A long tap handler triggered once a tap has been release if the tap was longer than the longTapThreshold.
-     * You can set the time delay for a long tap with the {@link $.fn.swipe.defaults#longTapThreshold} property.
-     * @name $.fn.swipe#longTap
-     * @see  $.fn.swipe.defaults#longTapThreshold
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {DomObject} target The element clicked on.
+     * Returns true if any Pinch events have been registered
+     * @return Boolean
+     * @inner
      */
+    function hasPinches() {
+      //Enure we dont return 0 or null for false values
+      return !!(options.pinchStatus || options.pinchIn || options.pinchOut);
+    }
 
     /**
-     * A hold tap handler triggered as soon as the longTapThreshold is reached
-     * You can set the time delay for a long tap with the {@link $.fn.swipe.defaults#longTapThreshold} property.
-     * @name $.fn.swipe#hold
-     * @see  $.fn.swipe.defaults#longTapThreshold
-     * @event
-     * @default null
-     * @param {EventObject} event The original event object
-     * @param {DomObject} target The element clicked on.
+     * Returns true if we are detecting pinches, and have one
+     * @return Boolean
+     * @inner
      */
+    function didPinch() {
+      //Enure we dont return 0 or null for false values
+      return !!(validatePinch() && hasPinches());
+    }
+
+
+
+
+    // SWIPES
+    /**
+     * Returns true if the current swipe meets the thresholds
+     * @return Boolean
+     * @inner
+     */
+    function validateSwipe() {
+      //Check validity of swipe
+      var hasValidTime = validateSwipeTime();
+      var hasValidDistance = validateSwipeDistance();
+      var hasCorrectFingerCount = validateFingers();
+      var hasEndPoint = validateEndPoint();
+      var didCancel = didSwipeBackToCancel();
+
+      // if the user swiped more than the minimum length, perform the appropriate action
+      // hasValidDistance is null when no distance is set
+      var valid = !didCancel && hasEndPoint && hasCorrectFingerCount && hasValidDistance && hasValidTime;
+
+      return valid;
+    }
+
+    /**
+     * Returns true if any Swipe events have been registered
+     * @return Boolean
+     * @inner
+     */
+    function hasSwipes() {
+      //Enure we dont return 0 or null for false values
+      return !!(options.swipe || options.swipeStatus || options.swipeLeft || options.swipeRight || options.swipeUp || options.swipeDown);
+    }
+
+
+    /**
+     * Returns true if we are detecting swipes and have one
+     * @return Boolean
+     * @inner
+     */
+    function didSwipe() {
+      //Enure we dont return 0 or null for false values
+      return !!(validateSwipe() && hasSwipes());
+    }
+
+    /**
+     * Returns true if we have matched the number of fingers we are looking for
+     * @return Boolean
+     * @inner
+     */
+    function validateFingers() {
+      //The number of fingers we want were matched, or on desktop we ignore
+      return ((fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !SUPPORTS_TOUCH);
+    }
+
+    /**
+     * Returns true if we have an end point for the swipe
+     * @return Boolean
+     * @inner
+     */
+    function validateEndPoint() {
+      //We have an end value for the finger
+      return fingerData[0].end.x !== 0;
+    }
+
+    // TAP / CLICK
+    /**
+     * Returns true if a click / tap events have been registered
+     * @return Boolean
+     * @inner
+     */
+    function hasTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(options.tap);
+    }
+
+    /**
+     * Returns true if a double tap events have been registered
+     * @return Boolean
+     * @inner
+     */
+    function hasDoubleTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(options.doubleTap);
+    }
+
+    /**
+     * Returns true if any long tap events have been registered
+     * @return Boolean
+     * @inner
+     */
+    function hasLongTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(options.longTap);
+    }
+
+    /**
+     * Returns true if we could be in the process of a double tap (one tap has occurred, we are listening for double taps, and the threshold hasn't past.
+     * @return Boolean
+     * @inner
+     */
+    function validateDoubleTap() {
+      if (doubleTapStartTime == null) {
+        return false;
+      }
+      var now = getTimeStamp();
+      return (hasDoubleTap() && ((now - doubleTapStartTime) <= options.doubleTapThreshold));
+    }
+
+    /**
+     * Returns true if we could be in the process of a double tap (one tap has occurred, we are listening for double taps, and the threshold hasn't past.
+     * @return Boolean
+     * @inner
+     */
+    function inDoubleTap() {
+      return validateDoubleTap();
+    }
+
+
+    /**
+     * Returns true if we have a valid tap
+     * @return Boolean
+     * @inner
+     */
+    function validateTap() {
+      return ((fingerCount === 1 || !SUPPORTS_TOUCH) && (isNaN(distance) || distance < options.threshold));
+    }
+
+    /**
+     * Returns true if we have a valid long tap
+     * @return Boolean
+     * @inner
+     */
+    function validateLongTap() {
+      //slight threshold on moving finger
+      return ((duration > options.longTapThreshold) && (distance < DOUBLE_TAP_THRESHOLD));
+    }
+
+    /**
+     * Returns true if we are detecting taps and have one
+     * @return Boolean
+     * @inner
+     */
+    function didTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(validateTap() && hasTap());
+    }
+
+
+    /**
+     * Returns true if we are detecting double taps and have one
+     * @return Boolean
+     * @inner
+     */
+    function didDoubleTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(validateDoubleTap() && hasDoubleTap());
+    }
+
+    /**
+     * Returns true if we are detecting long taps and have one
+     * @return Boolean
+     * @inner
+     */
+    function didLongTap() {
+      //Enure we dont return 0 or null for false values
+      return !!(validateLongTap() && hasLongTap());
+    }
+
+
+
+
+    // MULTI FINGER TOUCH
+    /**
+     * Starts tracking the time between 2 finger releases, and keeps track of how many fingers we initially had up
+     * @inner
+     */
+    function startMultiFingerRelease(event) {
+      previousTouchEndTime = getTimeStamp();
+      fingerCountAtRelease = event.touches.length + 1;
+    }
+
+    /**
+     * Cancels the tracking of time between 2 finger releases, and resets counters
+     * @inner
+     */
+    function cancelMultiFingerRelease() {
+      previousTouchEndTime = 0;
+      fingerCountAtRelease = 0;
+    }
+
+    /**
+     * Checks if we are in the threshold between 2 fingers being released
+     * @return Boolean
+     * @inner
+     */
+    function inMultiFingerRelease() {
+
+      var withinThreshold = false;
+
+      if (previousTouchEndTime) {
+        var diff = getTimeStamp() - previousTouchEndTime
+        if (diff <= options.fingerReleaseThreshold) {
+          withinThreshold = true;
+        }
+      }
+
+      return withinThreshold;
+    }
+
+
+    /**
+     * gets a data flag to indicate that a touch is in progress
+     * @return Boolean
+     * @inner
+     */
+    function getTouchInProgress() {
+      //strict equality to ensure only true and false are returned
+      return !!($element.data(PLUGIN_NS + '_intouch') === true);
+    }
+
+    /**
+     * Sets a data flag to indicate that a touch is in progress
+     * @param {boolean} val The value to set the property to
+     * @inner
+     */
+    function setTouchInProgress(val) {
+
+      //If destroy is called in an event handler, we have no el, and we have already cleaned up, so return.
+      if(!$element) { return; }
+
+      //Add or remove event listeners depending on touch status
+      if (val === true) {
+        $element.on(MOVE_EV, touchMove);
+        $element.on(END_EV, touchEnd);
+
+        //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
+        if (LEAVE_EV) {
+          $element.on(LEAVE_EV, touchLeave);
+        }
+      } else {
+
+        $element.off(MOVE_EV, touchMove, false);
+        $element.off(END_EV, touchEnd, false);
+
+        //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
+        if (LEAVE_EV) {
+          $element.off(LEAVE_EV, touchLeave, false);
+        }
+      }
+
+
+      //strict equality to ensure only true and false can update the value
+      $element.data(PLUGIN_NS + '_intouch', val === true);
+    }
+
+
+    /**
+     * Creates the finger data for the touch/finger in the event object.
+     * @param {int} id The id to store the finger data under (usually the order the fingers were pressed)
+     * @param {object} evt The event object containing finger data
+     * @return finger data object
+     * @inner
+     */
+    function createFingerData(id, evt) {
+      var f = {
+        start: {
+          x: 0,
+          y: 0
+        },
+        last: {
+          x: 0,
+          y: 0
+        },
+        end: {
+          x: 0,
+          y: 0
+        }
+      };
+      f.start.x = f.last.x = f.end.x = evt.pageX || evt.clientX;
+      f.start.y = f.last.y = f.end.y = evt.pageY || evt.clientY;
+      fingerData[id] = f;
+      return f;
+    }
+
+    /**
+     * Updates the finger data for a particular event object
+     * @param {object} evt The event object containing the touch/finger data to upadte
+     * @return a finger data object.
+     * @inner
+     */
+    function updateFingerData(evt) {
+      var id = evt.identifier !== undefined ? evt.identifier : 0;
+      var f = getFingerData(id);
+
+      if (f === null) {
+        f = createFingerData(id, evt);
+      }
+
+      f.last.x = f.end.x;
+      f.last.y = f.end.y;
+
+      f.end.x = evt.pageX || evt.clientX;
+      f.end.y = evt.pageY || evt.clientY;
+
+      return f;
+    }
+
+    /**
+     * Returns a finger data object by its event ID.
+     * Each touch event has an identifier property, which is used
+     * to track repeat touches
+     * @param {int} id The unique id of the finger in the sequence of touch events.
+     * @return a finger data object.
+     * @inner
+     */
+    function getFingerData(id) {
+      return fingerData[id] || null;
+    }
+
+
+    /**
+     * Sets the maximum distance swiped in the given direction.
+     * If the new value is lower than the current value, the max value is not changed.
+     * @param {string}  direction The direction of the swipe
+     * @param {int}  distance The distance of the swipe
+     * @inner
+     */
+    function setMaxDistance(direction, distance) {
+      if(direction==NONE) return;
+      distance = Math.max(distance, getMaxDistance(direction));
+      maximumsMap[direction].distance = distance;
+    }
+
+    /**
+     * gets the maximum distance swiped in the given direction.
+     * @param {string}  direction The direction of the swipe
+     * @return int  The distance of the swipe
+     * @inner
+     */
+    function getMaxDistance(direction) {
+      if (maximumsMap[direction]) return maximumsMap[direction].distance;
+      return undefined;
+    }
+
+    /**
+     * Creats a map of directions to maximum swiped values.
+     * @return Object A dictionary of maximum values, indexed by direction.
+     * @inner
+     */
+    function createMaximumsData() {
+      var maxData = {};
+      maxData[LEFT] = createMaximumVO(LEFT);
+      maxData[RIGHT] = createMaximumVO(RIGHT);
+      maxData[UP] = createMaximumVO(UP);
+      maxData[DOWN] = createMaximumVO(DOWN);
+
+      return maxData;
+    }
+
+    /**
+     * Creates a map maximum swiped values for a given swipe direction
+     * @param {string} The direction that these values will be associated with
+     * @return Object Maximum values
+     * @inner
+     */
+    function createMaximumVO(dir) {
+      return {
+        direction: dir,
+        distance: 0
+      }
+    }
+
+
+    //
+    // MATHS / UTILS
+    //
+
+    /**
+     * Calculate the duration of the swipe
+     * @return int
+     * @inner
+     */
+    function calculateDuration() {
+      return endTime - startTime;
+    }
+
+    /**
+     * Calculate the distance between 2 touches (pinch)
+     * @param {point} startPoint A point object containing x and y co-ordinates
+     * @param {point} endPoint A point object containing x and y co-ordinates
+     * @return int;
+     * @inner
+     */
+    function calculateTouchesDistance(startPoint, endPoint) {
+      var diffX = Math.abs(startPoint.x - endPoint.x);
+      var diffY = Math.abs(startPoint.y - endPoint.y);
+
+      return Math.round(Math.sqrt(diffX * diffX + diffY * diffY));
+    }
+
+    /**
+     * Calculate the zoom factor between the start and end distances
+     * @param {int} startDistance Distance (between 2 fingers) the user started pinching at
+     * @param {int} endDistance Distance (between 2 fingers) the user ended pinching at
+     * @return float The zoom value from 0 to 1.
+     * @inner
+     */
+    function calculatePinchZoom(startDistance, endDistance) {
+      var percent = (endDistance / startDistance) * 1;
+      return percent.toFixed(2);
+    }
+
+
+    /**
+     * Returns the pinch direction, either IN or OUT for the given points
+     * @return string Either {@link $.fn.swipe.directions.IN} or {@link $.fn.swipe.directions.OUT}
+     * @see $.fn.swipe.directions
+     * @inner
+     */
+    function calculatePinchDirection() {
+      if (pinchZoom < 1) {
+        return OUT;
+      } else {
+        return IN;
+      }
+    }
+
+
+    /**
+     * Calculate the length / distance of the swipe
+     * @param {point} startPoint A point object containing x and y co-ordinates
+     * @param {point} endPoint A point object containing x and y co-ordinates
+     * @return int
+     * @inner
+     */
+    function calculateDistance(startPoint, endPoint) {
+      return Math.round(Math.sqrt(Math.pow(endPoint.x - startPoint.x, 2) + Math.pow(endPoint.y - startPoint.y, 2)));
+    }
+
+    /**
+     * Calculate the angle of the swipe
+     * @param {point} startPoint A point object containing x and y co-ordinates
+     * @param {point} endPoint A point object containing x and y co-ordinates
+     * @return int
+     * @inner
+     */
+    function calculateAngle(startPoint, endPoint) {
+      var x = startPoint.x - endPoint.x;
+      var y = endPoint.y - startPoint.y;
+      var r = Math.atan2(y, x); //radians
+      var angle = Math.round(r * 180 / Math.PI); //degrees
+
+      //ensure value is positive
+      if (angle < 0) {
+        angle = 360 - Math.abs(angle);
+      }
+
+      return angle;
+    }
+
+    /**
+     * Calculate the direction of the swipe
+     * This will also call calculateAngle to get the latest angle of swipe
+     * @param {point} startPoint A point object containing x and y co-ordinates
+     * @param {point} endPoint A point object containing x and y co-ordinates
+     * @return string Either {@link $.fn.swipe.directions.LEFT} / {@link $.fn.swipe.directions.RIGHT} / {@link $.fn.swipe.directions.DOWN} / {@link $.fn.swipe.directions.UP}
+     * @see $.fn.swipe.directions
+     * @inner
+     */
+    function calculateDirection(startPoint, endPoint) {
+
+      if( comparePoints(startPoint, endPoint) ) {
+        return NONE;
+      }
+
+      var angle = calculateAngle(startPoint, endPoint);
+
+      if ((angle <= 45) && (angle >= 0)) {
+        return LEFT;
+      } else if ((angle <= 360) && (angle >= 315)) {
+        return LEFT;
+      } else if ((angle >= 135) && (angle <= 225)) {
+        return RIGHT;
+      } else if ((angle > 45) && (angle < 135)) {
+        return DOWN;
+      } else {
+        return UP;
+      }
+    }
+
+
+    /**
+     * Returns a MS time stamp of the current time
+     * @return int
+     * @inner
+     */
+    function getTimeStamp() {
+      var now = new Date();
+      return now.getTime();
+    }
+
+
+
+    /**
+     * Returns a bounds object with left, right, top and bottom properties for the element specified.
+     * @param {DomNode} The DOM node to get the bounds for.
+     */
+    function getbounds(el) {
+      el = $(el);
+      var offset = el.offset();
+
+      var bounds = {
+        left: offset.left,
+        right: offset.left + el.outerWidth(),
+        top: offset.top,
+        bottom: offset.top + el.outerHeight()
+      }
+
+      return bounds;
+    }
+
+
+    /**
+     * Checks if the point object is in the bounds object.
+     * @param {object} point A point object.
+     * @param {int} point.x The x value of the point.
+     * @param {int} point.y The x value of the point.
+     * @param {object} bounds The bounds object to test
+     * @param {int} bounds.left The leftmost value
+     * @param {int} bounds.right The righttmost value
+     * @param {int} bounds.top The topmost value
+     * @param {int} bounds.bottom The bottommost value
+     */
+    function isInBounds(point, bounds) {
+      return (point.x > bounds.left && point.x < bounds.right && point.y > bounds.top && point.y < bounds.bottom);
+    };
+
+    /**
+     * Checks if the two points are equal
+     * @param {object} point A point object.
+     * @param {object} point B point object.
+     * @return true of the points match
+     */
+    function comparePoints(pointA, pointB) {
+      return (pointA.x == pointB.x && pointA.y == pointB.y);
+    }
+
+
+  }
+
+
+
+
+  /**
+   * A catch all handler that is triggered for all swipe directions.
+   * @name $.fn.swipe#swipe
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+
+
+
+  /**
+   * A handler that is triggered for "left" swipes.
+   * @name $.fn.swipe#swipeLeft
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+  /**
+   * A handler that is triggered for "right" swipes.
+   * @name $.fn.swipe#swipeRight
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+  /**
+   * A handler that is triggered for "up" swipes.
+   * @name $.fn.swipe#swipeUp
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+  /**
+   * A handler that is triggered for "down" swipes.
+   * @name $.fn.swipe#swipeDown
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user swiped in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+  /**
+   * A handler triggered for every phase of the swipe. This handler is constantly fired for the duration of the pinch.
+   * This is triggered regardless of swipe thresholds.
+   * @name $.fn.swipe#swipeStatus
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {string} phase The phase of the swipe event. See {@link $.fn.swipe.phases}
+   * @param {string} direction The direction the user swiped in. This is null if the user has yet to move. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user swiped. This is 0 if the user has yet to move.
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {object} fingerData The coordinates of fingers in event
+   * @param {string} currentDirection The current direction the user is swiping.
+   */
+
+  /**
+   * A handler triggered for pinch in events.
+   * @name $.fn.swipe#pinchIn
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user pinched
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
+   * @param {object} fingerData The coordinates of fingers in event
+   */
+
+  /**
+   * A handler triggered for pinch out events.
+   * @name $.fn.swipe#pinchOut
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user pinched
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
+   * @param {object} fingerData The coordinates of fingers in event
+   */
+
+  /**
+   * A handler triggered for all pinch events. This handler is constantly fired for the duration of the pinch. This is triggered regardless of thresholds.
+   * @name $.fn.swipe#pinchStatus
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {int} direction The direction the user pinched in. See {@link $.fn.swipe.directions}
+   * @param {int} distance The distance the user pinched
+   * @param {int} duration The duration of the swipe in milliseconds
+   * @param {int} fingerCount The number of fingers used. See {@link $.fn.swipe.fingers}
+   * @param {int} zoom The zoom/scale level the user pinched too, 0-1.
+   * @param {object} fingerData The coordinates of fingers in event
+   */
+
+  /**
+   * A click handler triggered when a user simply clicks, rather than swipes on an element.
+   * This is deprecated since version 1.6.2, any assignment to click will be assigned to the tap handler.
+   * You cannot use <code>on</code> to bind to this event as the default jQ <code>click</code> event will be triggered.
+   * Use the <code>tap</code> event instead.
+   * @name $.fn.swipe#click
+   * @event
+   * @deprecated since version 1.6.2, please use {@link $.fn.swipe#tap} instead
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {DomObject} target The element clicked on.
+   */
+
+  /**
+   * A click / tap handler triggered when a user simply clicks or taps, rather than swipes on an element.
+   * @name $.fn.swipe#tap
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {DomObject} target The element clicked on.
+   */
+
+  /**
+   * A double tap handler triggered when a user double clicks or taps on an element.
+   * You can set the time delay for a double tap with the {@link $.fn.swipe.defaults#doubleTapThreshold} property.
+   * Note: If you set both <code>doubleTap</code> and <code>tap</code> handlers, the <code>tap</code> event will be delayed by the <code>doubleTapThreshold</code>
+   * as the script needs to check if its a double tap.
+   * @name $.fn.swipe#doubleTap
+   * @see  $.fn.swipe.defaults#doubleTapThreshold
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {DomObject} target The element clicked on.
+   */
+
+  /**
+   * A long tap handler triggered once a tap has been release if the tap was longer than the longTapThreshold.
+   * You can set the time delay for a long tap with the {@link $.fn.swipe.defaults#longTapThreshold} property.
+   * @name $.fn.swipe#longTap
+   * @see  $.fn.swipe.defaults#longTapThreshold
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {DomObject} target The element clicked on.
+   */
+
+  /**
+   * A hold tap handler triggered as soon as the longTapThreshold is reached
+   * You can set the time delay for a long tap with the {@link $.fn.swipe.defaults#longTapThreshold} property.
+   * @name $.fn.swipe#hold
+   * @see  $.fn.swipe.defaults#longTapThreshold
+   * @event
+   * @default null
+   * @param {EventObject} event The original event object
+   * @param {DomObject} target The element clicked on.
+   */
 
 }));


### PR DESCRIPTION
Resolves #999.

The updated version now allows for Windows computers with touchscreens to work and the amount of scroll required to proceed has been slightly reduced. Unfortunately, you're still unable to scroll vertically after touching and holding an item and I wasn't able to find any PR that resolved that. We'll likely need to switch a different library or fork that one to resolve that. Overall, the improvements in the newer version are still worth updating for.

I tested the updated version on Windows, Android, and iPad (I don't currently have an iPhone on hand).