### PR TITLE
Changed widget remove icon v-align to baseline

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -221,7 +221,6 @@
 
 			&:before {
 				font-family: dashicons;
-				vertical-align: baseline;
 				color: #999999;
 			}
 

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -221,7 +221,7 @@
 
 			&:before {
 				font-family: dashicons;
-				vertical-align: middle;
+				vertical-align: baseline;
 				color: #999999;
 			}
 


### PR DESCRIPTION
Currently, the repeater remove icon hover looks as follows:

![hover](https://user-images.githubusercontent.com/789159/80867301-d6337880-8c93-11ea-9c18-e95cfcb3edab.png)

Note the alignment, it's correct. This PR corrects that issue. I'm not seeing any negatives from this change, can you, Alex?
