### PR TITLE
Prevent previewing issues for widgets that use Google Fonts

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -37,8 +37,6 @@ function siteorigin_widget_print_styles(){
             <style type="text/css"><?php echo($widget_css) ?></style><?php
         }
     }
-
-	$siteorigin_widgets_inline_styles = array();
 }
 add_action('wp_head', 'siteorigin_widget_print_styles');
 add_action('wp_footer', 'siteorigin_widget_print_styles');


### PR DESCRIPTION
Resolves https://github.com/siteorigin/siteorigin-panels/issues/732

I do not see any issues with removing this line and removing it results in this issue no longer occurs. Do you see any @Misplon?

I can't when exactly this issue was introduced. I tried a few older versions of the SiteOrigin Widgets Bundle and this issue is present. I suspect this issue may have always been present as it's not clear why `siteorigin_widgets_inline_styles` was being cleared.