### PR TITLE
Button: Don't adjust :visited color

### DIFF
--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -48,7 +48,6 @@
 			}
 		}
 
-		&:visited,
 		&:active,
 		&:hover{
 			color: @hover_text_color !important;

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -48,7 +48,6 @@
 			}
 		}
 
-		&:visited,
 		&:active,
 		&:hover{
 			color: @hover_text_color !important;

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -46,7 +46,6 @@
 			}
 		}
 
-		&:visited,
 		&:active,
 		&:hover{
 			color: @hover_text_color !important;


### PR DESCRIPTION
This PR resolves an issue where the button will use the hover color by default.