### PR TITLE
Editor Widget: Add wp_filter_content_tags

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -66,7 +66,9 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			empty( $GLOBALS[ 'SITEORIGIN_PANELS_CACHE_RENDER' ] ) &&
 			empty( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] )
 		) {
-			if (function_exists('wp_make_content_images_responsive')) {
+			if ( function_exists( 'wp_filter_content_tags' ) ) {
+				$instance['text'] = wp_filter_content_tags( $instance['text'] );
+			} else if ( function_exists( 'wp_make_content_images_responsive' ) ) {
 				$instance['text'] = wp_make_content_images_responsive( $instance['text'] );
 			}
 


### PR DESCRIPTION
Resolve #1047

`wp_make_content_images_responsive` is checked for if `wp_filter_content_tags` doesn'r exist for backwards compatability.