### PR TITLE
Accordion: Scroll to panel if the user is below it

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -42,7 +42,14 @@ jQuery( function ( $ ) {
 							$( sowb ).trigger( 'setup_widgets' );
 						},
 						complete: function() {
-							if ( keepVisible && sowAccordion.scrollto_after_change && $panel.offset().top < window.scrollY ) {
+							if (
+								keepVisible &&
+								sowAccordion.scrollto_after_change &&
+								(
+									$panel.offset().top < window.scrollY ||
+									$panel.offset().top + $panel.height() > window.scrollY
+								)
+							) {
 								scrollToPanel( $panel, true );
 							}
 							$( this ).trigger( 'show' );


### PR DESCRIPTION
This PR brings the Accordion widget into line with how the Tabs widget handles scroll to. If the user is below the Accordion panel and opens a new one they will now be scrolled up. Previously, the scroll would only occur if the user was above it.