### PR TITLE
Prevent media field overflow

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -25,6 +25,7 @@
 			.box-sizing(border-box);
 			float: left;
 			height: 32px;
+			overflow: hidden;
 			padding: 4px;
 			position: relative;
 


### PR DESCRIPTION
To replicate this issue, insert a Simple Masonry widget and insert an image with a long title. Next, carefully hover over the thumbnail in the media field, notice the scrollbar.

![Screenshot 2020-04-23 at 14 16 41](https://user-images.githubusercontent.com/789159/80098755-b1415600-856d-11ea-8242-110d8ea6adbc.png)

This PR prevents the scrollbar from appearing.