### PR TITLE
Only output widget CSS inline during if preview is full widget

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -238,8 +238,8 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		echo $args['after_widget'];
 		do_action( 'siteorigin_widgets_after_widget_' . $this->id_base, $instance, $this );
 
-		if ( $this->is_preview( $instance ) ) {
-			// print inline styles if we're preview the widget.
+		// If this is a widget preview, we need to print the styling inline
+		if ( $this->is_preview( $instance ) && isset( $_POST['action'] ) &&  $_POST['action']== 'so_widgets_preview' ) {
 			siteorigin_widget_print_styles();
 		}
 	}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1085

This PR resolves the sub widget preview issue by only outputting widget CSS inline during if the preview is the direct widget preview - the dedicated preview widget button. A conditional is added rather than completely removing this line to allow for the widget preview button to still render as expected.

[Test widget](https://drive.google.com/uc?id=1vinLmiM6-LgEWOIiGXfdSDipd-hlAAg9). Once installed navigate to **WP Admin > plugins > SiteOrigin Widgets** and activate the Preview Error widget. Add it to a Block Editor page and then set a text color, and preview the widget. As expected, the color won't change. Load this PR and make any change to the widget (to trigger the content preview update) and then preview the widget again.

Note: You don't actually have to set the headline widget up.