### PR TITLE
Media Field Usability Enhancements

### DIFF
--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -47,6 +47,15 @@
 				}
 			} );
 
+			// If there's a selected image, highlight it. 
+			frame.on( 'open', function() {
+				var selection = frame.state().get( 'selection' );
+				var selectedImage = $field.find( '.siteorigin-widget-input[type="hidden"]' ).val();
+				if ( selectedImage ) {
+				    selection.add( wp.media.attachment( selectedImage ) );
+				}
+			} );
+
 			// Store the frame
 			$$.data('frame', frame);
 

--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -55,7 +55,7 @@
 				// Grab the selected attachment.
 				var attachment = frame.state().get('selection').first().attributes;
 
-				$field.find('.current .title' ).html(attachment.title);
+				$field.find('.current .thumbnail' ).attr( 'title', attachment.title );
 				$inputField.val(attachment.id);
 				$inputField.trigger( 'change', { silent: true } );
 
@@ -82,21 +82,9 @@
 			frame.open();
 		});
 
-		$media.find('.current' )
-			.mouseenter(function(){
-				var t = $(this ).find('.title' );
-				if( t.html() !== ''){
-					t.fadeIn('fast');
-				}
-			})
-			.mouseleave(function(){
-				$(this ).find('.title' ).clearQueue().fadeOut('fast');
-			});
-
 		$field.find('a.media-remove-button' )
 			.click( function( e ){
 				e.preventDefault();
-				$field.find('.current .title' ).html('');
 				$inputField.val('');
 				$inputField.trigger( 'change', { silent: true } );
 				$field.find('.current .thumbnail' ).fadeOut('fast');

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -92,9 +92,8 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 		<div class="media-field-wrapper">
 			<div class="current">
 				<div class="thumbnail-wrapper">
-					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> />
+					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> <?php if( !empty( $post ) ) echo 'title="' . esc_attr( $post->post_title ) . '"' ?>/>
 				</div>
-				<div class="title"><?php if( !empty( $post ) ) echo esc_attr( $post->post_title ) ?></div>
 			</div>
 			<a href="#" class="media-upload-button" data-choose="<?php echo esc_attr( $this->choose ) ?>"
 			   data-update="<?php echo esc_attr( $this->update ) ?>"


### PR DESCRIPTION
This PR improves the useability of the media field by adding the image title to the preview image and highlights the currently selected image in the WP Media modal. These changes were made per user's feedback that it was impossible to tell what item was selected if the selected image looks very similar to another image.

![](https://i.imgur.com/4uEcs7C.png)
