### PR TITLE
TinyMCE: Only Alter textarea id when field is added in repeater.

### DIFF
--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -123,12 +123,12 @@
 	$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-tinymce', function () {
 		var $field = $( this );
 		var $parentRepeaterItem = $field.closest( '.siteorigin-widget-field-repeater-item-form' );
-		
-		// Prevent potential id overlap by appending the textarea field a random id.
-		var $textarea = $field.find( 'textarea' );
-		$textarea.attr( 'id', $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 ) );
-		
+
 		if ( $parentRepeaterItem.length > 0 ) {
+			// Prevent potential id overlap by appending the textarea field a random id.
+			var $textarea = $field.find( 'textarea' );
+			$textarea.attr( 'id', $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 ) );
+
 			if ( $parentRepeaterItem.is( ':visible' ) ) {
 				setup( $field );
 			}

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -39,7 +39,10 @@
 			settings.tinymce.wpautop = $wpautopToggleField.is( ':checked' );
 		}
 		var $textarea = $container.find( 'textarea' );
-		var id = $textarea.attr( 'id' );
+		// Prevent potential id overlap by appending the textarea field with a random id.
+		var id = $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 );
+		$textarea.attr( 'id', id );
+
 		var setupEditor = function ( editor ) {
 			editor.on( 'change',
 				function () {
@@ -125,10 +128,6 @@
 		var $parentRepeaterItem = $field.closest( '.siteorigin-widget-field-repeater-item-form' );
 
 		if ( $parentRepeaterItem.length > 0 ) {
-			// Prevent potential id overlap by appending the textarea field a random id.
-			var $textarea = $field.find( 'textarea' );
-			$textarea.attr( 'id', $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 ) );
-
 			if ( $parentRepeaterItem.is( ':visible' ) ) {
 				setup( $field );
 			}

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -40,8 +40,12 @@
 		}
 		var $textarea = $container.find( 'textarea' );
 		// Prevent potential id overlap by appending the textarea field with a random id.
-		var id = $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 );
-		$textarea.attr( 'id', id );
+		var id = $textarea.data( 'tinymce-id' );
+		if ( ! id ) {
+			var id = $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 );
+			$textarea.data( 'tinymce-id', id );
+			$textarea.attr( 'id', id );
+		}
 
 		var setupEditor = function ( editor ) {
 			editor.on( 'change',

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -830,11 +830,7 @@ var sowbForms = window.sowbForms || {};
 						var nm = $inputElement.attr('name');
 						// TinyMCE field :/
 						if ($inputElement.is('textarea') && $inputElement.parent().is('.wp-editor-container') && typeof tinymce != 'undefined') {
-							// Update the field ID to prevent duplicates.
-							id = id.replace( /\d+$/, Math.floor( Math.random() * 1000 ) );
-							// Set the field to be reinitialized.
-							$inputElement.find( 'siteorigin-widget-field-type-tinymce' ).data( 'initialized', false );
-							$inputElement.parent().parent().empty().append( $inputElement );
+							$inputElement.parent().empty().append($inputElement);
 							$inputElement.css('display', '');
 							var curEd = tinymce.get(id);
 							if (curEd) {
@@ -886,18 +882,23 @@ var sowbForms = window.sowbForms || {};
 								var newRadioIdBase = idBase + '-' + newIds[idBase];
 								newId = newRadioIdBase + id.match(/-\d+$/)[0];
 								$copyItem.find('label[for=' + radioIdBase + ']').attr('for', newRadioIdBase);
-							} else if ( ! $inputElement.is( '.wp-editor-area' ) || typeof tinymce == 'undefined' ) {
+							} else {
 								idRegExp = new RegExp('-\\d+$');
 								idBase = id.replace(idRegExp, '');
 								if (!newIds[idBase]) {
 									newIds[idBase] = $form.find('.siteorigin-widget-input[id^=' + idBase + ']').not('[id*=_id_]').length + 1;
 								}
 								newId = idBase + '-' + newIds[idBase]++;
-							} else {
-								newId = id;
+							}
+
+							if ( $inputElement.is( '.wp-editor-area' ) ) {
+								// Prevent potential id overlap by appending the textarea field with a random id.
+								newId += Math.floor( Math.random() * 1000 );
+								$inputElement.data( 'tinymce-id', newId );
 							}
 
 							$inputElement.attr('id', newId);
+
 							if ( $inputElement.is( '.wp-editor-area' ) ) {
 								var tmceContainer = $inputElement.closest( '.siteorigin-widget-tinymce-container' );
 								var mediaButtons = tmceContainer.data( 'media-buttons' );

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -832,7 +832,6 @@ var sowbForms = window.sowbForms || {};
 						if ($inputElement.is('textarea') && $inputElement.parent().is('.wp-editor-container') && typeof tinymce != 'undefined') {
 							// Update the field ID to prevent duplicates.
 							id = id.replace( /\d+$/, Math.floor( Math.random() * 1000 ) );
-							$inputElement.attr( 'id', id );
 							// Set the field to be reinitialized.
 							$inputElement.find( 'siteorigin-widget-field-type-tinymce' ).data( 'initialized', false );
 							$inputElement.parent().parent().empty().append( $inputElement );
@@ -887,13 +886,15 @@ var sowbForms = window.sowbForms || {};
 								var newRadioIdBase = idBase + '-' + newIds[idBase];
 								newId = newRadioIdBase + id.match(/-\d+$/)[0];
 								$copyItem.find('label[for=' + radioIdBase + ']').attr('for', newRadioIdBase);
-							} else {
+							} else if ( ! $inputElement.is( '.wp-editor-area' ) || typeof tinymce == 'undefined' ) {
 								idRegExp = new RegExp('-\\d+$');
 								idBase = id.replace(idRegExp, '');
 								if (!newIds[idBase]) {
 									newIds[idBase] = $form.find('.siteorigin-widget-input[id^=' + idBase + ']').not('[id*=_id_]').length + 1;
 								}
 								newId = idBase + '-' + newIds[idBase]++;
+							} else {
+								newId = id;
 							}
 
 							$inputElement.attr('id', newId);

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -830,7 +830,12 @@ var sowbForms = window.sowbForms || {};
 						var nm = $inputElement.attr('name');
 						// TinyMCE field :/
 						if ($inputElement.is('textarea') && $inputElement.parent().is('.wp-editor-container') && typeof tinymce != 'undefined') {
-							$inputElement.parent().empty().append($inputElement);
+							// Update the field ID to prevent duplicates.
+							id = id.replace( /\d+$/, Math.floor( Math.random() * 1000 ) );
+							$inputElement.attr( 'id', id );
+							// Set the field to be reinitialized.
+							$inputElement.find( 'siteorigin-widget-field-type-tinymce' ).data( 'initialized', false );
+							$inputElement.parent().parent().empty().append( $inputElement );
 							$inputElement.css('display', '');
 							var curEd = tinymce.get(id);
 							if (curEd) {


### PR DESCRIPTION
This PR resolves an error that results in TinyMCE sometimes not working correctly. An example of this is with the Editor or Tabs widget.

Follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1146
