### PR TITLE
Code form field: Remove Sanitization

### DIFF
--- a/base/inc/fields/code.class.php
+++ b/base/inc/fields/code.class.php
@@ -33,4 +33,8 @@ class SiteOrigin_Widget_Field_Code extends SiteOrigin_Widget_Field_Text_Input_Ba
 	function enqueue_scripts(){
 		wp_enqueue_script( 'so-code-field', plugin_dir_url( __FILE__ ) . 'js/code-field' . SOW_BUNDLE_JS_SUFFIX .  '.js', array( 'jquery' ), SOW_BUNDLE_VERSION );
 	}
+
+	public function sanitize( $value, $instance = array(), $old_value = null ) {
+		return $value;
+	}
 }


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1060 

This will remove the standard HTML sanitization from occurring. It does not affect sanitization elsewhere but that sanitization isn't interesting with the code form field. Developers using this form field would already be escaping on output so backwards compatibility isn't an issue.