### PR TITLE
Testimonial: Resolve Alignment issues and stretch testimonials

### DIFF
--- a/widgets/testimonial/css/style.less
+++ b/widgets/testimonial/css/style.less
@@ -1,16 +1,23 @@
 @import "../../../base/less/mixins";
 
 .sow-testimonials {
-	margin: -10px;
-	.clearfix();
+	align-self: stretch;
+	display: flex;
+	flex-wrap: wrap;
 
 	* {
 		box-sizing: border-box;
 	}
 
 	.sow-testimonial-wrapper {
-		float: left;
+		display: flex;
 		padding: 10px;
+
+		&.sow-layout-side {
+			.sow-testimonial, .sow-testimonial-text {
+				display: flex;
+			}
+		}
 	}
 
 	.sow-testimonial-user {
@@ -61,6 +68,10 @@
 	.sow-user-right {
 		.sow-testimonial-user {
 			text-align: right;
+		}
+
+		.sow-testimonial {
+			flex-direction: row-reverse;
 		}
 	}
 

--- a/widgets/testimonial/css/style.less
+++ b/widgets/testimonial/css/style.less
@@ -1,7 +1,6 @@
 @import "../../../base/less/mixins";
 
 .sow-testimonials {
-	align-self: stretch;
 	display: flex;
 	flex-wrap: wrap;
 
@@ -10,7 +9,6 @@
 	}
 
 	.sow-testimonial-wrapper {
-		display: flex;
 		padding: 10px;
 
 		&.sow-layout-side {

--- a/widgets/testimonial/css/style.less
+++ b/widgets/testimonial/css/style.less
@@ -11,10 +11,8 @@
 	.sow-testimonial-wrapper {
 		padding: 10px;
 
-		&.sow-layout-side {
-			.sow-testimonial, .sow-testimonial-text {
-				display: flex;
-			}
+		&.sow-layout-side .sow-testimonial {
+			display: flex;
 		}
 	}
 

--- a/widgets/testimonial/css/style.less
+++ b/widgets/testimonial/css/style.less
@@ -62,6 +62,14 @@
 	}
 
 	.sow-user-right {
+		.sow-image-wrapper {
+			float: right;
+		}
+
+		.sow-text {
+			clear: both;
+		}
+
 		.sow-testimonial-user {
 			text-align: right;
 		}
@@ -72,6 +80,10 @@
 	}
 
 	.sow-user-middle {
+		.sow-image-wrapper {
+			margin: 0 auto;
+		}
+
 		.sow-testimonial-user {
 			text-align: center;
 		}

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -122,9 +122,6 @@
 					}
 				}
 
-				.sow-testimonial-text {
-					margin-left: 33%;
-				}
 			}
 
 			&.sow-user-right {
@@ -139,10 +136,6 @@
 						max-width: 100%;
 						height: auto;
 					}
-				}
-
-				.sow-testimonial-text {
-					margin-right: 33%;
 				}
 
 			}

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -113,15 +113,13 @@
 			  display: flex;
 
 			}
-			&.sow-layout-text-above .sow-testimonial {
-			  flex-direction: column;
+			&.sow-layout-text-above,
+			&.sow-layout-text-below {
+				.sow-testimonial {
+
+					flex-direction: column;
+				}
 			}
-
-
-			&.sow-layout-text-below .sow-testimonial {
-			  flex-direction: column-reverse;
-			}
-
 			
 			.sow-testimonial-text {
 				display: flex;
@@ -130,7 +128,6 @@
 		}
 
 		&.sow-layout-side {
-
 			&.sow-user-left,
 			&.sow-user-middle {
 				.sow-testimonial-user {

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -8,6 +8,7 @@
 @text_background: #f0f0f0;
 @text_color: #666;
 @text_border_radius: 4px;
+@equalize_testimonial_height: default;
 
 @title_font_family: default;
 @title_font_weight: default;
@@ -105,7 +106,10 @@
 	// All the specific layouts
 
 	.sow-testimonial-wrapper {
-		.clearfix();
+		& when (@equalize_testimonial_height = true) {
+			display: flex;
+			display: @equalize_testimonial_height;
+		}
 
 		&.sow-layout-side {
 

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -108,7 +108,25 @@
 	.sow-testimonial-wrapper {
 		& when (@equalize_testimonial_height = true) {
 			display: flex;
-			display: @equalize_testimonial_height;
+
+			.sow-testimonial {
+			  display: flex;
+
+			}
+			&.sow-layout-text-above .sow-testimonial {
+			  flex-direction: column;
+			}
+
+
+			&.sow-layout-text-below .sow-testimonial {
+			  flex-direction: column-reverse;
+			}
+
+			
+			.sow-testimonial-text {
+				display: flex;
+				height: 100%;
+			}
 		}
 
 		&.sow-layout-side {

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -317,7 +317,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			'testimonial_size' => round(100/$instance['settings']['per_line'], 4) . '%',
 			'testimonial_padding' => intval($instance['design']['padding']) . 'px',
 			'testimonial_background' => $instance['design']['colors']['testimonial_background'],
-			'equalize_testimonial_height' => $instance['design']['equalize_testimonial_height'],
+			'equalize_testimonial_height' => ! empty( $instance['design']['equalize_testimonial_height'] ) ? 'true' : 'false',
 
 			// The text block
 			'text_border_radius' => intval($instance['design']['border_radius']) . 'px',

--- a/widgets/testimonial/testimonial.php
+++ b/widgets/testimonial/testimonial.php
@@ -269,6 +269,11 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 						),
 						'default' => 'side',
 					),
+
+					'equalize_testimonial_height' => array(
+						'type' => 'checkbox',
+						'label' => __('Equalize testimonial height', 'so-widgets-bundle'),
+					),
 				),
 			),
 		);
@@ -312,6 +317,7 @@ class SiteOrigin_Widgets_Testimonials_Widget extends SiteOrigin_Widget {
 			'testimonial_size' => round(100/$instance['settings']['per_line'], 4) . '%',
 			'testimonial_padding' => intval($instance['design']['padding']) . 'px',
 			'testimonial_background' => $instance['design']['colors']['testimonial_background'],
+			'equalize_testimonial_height' => $instance['design']['equalize_testimonial_height'],
 
 			// The text block
 			'text_border_radius' => intval($instance['design']['border_radius']) . 'px',


### PR DESCRIPTION
Resolve #1035

This PR will prevent an issue where larger Testimonials on the previous row can cause alignment issues on the next. It will also stretch the testimonials so that they're all same height.

Here's a screenshot of this issue:
![](https://i.imgur.com/n4gDrd2.jpg)

I had meant to split this commit into two but I had already gone too deep before I did. 😞 