### PR TITLE
Slider: Set Loading To Eager

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -168,7 +168,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						!empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
 						array(
 							'class' => 'sow-slider-foreground-image',
-							'loading' => true,
+							'loading' => 'eager',
 						)
 					);
 					?>
@@ -198,7 +198,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				!empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
 				array(
 					'class' => 'sow-slider-background-image',
-					'loading' => true,
+					'loading' => 'eager',
 				)
 			);
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1192

This PR will ensure we comply with HTML standards with how we're disabling (lazy) loading for the Slider images. I didn't notice any issues after making this change. Please be sure to test the SiteOrigin Layout block preview as that's why the [original change](https://github.com/siteorigin/so-widgets-bundle/pull/1125) was made.