### PR TITLE
Contact: Don't double sanitize success message

### DIFF
--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -10,7 +10,7 @@ if( $result['status'] == 'success' ) {
 	// Display the success message
 	?>
 	<div class="sow-contact-form-success" id="contact-form-<?php echo esc_attr( $short_hash ) ?>">
-		<?php echo $instance['settings']['success_message'] ); ?>
+		<?php echo $instance['settings']['success_message']; ?>
 	</div>
 	<?php
 }

--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -10,7 +10,7 @@ if( $result['status'] == 'success' ) {
 	// Display the success message
 	?>
 	<div class="sow-contact-form-success" id="contact-form-<?php echo esc_attr( $short_hash ) ?>">
-		<?php echo wp_kses_post( wpautop( $instance['settings']['success_message'] ) ) ?>
+		<?php echo $instance['settings']['success_message'] ); ?>
 	</div>
 	<?php
 }


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/so-widgets-bundle/issues/1028.

Neither `wp_kses_post` nor `wpautop` are required here as they're already [run when the page saves](https://github.com/siteorigin/so-widgets-bundle/blob/e0deee4e80c6c27a5e944e22f814a7443569b389/base/inc/fields/tinymce.class.php#L504-L516).