### PR TITLE
Images widgets: Add auto image titles

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -158,16 +158,21 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	 *
 	 * @return string The title of the image.
 	 */
-	private function get_image_title($image) {
+	private function get_image_title( $image ) {
 		if ( ! empty( $image['title'] ) ) {
 			$title = $image['title'];
-		} else {
-			// We do not want to use the default image titles as they're based on the file name without the extension
-			$file_name = pathinfo( get_post_meta( $image['image'], '_wp_attached_file', true ), PATHINFO_FILENAME );
-			$title = get_the_title( $image['image'] );
-			if ( $title == $file_name ) {
-				$title = '';
+		} else if ( apply_filters( 'siteorigin_widgets_auto_title', true, 'sow-image-grid' ) ) {
+			$title = wp_get_attachment_caption( $image['image'] );
+			if ( empty( $title ) ) {
+				// We do not want to use the default image titles as they're based on the file name without the extension
+				$file_name = pathinfo( get_post_meta( $image['image'], '_wp_attached_file', true ), PATHINFO_FILENAME );
+				$title = get_the_title( $image['image'] );
+				if ( $title == $file_name ) {
+					$title = '';
+				}
 			}
+		} else {
+			$title = '';
 		}
 
 		return $title;

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -115,17 +115,8 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 	}
 
 	public function get_template_variables( $instance, $args ) {
-		// Workout the image title
-		if ( ! empty( $instance['title'] ) ) {
-			$title = $instance['title'];
-		} else {
-			// We do not want to use the default image titles as they're based on the file name without the extension
-			$file_name = pathinfo( get_post_meta( $instance['image'], '_wp_attached_file', true ), PATHINFO_FILENAME );
-			$title = get_the_title( $instance['image'] );
-			if ( $title == $file_name ) {
-				$title = '';
-			}
-		}
+		$title = $this->get_image_title( $instance );
+
 		$src = siteorigin_widgets_get_attachment_image_src(
 			$instance['image'],
 			$instance['size'],
@@ -187,6 +178,32 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 		);
 	}
 
+	/**
+	 * Try to figure out an image's title for display.
+	 *
+	 * @param $image
+	 *
+	 * @return string The title of the image.
+	 */
+	private function get_image_title( $image ) {
+		if ( ! empty( $image['title'] ) ) {
+			$title = $image['title'];
+		} else if ( apply_filters( 'siteorigin_widgets_auto_title', true, 'sow-image' ) ) {
+			$title = wp_get_attachment_caption( $image['image'] );
+			if ( empty( $title ) ) {
+				// We do not want to use the default image titles as they're based on the file name without the extension
+				$file_name = pathinfo( get_post_meta( $image['image'], '_wp_attached_file', true ), PATHINFO_FILENAME );
+				$title = get_the_title( $image['image'] );
+				if ( $title == $file_name ) {
+					$title = '';
+				}
+			}
+		} else {
+			$title = '';
+		}
+
+		return $title;
+	}
 
 	function get_less_variables($instance){
 		if ( empty( $instance ) ) {

--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -229,6 +229,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 				$link_atts['rel'] = 'noopener noreferrer';
 			}
 			$item['link_attributes'] = $link_atts;
+			$item['title'] = $this->get_image_title( $item );
 		}
 		return array(
 			'args' => $args,
@@ -261,6 +262,33 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Try to figure out an image's title for display.
+	 *
+	 * @param $image
+	 *
+	 * @return string The title of the image.
+	 */
+	private function get_image_title( $image ) {
+		if ( ! empty( $image['title'] ) ) {
+			$title = $image['title'];
+		} else if ( apply_filters( 'siteorigin_widgets_auto_title', true, 'sow-simple-masonry' ) ) {
+			$title = wp_get_attachment_caption( $image['image'] );
+			if ( empty( $title ) ) {
+				// We do not want to use the default image titles as they're based on the file name without the extension
+				$file_name = pathinfo( get_post_meta( $image['image'], '_wp_attached_file', true ), PATHINFO_FILENAME );
+				$title = get_the_title( $image['image'] );
+				if ( $title == $file_name ) {
+					return;
+				}
+			}
+		} else {
+			$title = '';
+		}
+
+		return $title;
 	}
 
 	public function get_less_variables( $instance ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-premium/issues/437 (also adds it to Image Overlay).

- Supports image caption, title.
- Prevent filename being used as title
- Add filter `siteorigin_widgets_auto_title` to disable auto title.

Here are some filters to test the filter.

Disable auto title for all image widgets:

`add_filter( 'siteorigin_widgets_auto_title', '__return_false' );`

Disable auto title for image widget:

```
add_filter( 'siteorigin_widgets_auto_title', function ( $enabled, $widget ) {
	if ( $widget == 'sow-image' ) {
		return false;
	}
	return true;
}, 10, 2 );
```