### PR TITLE
Simple Masonry: Add Layout Origin setting

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -64,7 +64,8 @@ jQuery( function ( $ ) {
 					$gridEl.packery( {
 						itemSelector: '.sow-masonry-grid-item',
 						columnWidth: columnWidth,
-						gutter: layout.gutter
+						gutter: layout.gutter,
+						originLeft: $gridEl.data( 'layout-origin-left' ),
 					} );
 
 					// If preloader is present, remove and show masonry

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -204,7 +204,17 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 						'description' => __( 'The size of the preloader prior to the Masonry images showing.', 'so-widgets-bundle' )
 					)
 				)
-			)
+			),
+			'layout_origin_left' => array(
+				'type' => 'select',
+				'label' => __( 'Layout origin', 'so-widgets-bundle' ),
+				'description' => __( 'Controls the horizontal flow of the layout. Items can either start positioned on the left or right.', 'so-widgets-bundle' ),
+				'default' => 'true',
+				'options' => array(
+					'true' => __( 'Left', 'so-widgets-bundle' ),
+					'false' => __( 'Right', 'so-widgets-bundle' ),
+				),
+			),
 		);
 	}
 
@@ -219,11 +229,11 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 			}
 			$item['link_attributes'] = $link_atts;
 		}
-		
 		return array(
 			'args' => $args,
 			'items' => $items,
 			'preloader_enabled' => ! empty( $instance['preloader']['enabled'] ) ? true : false,
+			'layout_origin_left' => ! empty( $instance['layout_origin_left'] ) ? $instance['layout_origin_left'] : 'true',
 			'layouts' => array(
 				'desktop' => siteorigin_widgets_underscores_to_camel_case(
 					array(

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -12,7 +12,7 @@
 	<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>
 <?php endif; ?>
 <div class="sow-masonry-grid"
-	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" <?php echo ! empty( $preloader_enabled ) ? 'style="opacity: 0;"' : ''; ?>>
+	 data-layouts="<?php echo esc_attr( json_encode( $layouts ) ) ?>" data-layout-origin-left="<?php esc_attr_e( $layout_origin_left ); ?>" <?php echo ! empty( $preloader_enabled ) ? 'style="opacity: 0;"' : ''; ?>>
 	<?php
 	if( ! empty( $items ) ) {
 		foreach ( $items as $item ) {


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/so-widgets-bundle/issues/1049. It requires https://github.com/siteorigin/so-widgets-bundle/pull/1050.
This PR implements [this Packery option](https://packery.metafizzy.co/options.html#originleft). 

The setting is internally known as layout_origin_left as the value needs to be a boolean and layouts_origin = true/false makes less sense than layouts_origin_left = true/false. While this setting could logically be a checkbox, I agree with the idea of using a select as it's more approachable and obvious what the outcome will be.