### PR TITLE
Allow HTML in widget title fields

### DIFF
--- a/widgets/editor/tpl/default.php
+++ b/widgets/editor/tpl/default.php
@@ -1,4 +1,4 @@
-<?php if( !empty( $instance['title'] ) ) echo $args['before_title'] . esc_html($instance['title']) . $args['after_title'] ?>
+<?php if( !empty( $instance['title'] ) ) echo $args['before_title'] . $instance['title'] . $args['after_title'] ?>
 
 <div class="siteorigin-widget-tinymce textwidget">
 	<?php echo $text ?>

--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -11,7 +11,7 @@
 ?>
 
 <?php if( $title_position == 'above' ) : ?>
-	<?php echo $args['before_title'] . wp_kses_post( $title ) . $args['after_title']; ?>
+	<?php echo $args['before_title'] . $title . $args['after_title']; ?>
 <?php endif; ?>
 
 <?php
@@ -25,5 +25,5 @@
 </div>
 
 <?php if( $title_position == 'below' ) : ?>
-	<?php echo $args['before_title'] . wp_kses_post( $title ) . $args['after_title']; ?>
+	<?php echo $args['before_title'] . $title . $args['after_title']; ?>
 <?php endif; ?>

--- a/widgets/price-table/tpl/atom.php
+++ b/widgets/price-table/tpl/atom.php
@@ -11,7 +11,7 @@
 ?>
 
 <?php if ( ! empty( $title ) ) {
-	echo $before_title . esc_html( $title ) . $after_title;
+	echo $before_title . $title . $after_title;
 } ?>
 
 <div class="ow-pt-columns-atom<?php echo( $equalize_row_heights ? ' sow-equalize-row-heights' : '' ) ?>">

--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<?php if( !empty( $instance['widget_title'] ) ) echo $args['before_title'] . esc_html( $instance['widget_title'] ) . $args['after_title'] ?>
+<?php if( !empty( $instance['widget_title'] ) ) echo $args['before_title'] . $instance['widget_title'] . $args['after_title'] ?>
 
 <?php if ( $preloader_enabled ) : ?>
 	<div class="sow-masonry-grid-preloader"><div></div><div></div><div></div><div></div></div>

--- a/widgets/social-media-buttons/tpl/default.php
+++ b/widgets/social-media-buttons/tpl/default.php
@@ -4,7 +4,7 @@
  */
 ?>
 
-<?php if ( !empty( $instance['title'] ) ) echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title']; ?>
+<?php if ( !empty( $instance['title'] ) ) echo $args['before_title'] . $instance['title'] . $args['after_title']; ?>
 
 <div class="social-media-button-container">
 	<?php foreach( $networks as $network ) :

--- a/widgets/testimonial/tpl/default.php
+++ b/widgets/testimonial/tpl/default.php
@@ -5,7 +5,7 @@
  * @var $testimonials
  */
 ?>
-<?php if( !empty( $instance['title'] ) ) echo $args['before_title'] . esc_html($instance['title']) . $args['after_title'] ?>
+<?php if( !empty( $instance['title'] ) ) echo $args['before_title'] . $instance['title'] . $args['after_title'] ?>
 <?php $this->caret_svg() ?>
 <div class="sow-testimonials">
 	<?php foreach( $testimonials as $testimonial ) : ?>

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -13,7 +13,7 @@
  */
 
 if ( ! empty( $instance['title'] ) ) {
-	echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];
+	echo $args['before_title'] . $instance['title'] . $args['after_title'];
 }
 
 $video_args = array(


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/913
Titles are already escaped [here](https://github.com/siteorigin/so-widgets-bundle/blob/1.17.8/base/inc/fields/text-input-base.class.php#L76-L80)

I tested using:

`<p>test</p><p>123</p><script>alert(123)</script>`

