### PR TITLE
Image widget: Add siteorigin_widgets_image_args filter

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -172,14 +172,18 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			$link_atts['rel'] = 'noopener noreferrer';
 		}
 
-		return array(
-			'title' => $title,
-			'title_position' => $instance['title_position'],
-			'url' => $instance['url'],
-			'new_window' => $instance['new_window'],
-			'link_attributes' => $link_atts,
-			'attributes' => $attr,
-			'classes' => array( 'so-widget-image' ),
+		return apply_filters( 'siteorigin_widgets_image_args',
+			array(
+				'title' => $title,
+				'title_position' => $instance['title_position'],
+				'url' => $instance['url'],
+				'new_window' => $instance['new_window'],
+				'link_attributes' => $link_atts,
+				'attributes' => $attr,
+				'classes' => array( 'so-widget-image' ),
+			),
+			$instance,
+			$this
 		);
 	}
 


### PR DESCRIPTION
Related https://github.com/siteorigin/so-widgets-bundle/pull/1054

This PR adds `siteorigin_widgets_image_args` to the SiteOrigin Image Widget. This filter allows you to adjust _all_ of the image widgets' arguments and attributes. The previous filter, `siteorigin_widgets_image_attr, is effectively deprecated by this but that filter is still retained for backward compatibility.

Test code:
```
add_filter( 'siteorigin_widgets_image_args', function( $args ) {
	$args['attributes']['title'] = 'This title has been overriden';

	return $args;
} );
```