### PR TITLE
Tabs: Prevent scrollto on selected tab

### DIFF
--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -35,11 +35,21 @@ jQuery( function ( $ ) {
 					window.scrollTo( 0, scrollTop );
 				}
 			};
-			
+
+			var shouldScroll = function( $tab ) {
+				return sowTabs.scrollto_after_change &&
+				(
+					$tab.offset().top < window.scrollY ||
+					$tab.offset().top + $tab.height() > window.scrollY
+				);
+			}
+
 			var selectTab = function ( tab, preventHashChange ) {
 				var $tab = $( tab );
 				if ( $tab.is( '.sow-tabs-tab-selected' ) ) {
-					scrollToTab( true );
+					if ( shouldScroll( $tab ) ) {
+						scrollToTab( true );
+					}
 					return true;
 				}
 				var selectedIndex = $tab.index();
@@ -79,11 +89,8 @@ jQuery( function ( $ ) {
 								},
 								complete: function() {
 									$( this ).trigger( 'show' );
-									if ( ! sowTabs.scrollto_after_change ) {
-										return;
-									}
 
-									if ( $tab.offset().top < window.scrollY || $tab.offset().top + $tab.height() > window.scrollY ) {
+									if ( shouldScroll( $tab ) ) {
 										scrollToTab( true );
 									}
 								}


### PR DESCRIPTION
This PR will prevent the scrollto setting from affecting the currently selected tab. Previously, selecting the currently selected tab when scrollto was disabled would still trigger the scroll.