### PR TITLE
Tabs: Ensure Tabs are in view if anchor set and on hashchange

### DIFF
--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -23,6 +23,18 @@ jQuery( function ( $ ) {
 			var $tabPanels = $tabPanelsContainer.find( '> .sow-tabs-panel' );
 			$tabPanels.not( ':eq(' + selectedIndex + ')' ).hide();
 			var tabAnimation;
+
+			var scrollToTab = function ( smooth ) {
+				var navOffset = 90;// Add some magic number offset to make space for possible nav menus etc.
+				var scrollTop = $widget.offset().top - navOffset;
+				if ( smooth ) {
+					$( 'body,html' ).animate( {
+						scrollTop: scrollTop,
+					}, 200 );
+				} else {
+					window.scrollTo( 0, scrollTop );
+				}
+			};
 			
 			var selectTab = function ( tab, preventHashChange ) {
 				var $tab = $( tab );
@@ -66,6 +78,9 @@ jQuery( function ( $ ) {
 								},
 								complete: function() {
 									$( this ).trigger( 'show' );
+									if ( $tab.offset().top < window.scrollY || $tab.offset().top + $tab.height() > window.scrollY ) {
+										scrollToTab( true );
+									}
 								}
 							});
 						}

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -25,7 +25,7 @@ jQuery( function ( $ ) {
 			var tabAnimation;
 
 			var scrollToTab = function ( smooth ) {
-				var navOffset = 90;// Add some magic number offset to make space for possible nav menus etc.
+				var navOffset = 90; // Add some magic number offset to make space for possible nav menus etc.
 				var scrollTop = $widget.offset().top - navOffset;
 				if ( smooth ) {
 					$( 'body,html' ).animate( {

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -148,8 +148,6 @@ jQuery( function ( $ ) {
 				$( window ).on( 'hashchange', updateSelectedTab );
 				if ( window.location.hash ) {
 					updateSelectedTab();
-				} else {
-					window.location.hash = $selectedTab.data( 'anchor' );
 				}
 			}
 			

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -39,6 +39,7 @@ jQuery( function ( $ ) {
 			var selectTab = function ( tab, preventHashChange ) {
 				var $tab = $( tab );
 				if ( $tab.is( '.sow-tabs-tab-selected' ) ) {
+					scrollToTab( true );
 					return true;
 				}
 				var selectedIndex = $tab.index();


### PR DESCRIPTION
This PR ensure feature parity with the Accordion widgets by replicating [scrollToPanel](https://github.com/siteorigin/so-widgets-bundle/blob/1.17.0/widgets/accordion/js/accordion.js#L22-L32) functionality. scrollToTab allows for users to link to specific tabs and have the Tabs widget scroll to them like a standard Page Jump would (albeit with a nice scrolling effect).

Previously if the user linked to a tab the tab would change, but the browser would not scroll to the tab. 