### PR TITLE
Build Config: Exclude already minified JS files

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -32,8 +32,8 @@ module.exports = {
             'widgets/**/*.js',
             '!{node_modules,node_modules/**}',  // Ignore node_modules/ and contents
             '!{tests,tests/**}',                // Ignore tests/ and contents
-            '!{tmp,tmp/**}',                     // Ignore dist/ and contents
-            '!**/**/*.min.js'                     // Ignore dist/ and contents
+            '!{tmp,tmp/**}',                    // Ignore dist/ and contents
+            '!**/**/*.min.js'                   // Ignore already minified files.
         ]
     },
     bust : {

--- a/build-config.js
+++ b/build-config.js
@@ -32,7 +32,8 @@ module.exports = {
             'widgets/**/*.js',
             '!{node_modules,node_modules/**}',  // Ignore node_modules/ and contents
             '!{tests,tests/**}',                // Ignore tests/ and contents
-            '!{tmp,tmp/**}'                     // Ignore dist/ and contents
+            '!{tmp,tmp/**}',                     // Ignore dist/ and contents
+            '!**/**/*.min.js'                     // Ignore dist/ and contents
         ]
     },
     bust : {


### PR DESCRIPTION
This prevents *.min.min files that was resulting in weird minify issues in the Block Editor.