### PR TITLE
Hero: Don't load buttons unless set to output

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -355,15 +355,18 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 	 * @return string
 	 */
 	function process_content( $content, $frame ) {
-		ob_start();
-		foreach( $frame['buttons'] as $button ) {
-			$this->sub_widget('SiteOrigin_Widget_Button_Widget', array(), $button['button']);
-		}
-		$button_code = ob_get_clean();
 
-		// Add in the button code
-		$san_content = wp_kses_post($content);
-		$content = preg_replace('/(?:<(?:p|h\d|em|strong|li|blockquote) *([^>]*)> *)?\[ *buttons *\](:? *<\/(?:p|h\d|em|strong|li|blockquote)>)?/i', '<div class="sow-hero-buttons" $1>' . $button_code . '</div>', $san_content );
+		$content = wp_kses_post($content);
+		if ( strpos( $content, '[buttons]' ) !== false ) {
+			ob_start();
+			foreach( $frame['buttons'] as $button ) {
+				$this->sub_widget('SiteOrigin_Widget_Button_Widget', array(), $button['button']);
+			}
+			$button_code = ob_get_clean();
+
+			// Add in the button code
+			$content = preg_replace('/(?:<(?:p|h\d|em|strong|li|blockquote) *([^>]*)> *)?\[ *buttons *\](:? *<\/(?:p|h\d|em|strong|li|blockquote)>)?/i', '<div class="sow-hero-buttons" $1>' . $button_code . '</div>', $content );
+		}
 		
 		// Process normal shortcodes
 		$content = do_shortcode( shortcode_unautop( $content ) );


### PR DESCRIPTION
This PR ensures that the Hero widget buttons aren't loaded unless [buttons] is added to the Hero frame content. This PR will indirectly prevent the Hero widget from being affected by https://github.com/siteorigin/so-widgets-bundle/issues/1077.

[Related](https://github.com/siteorigin/so-widgets-bundle/pull/1073#discussion_r449801433).