### PR TITLE
Prevent pagination inline-block element spaces

### DIFF
--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -109,6 +109,7 @@
 	.sow-slider-pagination {
 		bottom: 20px;
 		.box-sizing(border-box);
+		font-size: 0;
 		list-style: none;
 		left: 0;
 		line-height: 11px;
@@ -122,8 +123,13 @@
 
 		li {
 			display: inline-block;
+			font-size: 1em;
 			text-align: left;
-			margin: 0;
+			margin: 0 4px 0 0;
+
+			&:last-of-type {
+				margin-right: 0;
+			}
 
 			a {
 				background: #fff;


### PR DESCRIPTION
Resolves #1005.

Pagination spacing relies on the extra space created between inline-block elements. If a user enables HTML optimization in a plugin like AO those spaces will be removed when the HTML is minimized and the new lines are removed.

It isn’t necessary to reset the font size for the list items but I did it anyway.

According to this page https://stackoverflow.com/questions/5078239/how-do-i-remove-the-space-between-inline-block-elements the method I’ve used is compatible as follows:

This works in recent versions of all modern browsers. It works in IE8. It does not work in Safari 5, but it does work in Safari 6. Safari 5 is nearly a dead browser (0.33%, August 2015).

Another option would be to format our HTML so that each list item for the pagination is on the same line.