### PR TITLE
Post Carousel: Remove default widget specific Posts Per Page

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -185,7 +185,6 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget {
 			$instance['posts'],
 			array(
 				'paged' => empty( $instance['paged'] ) ? 1 : $instance['paged'],
-				'posts_per_page' => -1,
 			)
 		) );
 		$posts = new WP_Query( $query );


### PR DESCRIPTION
This will prevent all posts from outputting. 10 will be output at a time instead.