### PR TITLE
Elementor styling changes

### DIFF
--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -14,20 +14,27 @@
 			background: none;
 
 			.wp-color-result {
-				float: none;
+				float: left;
 				margin: 0;
 			}
 
 			.wp-picker-input-wrap {
 				padding: 0;
-				display: flex;
-				flex-direction: row;
-				float: right;
+				float: left;
 
 				.siteorigin-widget-input-color,
 				.button.wp-picker-default {
 					height: 34.1px;
 				}
+
+				.button.wp-picker-default {
+					float: right;
+					width: auto;
+				}
+			}
+
+			.wp-picker-holder {
+				clear: both;
 			}
 
 			.iris-picker.iris-border {

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -77,7 +77,8 @@
 			}
 
 			.siteorigin-widget-input-measurement {
-				width: 66%;
+				width: 100%;
+				max-width: 58px;
 				margin-right: 1px;
 			}
 
@@ -85,6 +86,7 @@
 				min-width: inherit;
 				width: 32%;
 				margin-left: 1px;
+				max-width: 73px;
 			}
 		}
 

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -34,8 +34,10 @@
 				}
 			}
 
-			.wp-picker-holder {
+			.wp-picker-holder:before {
 				clear: both;
+				content: "";
+				display: table;
 			}
 
 			.iris-picker.iris-border {

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -24,7 +24,8 @@
 
 				.siteorigin-widget-input-color,
 				.button.wp-picker-default {
-					height: 34.1px;
+					font-size: 12px;
+					height: 32px;
 				}
 
 				.button.wp-picker-default {
@@ -163,8 +164,9 @@
 	}
 
 	.button.wp-color-result {
+		font-size: 12px;
+		height: 32px;
 		padding: 0 0 0 30px;
-		height: 34.1px;
 	}
 
 	.button.button-small {

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -20,7 +20,14 @@
 
 			.wp-picker-input-wrap {
 				padding: 0;
-				float: none;
+				display: flex;
+				flex-direction: row;
+				float: right;
+
+				.siteorigin-widget-input-color,
+				.button.wp-picker-default {
+					height: 34.1px;
+				}
 			}
 
 			.iris-picker.iris-border {
@@ -48,6 +55,10 @@
 		& .siteorigin-widget-input-color {
 			width: 120px;
 			margin: 0 3px;
+		}
+
+		.ui-draggable-handle {
+			transition: none;
 		}
 
 		&.siteorigin-widget-field-type-icon {
@@ -140,6 +151,11 @@
 		&.hidden {
 			display: none;
 		}
+	}
+
+	.button.wp-color-result {
+		padding: 0 0 0 30px;
+		height: 34.1px;
 	}
 
 	.button.button-small {

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -1,4 +1,5 @@
 .elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form {
+	color: #000;
 	min-width: inherit;
 
 	.wp-picker-container {


### PR DESCRIPTION
-  Set default form text color (Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1143)
- Prevent color picker button overlapping selected color and incorrect sizing. ([screenshot](https://i.imgur.com/2OQ9D4f.png))
- Prevent Noticeable lag when using the color picker. ([gif](https://i.imgur.com/23JpcDi.gif) - every time it moves is a single click)
- Move Color picker buttons and color field to the same line. ([screenshot](https://i.imgur.com/2OQ9D4f.png))
- Reduce size of measurement fields 