### PR TITLE
Ensure Carousel is setup before triggering load event

### DIFF
--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -179,12 +179,12 @@ jQuery( function ( $ ) {
 				.prop( 'tabindex', 0 );
 		} );
 
-		$( window ).on( 'resize load', function() {
+		$( window ).on( 'resize setup_widgets', function() {
 			// Hide/disable scroll if number of visible items is less than total posts.
 
 			$( '.sow-carousel-wrapper' ).each( function() {
 				var currentCarousel = $( this ),
-					$items = currentCarousel.find( '.sow-carousel-items' ),
+					$items = currentCarousel.find( '.sow-carousel-items.slick-initialized' ),
 					numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
 					navigation = currentCarousel.parent().parent().find( '.sow-carousel-navigation' );
 
@@ -201,8 +201,8 @@ jQuery( function ( $ ) {
 
 			// Change Slick Settings on iPad Pro while Landscape
 			if ( window.matchMedia( '(min-width: ' + carouselBreakpoints.tablet_portrait + 'px) and (max-width: ' + carouselBreakpoints.tablet_landscape + 'px) and (orientation: landscape)' ).matches ) {
-				$( '.sow-carousel-items' ).slick( 'slickSetOption', 'slidesToShow', 3 );
-				$( '.sow-carousel-items' ).slick( 'slickSetOption', 'slidesToScroll', 3 );
+				$( '.sow-carousel-items.slick-initialized' ).slick( 'slickSetOption', 'slidesToShow', 3 );
+				$( '.sow-carousel-items.slick-initialized' ).slick( 'slickSetOption', 'slidesToScroll', 3 );
 			}
 
 			$( '.sow-carousel-item:first-of-type' ).prop( 'tabindex', 0 );


### PR DESCRIPTION
This PR was done to avoid a potential situation where the load is triggered before setup_widgets is. It'll also avoid a situation where an error occurs if Slick isn't able to load.