### PR TITLE
Simple Masonry Preloader

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -6,7 +6,7 @@ jQuery( function ( $ ) {
 	sowb.setupSimpleMasonries = function () {
 		var $grid = $( '.sow-masonry-grid' );
 		
-		if ( !$grid.is( ':visible' ) || $grid.data( 'initialized' ) ) {
+		if ( $grid.data( 'initialized' ) ) {
 			return $grid;
 		}
 		
@@ -60,6 +60,13 @@ jQuery( function ( $ ) {
 							$img.css( 'margin-top', marginTop + 'px' );
 						}
 					} );
+
+					// If preloader is visble, hide and show masonry
+					if ( ! $grid.is( ':visible' ) ) {
+						$grid.prev().remove()
+						$grid.show();
+					}
+
 					$gridEl.packery( {
 						itemSelector: '.sow-masonry-grid-item',
 						columnWidth: columnWidth,
@@ -74,10 +81,6 @@ jQuery( function ( $ ) {
 		// Ensure that the masonry has resized correctly on load.
 		setTimeout( function () {
 			resizeMasonry();
-
-			// Hide preloader and show masonry
-			$grid.prev().remove()
-			$grid.show();
 		}, 100 );
 		
 		$grid.data( 'initialized', true );

--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -61,17 +61,17 @@ jQuery( function ( $ ) {
 						}
 					} );
 
-					// If preloader is visble, hide and show masonry
-					if ( ! $grid.is( ':visible' ) ) {
-						$grid.prev().remove()
-						$grid.show();
-					}
-
 					$gridEl.packery( {
 						itemSelector: '.sow-masonry-grid-item',
 						columnWidth: columnWidth,
 						gutter: layout.gutter
 					} );
+
+					// If preloader is present, remove and show masonry
+					if ( $grid.prev( '.sow-masonry-grid-preloader' ).length ) {
+						$grid.prev().remove()
+						$grid.css( 'opacity', 1 );
+					}
 				} );
 			} );
 		};

--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -74,6 +74,10 @@ jQuery( function ( $ ) {
 		// Ensure that the masonry has resized correctly on load.
 		setTimeout( function () {
 			resizeMasonry();
+
+			// Hide preloader and show masonry
+			$grid.prev().remove()
+			$grid.show();
 		}, 100 );
 		
 		$grid.data( 'initialized', true );

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -190,18 +190,18 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 				'fields' => array(
 					'enabled' => array(
 						'type' => 'checkbox',
-						'label' => __( 'Show preloader ', 'so-widgets-bundle')
+						'label' => __( 'Enable preloader', 'so-widgets-bundle')
 					),
 					'color' => array(
 						'type' => 'color',
-						'label' => __( 'Preloader color', 'so-widgets-bundle'),
 						'default' => '#000'
+						'label' => __( 'Preloader icon color', 'so-widgets-bundle'),
 					),
 					'height' => array(
 						'type' => 'measurement',
 						'label' => __( 'Preloader height', 'so-widgets-bundle'),
 						'default' => '250px',
-						'description' => __( 'The size of the preloader prior to your Masonry Images showing', 'so-widgets-bundle')
+						'description' => __( 'The size of the preloader prior to the Masonry images showing.', 'so-widgets-bundle')
 					)
 				)
 			)

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -190,18 +190,18 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 				'fields' => array(
 					'enabled' => array(
 						'type' => 'checkbox',
-						'label' => __( 'Enable preloader', 'so-widgets-bundle')
+						'label' => __( 'Enable preloader', 'so-widgets-bundle' )
 					),
 					'color' => array(
 						'type' => 'color',
-						'label' => __( 'Preloader icon color', 'so-widgets-bundle'),
+						'label' => __( 'Preloader icon color', 'so-widgets-bundle' ),
 						'default' => '#232323'
 					),
 					'height' => array(
 						'type' => 'measurement',
-						'label' => __( 'Preloader height', 'so-widgets-bundle'),
+						'label' => __( 'Preloader height', 'so-widgets-bundle' ),
 						'default' => '250px',
-						'description' => __( 'The size of the preloader prior to the Masonry images showing.', 'so-widgets-bundle')
+						'description' => __( 'The size of the preloader prior to the Masonry images showing.', 'so-widgets-bundle' )
 					)
 				)
 			)

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -182,6 +182,28 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 						'default' => 0
 					)
 				)
+			),
+			'preloader' => array(
+				'type' => 'section',
+				'label' => __( 'Preloader', 'so-widgets-bundle' ),
+				'hide' => true,
+				'fields' => array(
+					'enabled' => array(
+						'type' => 'checkbox',
+						'label' => __( 'Show preloader ', 'so-widgets-bundle')
+					),
+					'color' => array(
+						'type' => 'color',
+						'label' => __( 'Preloader color', 'so-widgets-bundle'),
+						'default' => '#000'
+					),
+					'height' => array(
+						'type' => 'measurement',
+						'label' => __( 'Preloader height', 'so-widgets-bundle'),
+						'default' => '250px',
+						'description' => __( 'The size of the preloader prior to your Masonry Images showing', 'so-widgets-bundle')
+					)
+				)
 			)
 		);
 	}
@@ -201,6 +223,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 		return array(
 			'args' => $args,
 			'items' => $items,
+			'preloader_enabled' => ! empty( $instance['preloader']['enabled'] ) ? true : false,
 			'layouts' => array(
 				'desktop' => siteorigin_widgets_underscores_to_camel_case(
 					array(
@@ -228,6 +251,19 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 			)
 		);
 	}
+
+	public function get_less_variables( $instance ) {
+		if ( empty( $instance['preloader'] ) || ! $instance['preloader']['enabled'] ) {
+			return array();
+		}
+		
+		return array(
+			'preloader_enabled' => 'true',
+			'preloader_height' => $instance['preloader']['height'],
+			'preloader_color' => $instance['preloader']['color']
+		);
+	}
+	
 
 	function get_form_teaser(){
 		if( class_exists( 'SiteOrigin_Premium' ) ) return false;

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -194,8 +194,8 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 					),
 					'color' => array(
 						'type' => 'color',
-						'default' => '#000'
 						'label' => __( 'Preloader icon color', 'so-widgets-bundle'),
+						'default' => '#232323'
 					),
 					'height' => array(
 						'type' => 'measurement',

--- a/widgets/simple-masonry/styles/default.less
+++ b/widgets/simple-masonry/styles/default.less
@@ -1,3 +1,6 @@
+.sow-masonry-grid {
+	display: none;
+}
 
 .sow-masonry-grid-item {
     overflow: hidden;
@@ -6,4 +9,42 @@
         display: block;
         max-width: inherit;
     }
+}
+
+.sow-masonry-grid-preloader {
+	display: inline-block;
+	position: relative;
+	width: 80px;
+	height: 80px;
+	div {
+		box-sizing: border-box;
+		display: block;
+		position: absolute;
+		width: 64px;
+		height: 64px;
+		margin: 8px;
+		border: 8px solid #000;
+		border-radius: 50%;
+		animation: sow-masonry-preloader 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+		border-color: #000 transparent transparent transparent;
+
+		&:nth-child(1) {
+		  animation-delay: -0.45s;
+		}
+		&:nth-child(2) {
+		  animation-delay: -0.3s;
+		}
+		&:nth-child(3) {
+		  animation-delay: -0.15s;
+		}
+	}
+}
+
+@keyframes sow-masonry-preloader {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/widgets/simple-masonry/styles/default.less
+++ b/widgets/simple-masonry/styles/default.less
@@ -28,10 +28,10 @@
 			box-sizing: border-box;
 			display: block;
 			position: absolute;
-			width: 64px;
-			height: 64px;
+			width: 30px;
+			height: 30px;
 			margin: 8px;
-			border: 8px solid @preloader_color;
+			border: 2px solid @preloader_color;
 			border-radius: 50%;
 			animation: sow-masonry-preloader 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
 			border-color: @preloader_color transparent transparent transparent;

--- a/widgets/simple-masonry/styles/default.less
+++ b/widgets/simple-masonry/styles/default.less
@@ -1,6 +1,6 @@
-.sow-masonry-grid {
-	display: none;
-}
+@preloader_enabled: false;
+@preloader_height: 250px;
+@preloader_color: #000;
 
 .sow-masonry-grid-item {
     overflow: hidden;
@@ -11,40 +11,49 @@
     }
 }
 
-.sow-masonry-grid-preloader {
-	display: inline-block;
-	position: relative;
-	width: 80px;
-	height: 80px;
-	div {
-		box-sizing: border-box;
-		display: block;
-		position: absolute;
-		width: 64px;
-		height: 64px;
-		margin: 8px;
-		border: 8px solid #000;
-		border-radius: 50%;
-		animation: sow-masonry-preloader 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-		border-color: #000 transparent transparent transparent;
+& when ( @preloader_enabled = true ) {
+	.sow-masonry-grid {
+		display: none;
+	}
 
-		&:nth-child(1) {
-		  animation-delay: -0.45s;
-		}
-		&:nth-child(2) {
-		  animation-delay: -0.3s;
-		}
-		&:nth-child(3) {
-		  animation-delay: -0.15s;
+	.sow-masonry-grid-preloader {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		width: 100%;
+		height: @preloader_height;
+
+		div {
+			box-sizing: border-box;
+			display: block;
+			position: absolute;
+			width: 64px;
+			height: 64px;
+			margin: 8px;
+			border: 8px solid @preloader_color;
+			border-radius: 50%;
+			animation: sow-masonry-preloader 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+			border-color: @preloader_color transparent transparent transparent;
+
+			&:nth-child(1) {
+			  animation-delay: -0.45s;
+			}
+			&:nth-child(2) {
+			  animation-delay: -0.3s;
+			}
+			&:nth-child(3) {
+			  animation-delay: -0.15s;
+			}
 		}
 	}
-}
 
-@keyframes sow-masonry-preloader {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+	@keyframes sow-masonry-preloader {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
 }

--- a/widgets/simple-masonry/styles/default.less
+++ b/widgets/simple-masonry/styles/default.less
@@ -13,7 +13,7 @@
 
 & when ( @preloader_enabled = true ) {
 	.sow-masonry-grid {
-		display: none;
+		opacity: 0;
 	}
 
 	.sow-masonry-grid-preloader {

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -12,7 +12,7 @@
 	<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
 <?php endif; ?>
 <div class="sow-masonry-grid"
-	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" <?php echo ! empty( $preloader_enabled ) ? 'style="display: none;">' : ''; ?>
+	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" <?php echo ! empty( $preloader_enabled ) ? 'style="opacity: 0;"' : ''; ?>>
 	<?php
 	if( ! empty( $items ) ) {
 		foreach ( $items as $item ) {

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -8,10 +8,11 @@
 
 <?php if( !empty( $instance['widget_title'] ) ) echo $args['before_title'] . esc_html( $instance['widget_title'] ) . $args['after_title'] ?>
 
-<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
-
+<?php if ( $preloader_enabled ): ?>
+	<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
+<?php endif; ?>
 <div class="sow-masonry-grid"
-	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" style="display: none;">
+	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" <?php echo ! empty( $preloader_enabled ) ? 'style="display: none;">' : ''; ?>
 	<?php
 	if( ! empty( $items ) ) {
 		foreach ( $items as $item ) {

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -8,7 +8,7 @@
 
 <?php if( !empty( $instance['widget_title'] ) ) echo $args['before_title'] . esc_html( $instance['widget_title'] ) . $args['after_title'] ?>
 
-<?php if ( $preloader_enabled ): ?>
+<?php if ( $preloader_enabled ) : ?>
 	<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
 <?php endif; ?>
 <div class="sow-masonry-grid"

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -8,8 +8,10 @@
 
 <?php if( !empty( $instance['widget_title'] ) ) echo $args['before_title'] . esc_html( $instance['widget_title'] ) . $args['after_title'] ?>
 
+<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
+
 <div class="sow-masonry-grid"
-	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>">
+	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" style="display: none;">
 	<?php
 	if( ! empty( $items ) ) {
 		foreach ( $items as $item ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1023

This PR adds a preloader to the Simple Masonry widget. This prevents an issue where the images display at full size before they've finished loading and then are resized into a Masonry.

Note: you'll need to clear wp-content/uploads/siteorigin-widgets or create a new widget due to the CSS cache not being cleared when plugin files are manually replaced.