### PR TITLE
Don't use wpColorPickerL10n if WP >= 5.5

### DIFF
--- a/compat/beaver-builder/beaver-builder.php
+++ b/compat/beaver-builder/beaver-builder.php
@@ -60,13 +60,16 @@ class SiteOrigin_Widgets_Bundle_Beaver_Builder {
 
 			wp_enqueue_style( 'wp-color-picker' );
 
-			// Localization args for when wp-color-picker script hasn't been registered.
-			wp_localize_script( 'wp-color-picker', 'wpColorPickerL10n', array(
-				'clear'         => __( 'Clear', 'so-widgets-bundle' ),
-				'defaultString' => __( 'Default', 'so-widgets-bundle' ),
-				'pick'          => __( 'Select Color', 'so-widgets-bundle' ),
-				'current'       => __( 'Current Color', 'so-widgets-bundle' ),
-			) );
+			global $wp_version;
+			if ( version_compare( $wp_version, '5.5', '<' ) ) {
+				// Localization args for when wp-color-picker script hasn't been registered.
+				wp_localize_script( 'wp-color-picker', 'wpColorPickerL10n', array(
+					'clear'         => __( 'Clear', 'so-widgets-bundle' ),
+					'defaultString' => __( 'Default', 'so-widgets-bundle' ),
+					'pick'          => __( 'Select Color', 'so-widgets-bundle' ),
+					'current'       => __( 'Current Color', 'so-widgets-bundle' ),
+				) );
+			}
 		}
 
 		wp_enqueue_style( 'sowb-styles-for-beaver', plugin_dir_url( __FILE__ ) . 'styles.css' );


### PR DESCRIPTION
This PR removes our usage of wpColorPickerL10n if the version of WordPress being used is at least 5.5. No replacement is required for any WP version after 5.5 as the translations are handled directly by the color picker ([reference](https://core.trac.wordpress.org/ticket/50596)). [We may still get flagged](https://wptavern.com/wordpress-5-5-1-released-with-backfill-for-deprecated-javascript-globals) for using wpColorPickerL10n, but it's not actively being used and only present for backwards compatibility.