### PR TITLE
IE 11: Prevent images from exceeding widget container

### DIFF
--- a/widgets/image/styles/default.less
+++ b/widgets/image/styles/default.less
@@ -24,7 +24,7 @@
 	}
 
 	> a {
-		display: inline-block;
+		display: flex;
 		width: @image_width;
 		max-width: @image_max_width;
 	}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1141

Before:
![](https://i.imgur.com/IxG7KR3.png)

After:
![](https://i.imgur.com/jrik3zO.png)

