### PR TITLE
Post Carousel: IE 11 Fix

### DIFF
--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -49,8 +49,8 @@ jQuery( function ( $ ) {
 			$widget.find( '.sow-carousel-previous, .sow-carousel-next' ).on( 'click', function( e ) {
 				e.preventDefault();
 				$items = $$.find( '.sow-carousel-items' );
-				const numVisibleItems = Math.ceil( $items.outerWidth() / itemWidth );
-				const lastPosition = numItems - numVisibleItems + 1
+				var numVisibleItems = Math.ceil( $items.outerWidth() / itemWidth );
+				var lastPosition = numItems - numVisibleItems + 1
 
 				// Check if all posts are displayed
 				if ( ! complete ) {


### PR DESCRIPTION
The const usage was resulting in a JavaScript error in IE 11.

![2020-06-25_01-24-42-1312](https://user-images.githubusercontent.com/17275120/85584664-aea0d100-b682-11ea-8b69-4a5aeee85180.png)
