### PR TITLE
Price Table: Remove text-shadow from feature text

### DIFF
--- a/widgets/price-table/styles/atom.less
+++ b/widgets/price-table/styles/atom.less
@@ -99,8 +99,6 @@
 					.gradient(#f1f1f1, #eeeeee, #f1f1f1);
 				}
 
-				text-shadow: 0 1px 0 #FFFFFF;
-
 				strong {
 					font-weight: 500;
 				}


### PR DESCRIPTION
This avoids an issue with Tooltips. There's no difference after removing this CSS.

![](https://i.imgur.com/NhAwytr.png)