### PR TITLE
DIsable Lazy Loading for SO Slider widgets added to Block Editor

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -168,7 +168,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
 						array(
 							'class' => 'sow-slider-foreground-image',
-							'loading' => false,
+							'loading' => true,
 						)
 					);
 					?>
@@ -198,7 +198,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
 				array(
 					'class' => 'sow-slider-background-image',
-					'loading' => false,
+					'loading' => true,
 				)
 			);
 


### PR DESCRIPTION
Contrary to what is [said here](https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/) (screenshot below), `lazy` needs to actually be set to `true` to be disabled. This is due to [this line](https://core.trac.wordpress.org/browser/tags/5.5/src/wp-includes/media.php#L1053) unsetting the lazy attribute if it's set to false when the lazy attribute needs to be output.

![Screenshot_2020-08-15 Lazy-loading images in 5 5](https://user-images.githubusercontent.com/17275120/90285830-f17b6a00-deb7-11ea-8601-abb7bfdfdf8f.png)
