### PR TITLE
Image: Prevent image stretching while using Safari

### DIFF
--- a/widgets/image/styles/default.less
+++ b/widgets/image/styles/default.less
@@ -24,9 +24,13 @@
 	}
 
 	> a {
-		display: flex;
+		display: inline-block;
 		width: @image_width;
 		max-width: @image_max_width;
+
+		@media screen and ( -ms-high-contrast: active ), screen and ( -ms-high-contrast: none ) {  
+			display: flex;
+		}
 	}
 
 	.so-widget-image {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1152

This is done by applying the https://github.com/siteorigin/so-widgets-bundle/issues/1141 fix in a media query that only targets IE 11.