### PR TITLE
Post Form Field: Add ability to override default fields

### DIFF
--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -164,10 +164,25 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 			} ?>"><?php
 		}
 
+		if ( isset( $this->field_options['fields'] ) ) {
+			$this->override_fields();
+		}
+
 		$this->create_and_render_sub_fields( $value, array( 'name' => $this->base_name, 'type' => 'composite' ) );
 
 		if ( $this->collapsible ) {
 			?></div><?php
+		}
+	}
+
+	private function override_fields() {
+		foreach ( $this->field_options['fields'] as $field => $options ) {
+			// Are we removing, or updating this field?
+			if ( ! empty( $options['remove'] ) ) {
+				unset( $this->fields[ $field ] );
+			} else {
+				$this->fields[ $field ] = wp_parse_args( $this->field_options['fields'][ $field ], $this->fields[ $field ] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1173

You can test this by opening the Post Carousel field and finding:

```
'posts' => array(
	'type' => 'posts',
	'label' => __('Posts query', 'so-widgets-bundle'),
	'hide' => true,
```

Add to the next line:

```
'fields' => array(
	'posts_per_page' => array(
		'label' => __( 'Example label', 'so-widgets-bundle' ),
	),
	'sticky' => array(
		'remove' => true,
	),
),
```