### PR TITLE
Bold Post Query settings group label

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -389,6 +389,7 @@
 
 			> label {
 				display: inline;
+				font-weight: bold;
 			}
 
 			&:before {


### PR DESCRIPTION
[Suggested here](https://github.com/siteorigin/so-widgets-bundle/pull/1131#issuecomment-682106511)

This PR will bold the Post Query settings group label. This is so it's consistent with section 

![](https://i.imgur.com/gybVRnN.png)
labels.



