### PR TITLE
Add Number Step Option to resolve Safari bug

### DIFF
--- a/base/inc/fields/number.class.php
+++ b/base/inc/fields/number.class.php
@@ -5,9 +5,27 @@
  */
 class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_Base {
 
+	/**
+	 * The minimum value of the allowed range.
+	 *
+	 * @access protected
+	 * @var float
+	 */
+	protected $step;
+
 	protected function get_default_options() {
 		return array(
 			'input_type' => 'number',
+		);
+	}
+
+	protected function get_input_attributes() {
+		if ( empty( $this->step ) ) {
+			return array();
+		}
+	
+		return array(
+			'step' => $this->step,
 		);
 	}
 

--- a/base/inc/fields/text-input-base.class.php
+++ b/base/inc/fields/text-input-base.class.php
@@ -46,6 +46,13 @@ abstract class SiteOrigin_Widget_Field_Text_Input_Base extends SiteOrigin_Widget
 		return array();
 	}
 
+	/**
+	 * The attributes to be added to the input element.
+	 */
+	protected function get_input_attributes() {
+		return array();
+	}
+
 	protected function get_default_options() {
 		return array(
 			'input_type' => 'text',
@@ -60,6 +67,15 @@ abstract class SiteOrigin_Widget_Field_Text_Input_Base extends SiteOrigin_Widget
 		echo $attr_string;
 	}
 
+
+	protected function render_attributes( $attributes ) {
+		$attr_string = '';
+		foreach ( $attributes as $name => $value ) {
+			$attr_string = esc_html( $name ) . '="' . esc_attr( $value ) . '"';
+		}
+		echo $attr_string;
+	}
+
 	protected function render_field( $value, $instance ) {
 		?>
 		<input type="<?php echo esc_attr( $this->input_type ) ?>"
@@ -67,6 +83,7 @@ abstract class SiteOrigin_Widget_Field_Text_Input_Base extends SiteOrigin_Widget
 			   id="<?php echo esc_attr( $this->element_id ) ?>"
 		         value="<?php echo esc_attr( $value ) ?>"
 		         <?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
+				 <?php $this->render_attributes( $this->get_input_attributes() ) ?>
 		         <?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
 			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?> />

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -261,7 +261,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 				'label' => __( 'FitText Compressor Strength', 'so-widgets-bundle' ),
 				'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 				'default' => 0.85,
-				'step' => 0.1,
+				'step' => 0.01,
 				'state_handler' => array(
 					'use_fittext[show]' => array( 'show' ),
 					'use_fittext[hide]' => array( 'hide' ),

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -261,6 +261,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 				'label' => __( 'FitText Compressor Strength', 'so-widgets-bundle' ),
 				'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 				'default' => 0.85,
+				'step' => 0.1,
 				'state_handler' => array(
 					'use_fittext[show]' => array( 'show' ),
 					'use_fittext[hide]' => array( 'hide' ),

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -241,7 +241,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 						'label' => __( 'FitText compressor strength', 'so-widgets-bundle' ),
 						'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 						'default' => 0.85,
-						'step' => 0.1,
+						'step' => 0.01,
 						'state_handler' => array(
 							'use_fittext[show]' => array( 'show' ),
 							'use_fittext[hide]' => array( 'hide' ),

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -241,6 +241,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 						'label' => __( 'FitText compressor strength', 'so-widgets-bundle' ),
 						'description' => __( 'The higher the value, the more your headings will be scaled down. Values above 1 are allowed.', 'so-widgets-bundle' ),
 						'default' => 0.85,
+						'step' => 0.1,
 						'state_handler' => array(
 							'use_fittext[show]' => array( 'show' ),
 							'use_fittext[hide]' => array( 'hide' ),


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1174

Safari won't allow number field inputs with a decimal amount unless the field has a decimal step amount. I'm unsure if this is a bug, or intentional.