### PR TITLE
SiteOrigin Slider: Disable 5.5 Lazy Loading

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -166,7 +166,10 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						$frame['foreground_image'],
 						'full',
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-						array( 'class' => 'sow-slider-foreground-image' )
+						array(
+							'class' => 'sow-slider-foreground-image',
+							'loading' => false,
+						)
 					);
 					?>
 					<?php if ( ! empty( $frame['url'] ) ) : ?>
@@ -193,7 +196,10 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				$frame['background_image'],
 				'full',
 				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
-				array( 'class' => 'sow-slider-background-image' )
+				array(
+					'class' => 'sow-slider-background-image',
+					'loading' => false,
+				)
 			);
 
 			?>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1120

In [WordPress 5.5 Lazy Loading](https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/) was introduced. Cycle2 doesn't appear to handle the new lazy load very well as the image is never actually loaded, nor are any related image load events are triggered (for example, [this one](https://github.com/siteorigin/so-widgets-bundle/blob/1.17.4/js/slider/jquery.slider.js#L255-L262)) - at least in Firefox. This PR disables the new loaded attribute for the SiteOrign Slider widget to avoid this.