### PR TITLE
Vertically align Post Carousel nav buttons if a title is present

### DIFF
--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -39,6 +39,21 @@
 }
 
 .sow-carousel-title {
+
+	&.has-title {
+		align-items: baseline;
+		display: flex;
+
+		.sow-carousel-navigation {
+			margin-left: auto;
+		}
+
+		body.rtl & .sow-carousel-navigation {
+			margin-right: auto;
+			margin-left: initial;
+		}
+	}
+
 	.widget-title {
 		display: inline-block;
 		padding-right: 15px;

--- a/widgets/post-carousel/tpl/base.php
+++ b/widgets/post-carousel/tpl/base.php
@@ -11,7 +11,7 @@
 ?>
 
 <?php if(! empty( $posts ) && $posts->have_posts() ) : ?>
-	<div class="sow-carousel-title">
+	<div class="sow-carousel-title<?php if ( ! empty( $title ) ) echo ' has-title'; ?>">
 		<?php if( ! empty( $title ) ) echo $args['before_title'] . esc_html( $title ) . $args['after_title'] ?>
 
 		<div class="sow-carousel-navigation">


### PR DESCRIPTION
@AlexGStapleton The goal of this PR is to better vertically align the carousel nav buttons when a title is present. 

Request: https://wordpress.org/support/topic/post-carousel-in-1-17/page/2/#post-13038229

As far as I'm aware, within CSS3, we don't have a way of counting children and then applying styles to the parent based on the count. Ideally, I'd apply Flexbox when two children are present within the `.sow-carousel-title` div (the title and the nav container). Counting in this manner will be included in CSS4.

I've set this PR to draft status. Let me know if you'd prefer to go in another direction.