### PR TITLE
Widget Settings: Avoid jQuery migrate notice by using $.get()

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -132,12 +132,16 @@ jQuery( function( $ ){
         var $$ = $(this);
         e.preventDefault();
 
-        dialog.find('.so-content')
+        $content = dialog.find('.so-content');
+        $content
             .empty()
             .addClass('so-loading')
-            .load( $$.data('form-url'), function(){
-                $(this).removeClass('so-loading');
-            } );
+
+        $.get( $$.data( 'form-url' ), function( form ) {
+            $content
+                .html( form )
+                .removeClass( 'so-loading' );
+        } );
 
         dialog.show();
     } );

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -132,7 +132,7 @@ jQuery( function( $ ){
         var $$ = $(this);
         e.preventDefault();
 
-        $content = dialog.find('.so-content');
+        $content = dialog.find( '.so-content' );
         $content
             .empty()
             .addClass('so-loading')

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -154,19 +154,13 @@ jQuery( function( $ ){
     dialog.find('.so-save').click( function( e ){
         e.preventDefault();
 
-	    var $$ = $(this);
-	    $$.prop('disabled', true);
-        $( '#widgets-list .so-widget-settings' ).prop('disabled', true);
+        var $$ = $( this );
+        $$.prop( 'disabled', true );
 
-	    dialog.find( 'form' ).submit( function( ){
-		    $$.prop('disabled', false);
-		    dialog.hide();
-	    } ).submit();
-    } );
-
-    // Enable all widget settings button after the save iframe has loaded.
-    $('#so-widget-settings-save').load( function(){
-        $( '#widgets-list .so-widget-settings' ).prop('disabled', false);
+        dialog.find( 'form' ).submit( function() {
+            $.prop( 'disabled', false );
+            dialog.hide();
+        } ).submit();
     } );
 
     // Automatically open settings modal based on hash


### PR DESCRIPTION
This PR prevents the [Enable jQuery Migrate Helper](https://wordpress.org/plugins/enable-jquery-migrate-helper/) plugin from showing a notice when viewing **WP Admin > Plugins > SiteOrigin Widgets**. This change isn't directly required, but this will avoid any reports.

![](https://i.imgur.com/6Aj32Qs.png)

To verify the settings form is still working as intended please navigate to**WP Admin > Plugins > SiteOrigin Widgets** and open a any widgets settings. Make a change, save, and then reload the page. Check the settings to ensure your change was saved.