### PR TITLE
Underscores to Camel Case: Account for nested arrays

### DIFF
--- a/base/inc/string-utils.php
+++ b/base/inc/string-utils.php
@@ -10,6 +10,10 @@ function siteorigin_widgets_underscores_to_camel_case( $array ) {
 	$transformed = array();
 	if ( !empty( $array ) ) {
 		foreach ( $array as $key => $val ) {
+			if ( is_array( $val ) ) {
+				$val = siteorigin_widgets_underscores_to_camel_case( $val );
+			}
+
 			$jsKey = preg_replace_callback( '/_(.?)/', 'siteorigin_widgets_match_to_upper', $key );
 			$transformed[ $jsKey ] = $val;
 		}


### PR DESCRIPTION
This PR accounts for nested arrays passed to the siteorigin_widgets_underscores_to_camel_case function.

An example use case are item labels. Standard Item labels use `value_method` to assign a function to retrieve the value. `value_method` is then converted to `valueMethod` by `siteorigin_widgets_underscores_to_camel_case` for use with JavaScript. This wasn't however possible in a `selectorArray` and required `valueMethod` to be used instead of `value_method`. This PR allows for both `value_method` and `valueMethod` to now be used.

You can test this PR by changing [this line](https://github.com/siteorigin/so-widgets-bundle/blob/1.17.8/widgets/simple-masonry/simple-masonry.php#L53) to value_method - requries https://github.com/siteorigin/so-widgets-bundle/pull/1198