### PR TITLE
Features: Prevent Text Overlapping Icon

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -91,34 +91,46 @@
         }
         
         .sow-icon-container {
-            width: @container_size;
-            height: @container_size;
-            font-size: @container_size;
             text-decoration: none;
 
             & when not ( @per_row = 1 ) {
                 margin: auto;
             }
 
-            [class^="sow-icon-"],
-            .sow-icon-image {
-				text-decoration: none;
-				color: #FFFFFF;
-				width: @container_size;
-				height: @container_size;
-				display: flex;
-				align-items: center;
-				justify-content: center;
+            [class^="sow-icon-"] {
+                text-decoration: none;
+                color: #FFFFFF;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
 
-				.icon_size() when ( @use_icon_size = true) {
-                	background-size: @icon_size @icon_size;
-				}
-				.icon_size() when not ( @use_icon_size = true) {
-                	background-size: contain;
-				}
-				.icon_size();
+            .sow-icon-image {
+                .icon_size() when ( @use_icon_size = true) {
+                    background-size: @icon_size @icon_size;
+                    width: @container_size;
+                    height: @container_size;
+                }
+                .icon_size() when not ( @use_icon_size = true) {
+                    background-size: contain;
+                }
+                .icon_size();
                 background-repeat: no-repeat;
                 background-position: center;
+            }
+
+            &:not(.sow-container-none) {
+                width: @container_size;
+                height: @container_size;
+                font-size: @container_size;
+
+                [class^="sow-icon-"] {
+                    width: @container_size;
+                    height: @container_size;
+                    font-size: @container_size;
+                    position: absolute;
+                    top: 0;
+                }
             }
         }
 

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -106,8 +106,6 @@
 				color: #FFFFFF;
 				width: @container_size;
 				height: @container_size;
-				position: absolute;
-				top: 0;
 				display: flex;
 				align-items: center;
 				justify-content: center;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1074

Removing this CSS allows for the icon and text to convert each other when sizing. This means that the features text may be slightly smaller as a result of this change due to the icon pushing it over.