### PR TITLE
Enqueue Google Fonts rather than @import

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -144,7 +144,12 @@ function siteorigin_widget_get_font($font_value) {
 			$font_url_param .= ':' . $font_parts[1];
 		}
 		$font['url'] = 'https://fonts.googleapis.com/css?family=' . $font_url_param;
-		$font['css_import'] = '@import url(https://fonts.googleapis.com/css?family=' . $font_url_param . '&display=swap);';
+		$style_name = 'sow-google-font-' . strtolower( $font['family'] );
+
+		// Check if WB (or something else has) has already enqueued the font.
+		if ( ! wp_style_is( $style_name ) ) {
+			wp_enqueue_style( $style_name,  $font['url'] . '&display=swap' );
+		}
 	}
 	else {
 		$font['family'] = $font_value;

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1014,49 +1014,6 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Less function for importing Google web fonts.
-	 *
-	 * @param $instance
-	 * @param $args
-	 *
-	 * @return string
-	 */
-	function less_import_google_font($instance, $args) {
-		if( empty( $instance ) ) return;
-
-		$fonts = $this->get_google_font_fields($instance);
-		if( empty( $fonts ) || ! is_array( $fonts ) ) return '';
-
-		$font_imports = array();
-
-		foreach ( $fonts as $font ) {
-			$font_imports[] = siteorigin_widget_get_font( $font );
-		}
-
-		$import_strings = array();
-		foreach( $font_imports as $import ) {
-			$import_strings[] = !empty($import['css_import']) ? $import['css_import'] : '';
-		}
-
-		// Remove empty and duplicate items from the array
-		$import_strings = array_filter( $import_strings );
-		$import_strings = array_unique( $import_strings );
-
-		return implode( "\n", $import_strings );
-	}
-
-	/**
-	 * Get any font fields which may be used by this widget.
-	 *
-	 * @param $instance
-	 *
-	 * @return array
-	 */
-	function get_google_font_fields( $instance ) {
-		return apply_filters( 'siteorigin_widgets_google_font_fields_' . $this->id_base, array(), $instance, $this );
-	}
-
-	/**
 	 * Utility function to get a field name for a widget field.
 	 *
 	 * @param $field_name

--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @heading_background_color: default;
 @heading_background_hover_color: default;
 @title_color: default;

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -371,11 +371,6 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 		return $less_vars;
 	}
 
-	function get_google_font_fields( $instance ) {
-		return array(
-			$instance['design']['font'],
-		);
-	}
 	/**
 	 * Make sure the instance is the most up to date version.
 	 *

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @button_width: '';
 @button_color: #41a9d5;
 @border_color: darken(@button_color, 15%);

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @button_width: '';
 @button_color: #41a9d5;
 @border_color: darken(@button_color, 5%);

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @button_width: '';
 @button_color: #41a9d5;
 @text_color: #FFFFFF;

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -892,13 +892,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		return $vars;
 	}
 
-	function get_google_font_fields( $instance ) {
-		return array(
-			$instance['design']['labels']['font'],
-			$instance['design']['fields']['font'],
-		);
-	}
-
 	static function name_from_label( $label, & $ids ) {
 		$it = 0;
 

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 .sow-form-field {
 	display: block;
 	margin-bottom: 1em;

--- a/widgets/cta/styles/default.less
+++ b/widgets/cta/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @border_color: default;
 @background_color: default;
 @title_color: default;

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -323,17 +323,6 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 			)
 		);
 	}
-
-	function get_google_font_fields( $instance ) {
-
-		$fonts = $instance['fonts'];
-
-		return array(
-			$fonts['title_options']['font'],
-			$fonts['text_options']['font'],
-			$fonts['more_text_options']['font'],
-		);
-	}
 }
 
 siteorigin_widget_register('sow-features', __FILE__, 'SiteOrigin_Widget_Features_Widget');

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @title_font: default;
 @title_font_weight: 400;
 @title_size: default;

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -319,13 +319,6 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 		return $less_vars;
 	}
 
-	function get_google_font_fields( $instance ) {
-		return array(
-			$instance['headline']['font'],
-			$instance['sub_headline']['font'],
-		);
-	}
-
 	/**
 	 * Get the template variables for the headline
 	 *

--- a/widgets/headline/styles/default.less
+++ b/widgets/headline/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @headline_tag: h1;
 @headline_font: default;
 @headline_font_weight: 400;

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -455,21 +455,6 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		return $val;
 	}
 
-	/**
-	 * Less function for importing Google web fonts.
-	 *
-	 * @param $instance
-	 * @param $args
-	 *
-	 * @return string
-	 */
-	function get_google_font_fields( $instance ) {
-		return array(
-			$instance['design']['heading_font'],
-			! empty( $instance['design']['text_font'] ) ? $instance['design']['text_font'] : '',
-		);
-	}
-
 	function wrapper_class_filter( $classes, $instance ){
 		if( ! empty( $instance['design']['fittext'] ) ) {
 			$classes[] = 'so-widget-fittext-wrapper';

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @nav_color_hex: #FFFFFF;
 @nav_size: 25;
 

--- a/widgets/tabs/styles/default.less
+++ b/widgets/tabs/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @tabs_container_background_color: default;
 @tabs_container_border_color: default;
 @tabs_container_border_width: default;

--- a/widgets/testimonial/styles/default.less
+++ b/widgets/testimonial/styles/default.less
@@ -1,7 +1,5 @@
 @import "../../../base/less/mixins";
 
-.widget-function('import_google_font');
-
 @testimonial_padding: 10px;
 
 @testimonial_background: transparent;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1179

`siteorigin_widgets_google_font_fields_X` has been removed, but as it's not the main method of adding fonts I don't see any harm in removing it.