### PR TITLE
Editor: Add noreferrer to any target links

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -23,6 +23,8 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			false,
 			plugin_dir_path(__FILE__)
 		);
+
+		add_filter( 'siteorigin_widgets_sanitize_instance_sow-editor', array( $this, 'add_noreferrer_to_link_targets' ) );
 	}
 
 	function get_widget_form() {
@@ -137,6 +139,13 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 		}
 
 		return $content;
+	}
+
+	function add_noreferrer_to_link_targets( $instance ) {
+		if ( function_exists( 'wp_targeted_link_rel' ) ) {
+			$instance['text'] = wp_targeted_link_rel( $instance['text'] );
+		}
+		return $instance;
 	}
 
 


### PR DESCRIPTION
This issue resolves https://github.com/siteorigin/siteorigin-panels/issues/770. This issue is caused due to the Block Editor automatically altering all links with targets to include `noreferrer`. This is problematic as the Block Editor will reject a widget if the markup of a block changes enough. 

It should be noted that `noreferrer` isn't added automatically when using the link builder. This is due to a known WP Issue and it's unlikely ever to be fixed as `noreferrer` will likely be removed in WordPress 5.5 ([related](https://core.trac.wordpress.org/ticket/49558)).

For this code to be run the user will need to recover the widget and make a minor change to the editor widget. The user can recover the widget by clicking the three vertical dots and clicking the recovery link.