### PR TITLE
Post Carousel: Add Keyboard Navigation

### DIFF
--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -103,6 +103,7 @@
 		background: #333333;
 		border-radius: 2px;
 
+		&:focus,
 		&:hover {
 			background: #444444;
 		}

--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -199,6 +199,10 @@
 					color: inherit;
 				}
 			}
+
+			&:focus .sow-carousel-thumbnail a span {
+				opacity: 0.5;
+			}
 		}
 
 		.sow-carousel-loading {

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -43,7 +43,7 @@ jQuery( function ( $ ) {
 
 			// click is used rather than Slick's beforeChange or afterChange
 			// due to the inability to stop a slide from changing from those events
-			$$.parent().parent().find( '.sow-carousel-previous, .sow-carousel-next' ).on( 'click touchend', function( e ) {
+			$$.parent().parent().find( '.sow-carousel-previous, .sow-carousel-next' ).on( 'click touchend', function( e, refocus ) {
 				e.preventDefault();
 				$items = $$.find( '.sow-carousel-items' );
 				var numItems = $items.find( '.sow-carousel-item' ).length,
@@ -76,7 +76,9 @@ jQuery( function ( $ ) {
 									$$.data( 'fetching', false );
 									$$.data( 'page', page );
 
-									$items.find( '.sow-carousel-item[tabindex="0"]' ).trigger( 'focus' );
+									if ( refocus ) {
+										$items.find( '.sow-carousel-item[tabindex="0"]' ).trigger( 'focus' );
+									}
 								}
 							);
 						}
@@ -143,7 +145,8 @@ jQuery( function ( $ ) {
 					if ( $wrapper.data( 'fetching' ) ) {
 						return; // Currently loading new post
 					}
-					$wrapper.parent().find( '.sow-carousel-next' ).trigger( 'click' );
+
+					$wrapper.parent().find( '.sow-carousel-next' ).trigger( 'click', true );
 				}
 			}
 

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -108,37 +108,41 @@ jQuery( function ( $ ) {
 				}
 			} );
 
-			$$.find( '.sow-carousel-item' ).on( 'keyup', function( e ) {
-				// Ensure left/right key was pressed
-				if ( e.keyCode != 37 && e.keyCode != 39 ) {
-					return;
+		} );
+
+		// Keyboard Navigation of carousel items.
+		$( document ).on( 'keyup', '.sow-carousel-item', function( e ) {
+			// Ensure left/right key was pressed
+			if ( e.keyCode != 37 && e.keyCode != 39 ) {
+				return;
+			}
+
+			var $wrapper =  $( this ).parents( '.sow-carousel-wrapper' ),
+			$items = $wrapper.find( '.sow-carousel-items' ),
+			numItems = $items.find( '.sow-carousel-item' ).length,
+			itemIndex = $( this ).data( 'slick-index' ),
+			lastPosition = numItems - ( numItems === $wrapper.data( 'post-count' ) ? 0 : 1 );
+
+			if ( e.keyCode == 37 ) {
+				itemIndex--;
+				if ( itemIndex < 0 ) {
+					itemIndex = lastPosition;
 				}
-
-				var $items = $$.find( '.sow-carousel-items' ),
-				numItems = $items.find( '.sow-carousel-item' ).length,
-				numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
-				itemIndex = $( this ).data( 'slick-index' ),
-				lastPosition = numItems - ( numItems === $$.data( 'post-count' ) ? 0 : 1 );
-
-				if ( e.keyCode == 37 ) {
-					itemIndex--;
-					if ( itemIndex < 0 ) {
-						itemIndex = lastPosition;
+			} else if ( e.keyCode == 39 ) {
+				itemIndex++;
+				if ( itemIndex >= lastPosition ) {
+					if ( $wrapper.data( 'fetching' ) ) {
+						return; // Currently loading new post
 					}
-				} else if ( e.keyCode == 39 ) {
-					if ( itemIndex >= lastPosition ) {
-						$( '.sow-carousel-next' ).trigger( 'click' );
-					} else {
-						itemIndex++;
-					}
+					$wrapper.parent().find( '.sow-carousel-next' ).trigger( 'click' );
 				}
+			}
 
-				$items.slick( 'slickGoTo', itemIndex, true );
-				$$.find( '.sow-carousel-item' ).prop( 'tabindex', -1 );
-				$$.find( '.sow-carousel-item[data-slick-index="' + itemIndex + '"]' )
-					.trigger( 'focus' )
-					.prop( 'tabindex', 0 );
-			} );
+			$items.slick( 'slickGoTo', itemIndex, true );
+			$wrapper.find( '.sow-carousel-item' ).prop( 'tabindex', -1 );
+			$wrapper.find( '.sow-carousel-item[data-slick-index="' + itemIndex + '"]' )
+				.trigger( 'focus' )
+				.prop( 'tabindex', 0 );
 		} );
 
 		$( window ).on( 'resize load', function() {
@@ -163,6 +167,8 @@ jQuery( function ( $ ) {
 				$( '.sow-carousel-items' ).slick( 'slickSetOption', 'slidesToShow', 3 );
 				$( '.sow-carousel-items' ).slick( 'slickSetOption', 'slidesToScroll', 3 );
 			}
+
+			$( '.sow-carousel-item:first-of-type' ).prop( 'tabindex', 0 );
 		} );
 	};
 

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -110,6 +110,15 @@ jQuery( function ( $ ) {
 
 		} );
 
+		// Keyboard Navigation of carousel navigation.
+		$( document ).on( 'keydown', '.sow-carousel-navigation a', function( e ) {
+			if ( e.keyCode != 13 && e.keyCode != 32 ) {
+				return;
+			}
+			e.preventDefault();
+			$( this ).click();
+		} );
+
 		// Keyboard Navigation of carousel items.
 		$( document ).on( 'keyup', '.sow-carousel-item', function( e ) {
 			// Ensure left/right key was pressed

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -7,8 +7,8 @@ jQuery( function ( $ ) {
 	sowb.setupCarousel = function () {
 		// The carousel widget
 		$( '.sow-carousel-wrapper' ).each( function () {
-			var $$ = $( this );
-			$items = $$.find( '.sow-carousel-items' );
+			var $$ = $( this ),
+				$items = $$.find( '.sow-carousel-items' );
 
 			$items.not( '.slick-initialized' ).slick( {
 				arrows: false,
@@ -45,11 +45,11 @@ jQuery( function ( $ ) {
 			// due to the inability to stop a slide from changing from those events
 			$$.parent().parent().find( '.sow-carousel-previous, .sow-carousel-next' ).on( 'click touchend', function( e, refocus ) {
 				e.preventDefault();
-				$items = $$.find( '.sow-carousel-items' );
-				var numItems = $items.find( '.sow-carousel-item' ).length,
-				complete = numItems === $$.data( 'post-count' ),
-				numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
-				lastPosition = numItems - numVisibleItems + 1;
+				var $items = $$.find( '.sow-carousel-items' ),
+					numItems = $items.find( '.sow-carousel-item' ).length,
+					complete = numItems === $$.data( 'post-count' ),
+					numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
+					lastPosition = numItems - numVisibleItems + 1;
 
 				// Check if all posts are displayed
 				if ( ! complete ) {
@@ -129,10 +129,10 @@ jQuery( function ( $ ) {
 			}
 
 			var $wrapper =  $( this ).parents( '.sow-carousel-wrapper' ),
-			$items = $wrapper.find( '.sow-carousel-items' ),
-			numItems = $items.find( '.sow-carousel-item' ).length,
-			itemIndex = $( this ).data( 'slick-index' ),
-			lastPosition = numItems - ( numItems === $wrapper.data( 'post-count' ) ? 0 : 1 );
+				$items = $wrapper.find( '.sow-carousel-items' ),
+				numItems = $items.find( '.sow-carousel-item' ).length,
+				itemIndex = $( this ).data( 'slick-index' ),
+				lastPosition = numItems - ( numItems === $wrapper.data( 'post-count' ) ? 0 : 1 );
 
 			if ( e.keyCode == 37 ) {
 				itemIndex--;
@@ -160,9 +160,9 @@ jQuery( function ( $ ) {
 		$( window ).on( 'resize load', function() {
 			// Hide/disable scroll if number of visible items is less than total posts.
 			var $carousels = $( '.sow-carousel-wrapper' ),
-			$items = $carousels.find( '.sow-carousel-items' ),
-			numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
-			navigation = $carousels.parent().parent().find( '.sow-carousel-navigation' );
+				$items = $carousels.find( '.sow-carousel-items' ),
+				numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
+				navigation = $carousels.parent().parent().find( '.sow-carousel-navigation' );
 
 			if ( numVisibleItems >= $carousels.data( 'post-count' ) ) {
 				navigation.hide();

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -17,6 +17,7 @@ jQuery( function ( $ ) {
 				rtl: $$.data( 'dir' ) == 'rtl',
 				touchThreshold: 20,
 				variableWidth: true,
+				accessibility: false,
 				responsive: [
 					{
 						breakpoint: carouselBreakpoints.tablet_portrait,
@@ -46,8 +47,7 @@ jQuery( function ( $ ) {
 				e.preventDefault();
 				$items = $$.find( '.sow-carousel-items' );
 				var numItems = $items.find( '.sow-carousel-item' ).length,
-				totalPosts = $$.data( 'post-count' );
-				complete = numItems === totalPosts,
+				complete = numItems === $$.data( 'post-count' ),
 				numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
 				lastPosition = numItems - numVisibleItems + 1;
 
@@ -75,6 +75,8 @@ jQuery( function ( $ ) {
 									numItems = $$.find( '.sow-carousel-item' ).length;
 									$$.data( 'fetching', false );
 									$$.data( 'page', page );
+
+									$items.find( '.sow-carousel-item[tabindex="0"]' ).trigger( 'focus' );
 								}
 							);
 						}
@@ -121,8 +123,41 @@ jQuery( function ( $ ) {
 					$items.slick( 'slickSetOption', 'touchMove', true );
 					$items.slick( 'slickSetOption', 'draggable', true );
 				}
+
+				$items.find( '.sow-carousel-item' ).first().prop( 'tabindex', 0 );
 			} );
 
+			$$.find( '.sow-carousel-item' ).on( 'keyup', function( e ) {
+				// Ensure left/right key was pressed
+				if ( e.keyCode != 37 && e.keyCode != 39 ) {
+					return;
+				}
+
+				var $items = $$.find( '.sow-carousel-items' ),
+				numItems = $items.find( '.sow-carousel-item' ).length,
+				numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
+				itemIndex = $( this ).data( 'slick-index' ),
+				lastPosition = numItems - ( numItems === $$.data( 'post-count' ) ? 0 : 1 );
+
+				if ( e.keyCode == 37 ) {
+					itemIndex--;
+					if ( itemIndex < 0 ) {
+						itemIndex = lastPosition;
+					}
+				} else if ( e.keyCode == 39 ) {
+					if ( itemIndex >= lastPosition ) {
+						$( '.sow-carousel-next' ).trigger( 'click' );
+					} else {
+						itemIndex++;
+					}
+				}
+
+				$items.slick( 'slickGoTo', itemIndex, true );
+				$$.find( '.sow-carousel-item' ).prop( 'tabindex', -1 );
+				$$.find( '.sow-carousel-item[data-slick-index="' + itemIndex + '"]' )
+					.trigger( 'focus' )
+					.prop( 'tabindex', 0 );
+			} );
 		} );
 
 		// Change Slick Settings on iPad Pro while Landscape

--- a/widgets/post-carousel/styles/default.less
+++ b/widgets/post-carousel/styles/default.less
@@ -25,6 +25,10 @@
         }
       }
 
+      &:focus .sow-carousel-thumbnail a {
+          background-size: @thumbnail_hover_width @thumbnail_hover_height;
+      }
+
       .sow-carousel-default-thumbnail {
         width: @thumbnail_width;
         height: @thumbnail_height;

--- a/widgets/post-carousel/tpl/carousel-post-loop.php
+++ b/widgets/post-carousel/tpl/carousel-post-loop.php
@@ -4,19 +4,20 @@
  * @var string $default_thumbnail
  */
 while($posts->have_posts()) : $posts->the_post(); ?>
-	<div class="sow-carousel-item">
+	<div class="sow-carousel-item" tabindex="-1">
 		<div class="sow-carousel-thumbnail">
 			<?php if( has_post_thumbnail() ) : $img = wp_get_attachment_image_src(get_post_thumbnail_id(), $instance['image_size']); ?>
-				<a href="<?php the_permalink() ?>" style="background-image: url(<?php echo sow_esc_url($img[0]) ?>)" aria-labelledby="sow-carousel-id-<?php echo the_ID(); ?>">
+				<a href="<?php the_permalink() ?>" style="background-image: url(<?php echo sow_esc_url($img[0]) ?>)" aria-labelledby="sow-carousel-id-<?php echo the_ID(); ?>" tabindex="-1">
 					<span class="overlay"></span>
 				</a>
 			<?php else : ?>
 				<a href="<?php the_permalink() ?>" class="sow-carousel-default-thumbnail"
 				<?php echo $link_target == 'new' ? 'target="_blank" rel="noopener noreferrer"': ''; ?>
 				<?php echo ! empty( $default_thumbnail ) ?
-				'style="background-image: url('. sow_esc_url( $default_thumbnail ) .')"' : '' ?> aria-labelledby="sow-carousel-id-<?php echo the_ID(); ?>"><span class="overlay"></span></a>
+				'style="background-image: url('. sow_esc_url( $default_thumbnail ) .')"' : '' ?> aria-labelledby="sow-carousel-id-<?php echo the_ID(); ?>"
+				tabindex="-1"><span class="overlay"></span></a>
 			<?php endif; ?>
 		</div>
-		<h3><a href="<?php the_permalink() ?>" id="sow-carousel-id-<?php echo the_ID(); ?>"><?php the_title() ?></a></h3>
+		<h3><a href="<?php the_permalink() ?>" id="sow-carousel-id-<?php echo the_ID(); ?>" tabindex="-1"><?php the_title() ?></a></h3>
 	</div>
 <?php endwhile; wp_reset_postdata(); ?>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1108

- The first item is the default tab index.
- Upon tabbing to tab index slide, use left and right keyboard arrows to navigate to the next/previous item
- The tab index is the currently active item
- Add keyboard navigation for post carousel arrows by pressing Enter or Space. Will navigate entire carousel slides rather than item by item.

`build:dev` is required due to LESS changes.