### PR TITLE
Add .current title to media field for item labels

### DIFF
--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -65,6 +65,7 @@
 				var attachment = frame.state().get('selection').first().attributes;
 
 				$field.find('.current .thumbnail' ).attr( 'title', attachment.title );
+				$field.find('.current .title' ).html( attachment.title );
 				$inputField.val(attachment.id);
 				$inputField.trigger( 'change', { silent: true } );
 
@@ -95,6 +96,7 @@
 			.click( function( e ){
 				e.preventDefault();
 				$inputField.val('');
+				$field.find('.current .title' ).empty();
 				$inputField.trigger( 'change', { silent: true } );
 				$field.find('.current .thumbnail' ).fadeOut('fast');
 				$(this).addClass('remove-hide');

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -92,7 +92,7 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 		<div class="media-field-wrapper">
 			<div class="current">
 				<div class="thumbnail-wrapper">
-					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> <?php if( !empty( $post ) ) echo 'title="' . esc_attr( $post->post_title ); . '"' ?>/>
+					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> <?php if( !empty( $post ) ) echo 'title="' . esc_attr( $post->post_title ) . '"' ?>/>
 					<div class="title"><?php if( !empty( $post ) ) echo esc_attr( $post->post_title ); ?></div>
 				</div>
 			</div>

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -92,7 +92,8 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 		<div class="media-field-wrapper">
 			<div class="current">
 				<div class="thumbnail-wrapper">
-					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> <?php if( !empty( $post ) ) echo 'title="' . esc_attr( $post->post_title ) . '"' ?>/>
+					<img src="<?php echo sow_esc_url( $src[0] ) ?>" class="thumbnail" <?php if( empty( $src[0] ) ) echo "style='display:none'" ?> <?php if( !empty( $post ) ) echo 'title="' . esc_attr( $post->post_title ); . '"' ?>/>
+					<div class="title"><?php if( !empty( $post ) ) echo esc_attr( $post->post_title ); ?></div>
 				</div>
 			</div>
 			<a href="#" class="media-upload-button" data-choose="<?php echo esc_attr( $this->choose ) ?>"


### PR DESCRIPTION
This PR adds the .current title field to the media field. This field is used by widgets such as the Simple Masonry and Layout Slider to label the item based on the select time.