### PR TITLE
Slider: Only Preload Slide Images

### DIFF
--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -245,7 +245,7 @@ jQuery( function($){
 			var imagesLoaded = 0;
 			var sliderLoaded = false;
 
-			// Preload all of the slide image, when they're loaded, then display the slider
+			// Preload all of the slide images, when they're loaded, then display the slider.
 			images.each( function(){
 				var $i = $(this);
 				if( this.complete ) {

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -241,11 +241,11 @@ jQuery( function($){
 				);
 			};
 
-			var images = $$.find('img');
+			var images = $$.find( 'img.sow-slider-background-image, img.sow-slider-foreground-image' );
 			var imagesLoaded = 0;
 			var sliderLoaded = false;
 
-			// Preload all the images, when they're loaded, then display the slider
+			// Preload all of the slide image, when they're loaded, then display the slider
 			images.each( function(){
 				var $i = $(this);
 				if( this.complete ) {


### PR DESCRIPTION
Images added to the Hero/Layout Slider contents will prevent the Hero and Layout Slider from showing due to the 5.5 lazy load. To be clear, it's not the slide background image, it's a separate image added to the slide content. 

Previously, we would preload all of the images added to the slider, but that doesn't actually appear to be intentional and looks to be more of an oversight that wasn't corrected with the introduction of the Hero and Layout Slider widgets.