### PR TITLE
Video Play: Mute Self Hosted Videos set to autoplay

### DIFF
--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -24,6 +24,10 @@ $video_args = array(
 );
 if ( $autoplay ) {
 	$video_args['autoplay'] = 1;
+	// In most brwosers, Videos need to be muted to autoplay.
+	if ( apply_filters( 'sow_video_autoplay_mute_self_hosted', true ) ) {
+		$video_args['muted'] = true;
+	}
 }
 if ( ! empty( $poster ) ) {
 	$video_args['poster'] = esc_url( $poster );


### PR DESCRIPTION
Resolves https://github.com/siteorigin/so-widgets-bundle/issues/1160

Adds `sow_video_autoplay_mute_self_hosted` that can be used to prevent the video from being muted. Here's an example snippet that does that:

`add_filter( 'sow_video_autoplay_mute_self_hosted', '__return_false' );`
