### PR TITLE
Contact: Update Accordion Selector

### DIFF
--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -19,7 +19,7 @@ sowb.SiteOriginContactForm = {
 					formPosition = $container.offset().top;
 					// If the closest visible ancestor is either SOWB Accordion or Tabs widget, try to open the panel.
 					if ( $container.is( '.sow-accordion-panel' ) ) {
-						$container.find( '> .sow-accordion-panel-header' ).click();
+						$container.find( '> .sow-accordion-panel-header-container > .sow-accordion-panel-header' ).trigger( 'click' );
 					} else if ( $container.is( '.sow-tabs-panel-container' ) ) {
 						var tabIndex = $el.closest( '.sow-tabs-panel' ).index();
 						$container.siblings( '.sow-tabs-tab-container' ).find( '> .sow-tabs-tab' ).eq( tabIndex ).click();


### PR DESCRIPTION
The previous selector was invalid. This PR will ensure the Accordion widget is opened on load. 

To test this, add an Accordion widget with a SiteOrigin Contact Form inside one of the panels - ensure the panel is set to be closed by default. Fill out the form and then submit it. The Accordion panel will be opened on load.