### PR TITLE
Elementor styling changes

### DIFF
--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -6,6 +6,7 @@
 		display: inline-block;
 		.gradient( #f9f9f9, #f2f2f2, #f9f9f9 );
 		.box-shadow(~"0 1px 2px rgba(0,0,0,0.1)");
+		box-sizing: content-box;
 		.rounded(3px);
 		vertical-align: middle;
 

--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -5,6 +5,7 @@
 	.media-field-wrapper {
 		border: 1px solid #bbb;
 		.box-shadow(~"0 1px 2px rgba(0, 0, 0, 0.1)");
+		box-sizing: content-box;
 		display: block;
 		float: left;
 		font-size: 13px;
@@ -17,6 +18,10 @@
 
 		&:hover {
 			.box-shadow(~"0 1px 2px rgba(0, 0, 0, 0.15)");
+		}
+
+		* {
+			box-sizing: content-box;
 		}
 
 		.current {
@@ -62,6 +67,7 @@
 		.media-upload-button,
 		.find-image-button {
 			display: block;
+			border-bottom: none;
 			cursor: pointer;
 			float: left;
 			font-size: 11px;
@@ -69,7 +75,8 @@
 			color: #666;
 			outline: none;
 			.rounded(2px);
-			padding: 7px 8px;
+			line-height: 32px;
+			padding: 0 8px;
 			text-decoration: none;
 			text-shadow: 0 1px 0 #fff;
 
@@ -89,6 +96,7 @@
 
 	.media-remove-button {
 		display: block;
+		border-bottom: none;
 		color: #aaa;
 		float: left;
 		font-size: 11px;

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -73,8 +73,20 @@
 		&.siteorigin-widget-field-type-icon {
 			.siteorigin-widget-icon-selector {
 				.siteorigin-widget-icon-search {
+					box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+					background-color: #fff;
+					color: #32373c;
 					width: 100%;
+
+					&::placeholder,
+					&::-webkit-input-placeholder {
+						color: #32373c;
+					}
 				}
+			}
+
+			.siteorigin-widget-icon-icons-icon {
+				color: #444;
 			}
 		}
 

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -144,44 +144,6 @@
 		color: #000;
 	}
 
-	/* Button styles copied from wp-core for default UI look. */
-	.button, .button-secondary {
-		display: inline-block;
-		text-decoration: none;
-		font-size: 13px;
-		line-height: 28px;
-		height: 28px;
-		margin: 0;
-		padding: 0 10px 1px;
-		cursor: pointer;
-		border: 1px solid #cccccc;
-		border-radius: 3px;
-		white-space: nowrap;
-		box-sizing: border-box;
-
-		font-family: inherit;
-		font-weight: normal;
-		text-transform: capitalize;
-		color: #555;
-		background: #f7f7f7;
-
-		&:hover,
-		&:focus {
-			background: #fafafa;
-			border-color: #999;
-			color: #23282d;
-		}
-
-		&:active,
-		&:focus {
-			outline: none;
-		}
-
-		&.hidden {
-			display: none;
-		}
-	}
-
 	.button.wp-color-result {
 		font-size: 12px;
 		height: 32px;
@@ -250,4 +212,91 @@
 		margin-top: 5px;
 	}
 
+}
+
+.elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form,
+#so-widgets-image-search-frame {
+	/* Button styles copied from wp-core for default UI look. */
+	.button, .button-secondary {
+		display: inline-block;
+		text-decoration: none;
+		font-size: 13px;
+		line-height: 28px;
+		height: 28px;
+		margin: 0;
+		padding: 0 10px 1px;
+		cursor: pointer;
+		border: 1px solid #cccccc;
+		border-radius: 3px;
+		white-space: nowrap;
+		box-sizing: border-box;
+
+		font-family: inherit;
+		font-weight: normal;
+		text-transform: capitalize;
+		color: #555;
+		background: #f7f7f7;
+
+		&:hover,
+		&:focus {
+			background: #fafafa;
+			border-color: #999;
+			color: #23282d;
+		}
+
+		&:active,
+		&:focus {
+			outline: none;
+		}
+
+		&.hidden {
+			display: none;
+		}
+	}
+
+	.button-primary {
+		background: #007cba;
+		border-color: #007cba;
+		color: #fff;
+		text-decoration: none;
+		text-shadow: none;
+	}
+
+}
+
+#so-widgets-image-search-frame {
+	.so-widgets-search-input {
+		background: #fff;
+		color: #32373c;
+		border: 1px solid #7e8993;
+		line-height: 1;
+		min-height: 47px;
+		font-size: 14px;
+	}
+
+	.so-widgets-image-search-powered {
+		font-size: 11px;
+	}
+
+	a {
+		color: #0073aa;
+		text-decoration: underline;
+
+		&:active,
+		&:hover {
+			color: #006799;
+		}
+	}
+
+	.so-widgets-results-loading {
+		color: #444;
+	}
+}
+
+.so-widgets-dialog .so-widgets-toolbar h3 {
+	color: #23282d;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 16.9px;
+	font-weight: 600;
+	margin: 15px 0 15px 20px;
 }

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -1,5 +1,4 @@
 .elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form {
-	color: #000;
 	min-width: inherit;
 
 	.wp-picker-container {
@@ -126,7 +125,16 @@
 				max-width: 220px;
 			}
 		}
+
+		.siteorigin-widget-description {
+			color: inherit;
+		}
 	}
+
+	.siteorigin-widget-field-type-section {
+		color: #000;
+	}
+
 	/* Button styles copied from wp-core for default UI look. */
 	.button, .button-secondary {
 		display: inline-block;

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -149,7 +149,7 @@
 		display: inline-block;
 		text-decoration: none;
 		font-size: 13px;
-		line-height: 26px;
+		line-height: 28px;
 		height: 28px;
 		margin: 0;
 		padding: 0 10px 1px;

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -126,6 +126,10 @@
 			}
 		}
 
+		.siteorigin-widget-input[type="text"] {
+			height: 30px;
+		}
+
 		.siteorigin-widget-input[type="checkbox"] {
 			display: inline-block;
 			vertical-align: middle;

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -1,6 +1,10 @@
 .elementor-panel #elementor-panel-page-editor .elementor-control-content .siteorigin-widget-form {
 	min-width: inherit;
 
+	a {
+		border-bottom: none;
+	}
+
 	.wp-picker-container {
 		float: none;
 

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -126,6 +126,11 @@
 			}
 		}
 
+		.siteorigin-widget-input[type="checkbox"] {
+			display: inline-block;
+			vertical-align: middle;
+		}
+
 		.siteorigin-widget-description {
 			color: inherit;
 		}

--- a/compat/elementor/styles.less
+++ b/compat/elementor/styles.less
@@ -190,7 +190,7 @@
 
 	.button.button-small {
 		height: 25px;
-		line-height: 23px;
+		line-height: 30px;
 		padding: 0 8px;
 		font-size: 11px;
 	}


### PR DESCRIPTION
This PR does the following:

- Allows for the darkmode text color to be used outside of sections
- Vertically aligns checkboxes with rest of the label text
- Gives text fields a set height so they're more consistent with other fields.

Regarding the first point, Elementor doesn't set a class to indicate whether dark mode is active so we need to rely on elementor to set the text color outside of the sections field.