### PR TITLE
Prevent TinyMCE not initializing in repeaters in repeaters

### DIFF
--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -124,6 +124,10 @@
 		var $field = $( this );
 		var $parentRepeaterItem = $field.closest( '.siteorigin-widget-field-repeater-item-form' );
 		
+		// Prevent potential id overlap by appending the textarea field a random id.
+		var $textarea = $field.find( 'textarea' );
+		$textarea.attr( 'id', $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 ) );
+		
 		if ( $parentRepeaterItem.length > 0 ) {
 			if ( $parentRepeaterItem.is( ':visible' ) ) {
 				setup( $field );


### PR DESCRIPTION
[Resolve the issue highlighted here](https://github.com/siteorigin/so-widgets-bundle/issues/745#issuecomment-689679515). You can test this PR by downloading [their widget](https://github.com/siteorigin/so-widgets-bundle/issues/745#issuecomment-667828328) (drop it into the SiteOrigin Widgets Bundle Widgets directory - their layout isn't required). To replicate it:

- Add a topic
- Add an item (no text required)
- Open Item
- Add a new topic
- Add an item to new topic
- Open the second item and TinyMCE won't appear.

There is a small chance of the id that's generated being a duplicate,. It's unlikely though due to how rare this issue is. It can be avoided by simply reloading the page.