### PR TITLE
5.6 jquery migrate changes

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2,7 +2,7 @@
 
 jQuery( function( $ ){
 
-	$('.so-widget-toggle-active button').click( function(){
+	$( '.so-widget-toggle-active button' ).on( 'click', function() {
 		var $$ = $(this),
 			s = $$.data('status'),
 			$w = $$.closest('.so-widget');
@@ -78,7 +78,7 @@ jQuery( function( $ ){
 		search: widgetSearch
 	});
 
-	$(window).resize(function() {
+	$( window ).on( 'resize', function() {
 		var $descriptions = $('.so-widget-text').css('height', 'auto');
 		var largestHeight = 0;
 
@@ -90,10 +90,10 @@ jQuery( function( $ ){
 			$(this).css('height', largestHeight);
 		});
 
-	}).resize();
+	} ).trigger( 'resize' );
 
 	// Handle the tabs
-	$('#sow-widgets-page .page-nav a').click(function(e){
+	$( '#sow-widgets-page .page-nav a' ).on( 'click', function( e ) {
 		e.preventDefault();
 		var $$ = $(this);
 		var href = $$.attr('href');
@@ -119,7 +119,7 @@ jQuery( function( $ ){
 				break;
 		}
 
-		$(window).resize();
+		$( window ).trigger( 'resize' );
 	});
 
 	// Enable css3 animations on the widgets list
@@ -128,7 +128,7 @@ jQuery( function( $ ){
 	// Handle the dialog
 	var dialog = $('#sow-settings-dialog');
 
-	$( '#widgets-list .so-widget-settings' ).click( function( e ){
+	$( '#widgets-list .so-widget-settings' ).on( 'click', function( e ) {
 		var $$ = $(this);
 		e.preventDefault();
 
@@ -146,21 +146,21 @@ jQuery( function( $ ){
 		dialog.show();
 	} );
 
-	dialog.find('.so-close').click( function( e ){
+	dialog.find( '.so-close' ).on( 'click', function( e ) {
 		e.preventDefault();
 		dialog.hide();
 	} );
 
-	dialog.find('.so-save').click( function( e ){
+	dialog.find( '.so-save' ).on( 'click', function( e ) {
 		e.preventDefault();
 
 		var $$ = $( this );
 		$$.prop( 'disabled', true );
 
-		dialog.find( 'form' ).submit( function() {
+		dialog.find( 'form' ).on( 'submit', function() {
 			$$.prop( 'disabled', false );
 			dialog.hide();
-		} ).submit();
+		} ).trigger( 'submit' );
 	} );
 
 	// Enable all widget settings button after the save iframe has loaded.
@@ -171,7 +171,7 @@ jQuery( function( $ ){
 	// Automatically open settings modal based on hash
 	if( window.location.hash && window.location.hash.substring(0, 10) === '#settings-' ) {
 		var openSettingsId = window.location.hash.substring(10);
-		$('div[data-id="' + openSettingsId +  '"] button.so-widget-settings').click();
+		$('div[data-id="' + openSettingsId +  '"] button.so-widget-settings').trigger( 'click' );
 	}
 
 } );

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -48,7 +48,7 @@ jQuery( function( $ ){
 		else {
 			if( $img.width() > 128 ) {
 				// Deal with wide banner images
-				$img.css('margin-left', -($img.width()-128)/2 );
+				$img.css( 'margin-left', - ( $img.width() - 128 ) / 2 + 'px' );
 			}
 		}
 	} );
@@ -87,7 +87,7 @@ jQuery( function( $ ){
 		});
 
 		$descriptions.each(function () {
-			$(this).css('height', largestHeight);
+			$( this ).css( 'height', largestHeight + "px" );
 		});
 
 	} ).trigger( 'resize' );

--- a/admin/trianglify.js
+++ b/admin/trianglify.js
@@ -226,7 +226,7 @@
          */
 
 // conditionally load jsdom if we don't have a browser environment available.
-        var doc = (typeof document !== "undefined") ? document : require('jsdom').jsdom('<html/>');
+        var doc = (typeof document !== "undefined") ? document : require('jsdom').jsdom('<html></html>');
 
         function Pattern(polys, opts) {
 

--- a/base/inc/fields/js/autocomplete-field.js
+++ b/base/inc/fields/js/autocomplete-field.js
@@ -66,7 +66,7 @@
 			);
 		};
 
-		$$.find('.siteorigin-widget-autocomplete-input').click(function () {
+		$$.find( '.siteorigin-widget-autocomplete-input' ).on( 'click', function () {
 			var $s = $$.find('.existing-content-selector');
 			$s.show();
 
@@ -84,14 +84,14 @@
 			$$.find('.existing-content-selector').hide();
 		};
 
-		$(window).mousedown(function (event) {
+		$( window ).on( 'mousedown', function( event ) {
 			var mouseDownOutside = $$.find(event.target).length === 0;
 			if ( mouseDownOutside ) {
 				closeContent();
 			}
 		});
 
-		$$.find('.button-close').click( closeContent );
+		$$.find('.button-close').on( 'click', closeContent );
 
 		// Clicking on one of the url items
 		$$.on( 'click', '.items li', function(e) {
@@ -111,11 +111,11 @@
 			}
 			var $input = $$.find('input.siteorigin-widget-input');
 			$input.val( selectedItems.join(',') );
-			$input.change();
+			$input.trigger( 'change' );
 		} );
 
 		var interval = null;
-		$$.find('.content-text-search').keyup( function(){
+		$$.find('.content-text-search').on( 'keyup', function() {
 			if( interval !== null ) {
 				clearTimeout(interval);
 			}

--- a/base/inc/fields/js/code-field.js
+++ b/base/inc/fields/js/code-field.js
@@ -191,14 +191,14 @@
 									end = start;
 								}
 								if (defaults.textarea.setSelectionRange) {
-									defaults.textarea.focus();
+									defaults.textarea.trigger( 'focus' );
 									defaults.textarea.setSelectionRange(start, end);
 								} else if (defaults.textarea.createTextRange) {
 									var range = defaults.textarea.createTextRange();
 									range.collapse(true);
 									range.moveEnd('character', end);
 									range.moveStart('character', start);
-									range.select();
+									range.trigger( 'select' );
 								}
 							},
 							selection: function(){

--- a/base/inc/fields/js/date-range-field.js
+++ b/base/inc/fields/js/date-range-field.js
@@ -47,7 +47,7 @@
 					onSelect: updateValField,
 				} );
 
-				$field.change( function ( event ) {
+				$field.on( 'change', function( event ) {
 					var dateVal = parse( $field.val() );
 					updateValField( dateVal );
 					
@@ -66,7 +66,7 @@
 			var afterPicker = createPikadayInput( 'after', initRange.after );
 			var beforePicker = createPikadayInput( 'before', initRange.before );
 
-			valField.change( function ( event, data ) {
+			valField.on( 'change', function( event, data ) {
 				if ( ! ( data && data.silent ) ) {
 					var newRange = valField.val() === '' ? { after: '', before: '' } : JSON.parse( valField.val() );
 					afterPicker.setDate( newRange.after );
@@ -78,7 +78,7 @@
 			$dateRangeField.find( '.sowb-relative-date' ).each( function () {
 				var $name = $( this ).data( 'name' );
 
-				$( this ).change( function () {
+				$( this ).on( 'change', function() {
 					var range = valField.val() === '' ? {} : JSON.parse( valField.val() );
 
 					if ( ! range.hasOwnProperty( $name ) ) {
@@ -92,7 +92,7 @@
 					valField.trigger( 'change', { silent: true } );
 				}.bind( this ) );
 
-				valField.change( function ( event, data ) {
+				valField.on( 'change', function( event, data ) {
 					if ( ! ( data && data.silent ) ) {
 						var range = valField.val() === '' ? { from: {}, to: {} } : JSON.parse( valField.val() );
 

--- a/base/inc/fields/js/icon-field.js
+++ b/base/inc/fields/js/icon-field.js
@@ -116,7 +116,7 @@
 				}
 				var familyStyle = 'sow-icon-' + family + ( style ? ' ' + style : '' );
 				var familyValue = family + ( style ? '-' + style : '' ) + '-' + i;
-				var $icon = $('<div data-sow-icon="' + unicode + '"/>')
+				var $icon = $( '<div data-sow-icon="' + unicode + '"></div>' )
 					.attr('data-value', familyValue )
 					.addClass( familyStyle )
 					.addClass( 'siteorigin-widget-icon-icons-icon' )

--- a/base/inc/fields/js/icon-field.js
+++ b/base/inc/fields/js/icon-field.js
@@ -17,18 +17,18 @@
 		}
 
 		// Clicking on the button should display the icon selector
-		$b.click( function(){
+		$b.on( 'click', function() {
 			$is.slideToggle();
 			$search.val( '' );
 			searchIcons();
 		} );
 
 		// Clicking on the remove button
-		$remove.click( function( e ){
+		$remove.on( 'click', function( e ) {
 			e.preventDefault();
 
 			// Trigger a click on the existing icon to remove it.
-			$$.find('.siteorigin-widget-active').click();
+			$$.find('.siteorigin-widget-active').trigger( 'click' );
 		} );
 
 		var searchIcons = function(){
@@ -52,7 +52,7 @@
 			}
 		};
 
-		$search.keyup( searchIcons ).change( searchIcons );
+		$search.keyup( searchIcons ).on( 'change', searchIcons );
 		
 		var renderStylesSelect = function ( init ) {
 			var $familySelect = $is.find( 'select.siteorigin-widget-icon-family' );
@@ -120,7 +120,7 @@
 					.attr('data-value', familyValue )
 					.addClass( familyStyle )
 					.addClass( 'siteorigin-widget-icon-icons-icon' )
-					.click(function(){
+					.on( 'click', function() {
 						var $$ = $(this);
 
 						if( $$.hasClass('siteorigin-widget-active') ) {
@@ -212,12 +212,12 @@
 		};
 		changeIconFamily( true );
 
-		$is.find('select.siteorigin-widget-icon-family').change(function(){
+		$is.find( 'select.siteorigin-widget-icon-family' ).on( 'change', function() {
 			$is.find('.siteorigin-widget-icon-icons').empty();
 			changeIconFamily();
 		});
 
-		$v.change( function ( event, data ) {
+		$v.on( 'change', function ( event, data ) {
 			if ( ! ( data && data.isRendering ) ) {
 				rerenderIcons();
 			}

--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -12,7 +12,7 @@
 		}
 
 		// Handle the media uploader
-		$media.find( '.media-upload-button' ).click(function(e){
+		$media.find( '.media-upload-button' ).on( 'click', function( e ) {
 			e.preventDefault();
 			if( typeof wp.media === 'undefined' ) {
 				return;
@@ -91,8 +91,8 @@
 			frame.open();
 		});
 
-		$field.find('a.media-remove-button' )
-			.click( function( e ){
+		$field.find( 'a.media-remove-button' )
+			.on( 'click', function( e ) {
 				e.preventDefault();
 				$inputField.val('');
 				$inputField.trigger( 'change', { silent: true } );
@@ -119,13 +119,13 @@
 				'height' : resultWidth / 1.4
 			} );
 		};
-		$(window).resize( reflowDialog );
+		$( window ).on( 'resize', reflowDialog );
 
 		var setupDialog = function(){
 			if( ! dialog ) {
 				// Create the dialog
 				dialog = $( $('#so-widgets-bundle-tpl-image-search-dialog').html().trim() ).appendTo( 'body' );
-				dialog.find( '.close' ).click( function(){
+				dialog.find( '.close' ).on( 'click', function() {
 					dialog.hide();
 				} );
 
@@ -206,7 +206,7 @@
 				};
 
 				// Setup the search
-				dialog.find('#so-widgets-image-search-form').submit( function( e ){
+				dialog.find( '#so-widgets-image-search-form' ).on( 'submit', function( e ) {
 					e.preventDefault();
 
 					// Perform the search
@@ -220,15 +220,15 @@
 				} );
 
 				// Clicking on the related search buttons
-				dialog.on( 'click', '.so-keywords-list a', function( e ){
+				dialog.on( 'click', '.so-keywords-list a', function( e ) {
 					e.preventDefault();
-					var $$ = $(this).blur();
+					var $$ = $( this ).trigger( 'blur' );
 					dialog.find('.so-widgets-search-input').val( $$.data( 'keyword' ) );
-					dialog.find('#so-widgets-image-search-form').submit();
+					dialog.find( '#so-widgets-image-search-form' ).trigger( 'submit' );
 				} );
 
 				// Clicking on the more button
-				dialog.find('.so-widgets-results-more button').click( function(){
+				dialog.find( '.so-widgets-results-more button' ).on( 'click', function() {
 					var $$ = $(this);
 					fetchImages( $$.data( 'query' ), $$.data( 'page' ) );
 				} );
@@ -364,16 +364,16 @@
 			}
 
 			dialog.show();
-			dialog.find( '.so-widgets-search-input' ).focus();
+			dialog.find( '.so-widgets-search-input' ).trigger( 'focus' );
 		};
 
 		// Handle displaying the image search dialog
-		$media.find( '.find-image-button' ).click( function(e){
+		$media.find( '.find-image-button' ).on( 'click', function( e ) {
 			e.preventDefault();
 			setupDialog();
 		} );
 
-		$inputField.change( function ( event, data ) {
+		$inputField.on( 'change', function( event, data ) {
 			if ( ! ( data && data.silent ) ) {
 				var newVal = $inputField.val();
 				if ( newVal) {
@@ -395,7 +395,7 @@
 						$field.find('.media-remove-button').removeClass('remove-hide');
 					} );
 				} else {
-					$field.find( 'a.media-remove-button' ).click();
+					$field.find( 'a.media-remove-button' ).trigger( 'click' );
 				}
 			}
 		} );

--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -115,8 +115,8 @@
 				resultWidth = spare / perRow + 260;
 
 			results.find( '.so-widgets-result-image' ).css( {
-				'width' : resultWidth,
-				'height' : resultWidth / 1.4
+				'width' : resultWidth + 'px',
+				'height' : resultWidth / 1.4 + 'px',
 			} );
 		};
 		$( window ).on( 'resize', reflowDialog );
@@ -319,8 +319,8 @@
 								.find('.so-widgets-preview-window-inside')
 								.css( {
 									'background-image' : 'url(' + $$.data('thumbnail') + ')',
-									'width' : preview[1] * scalePreview,
-									'height' : preview[2] * scalePreview
+									'width' : preview[1] * scalePreview + 'px',
+									'height' : preview[2] * scalePreview + 'px',
 								} )
 								.append( $( '<img />' ).attr( 'src', preview[0] ) );
 
@@ -355,8 +355,8 @@
 
 						// Figure out where the preview needs to go
 						previewWindow.css({
-							'top': top,
-							'left': left
+							'top': top + 'px',
+							'left': left + 'px',
 						});
 
 					}

--- a/base/inc/fields/js/multi-measurement-field.js
+++ b/base/inc/fields/js/multi-measurement-field.js
@@ -32,7 +32,7 @@
 			}
 		} );
 		
-		$inputContainers.change( function ( event ) {
+		$inputContainers.on( 'change', function( event ) {
 			var $valInput = $( event.currentTarget ).find( '> .sow-multi-measurement-input' );
 			var doAutofill = autoFillEnabled;
 			if ( autoFillEnabled ) {

--- a/base/inc/fields/js/order-field.js
+++ b/base/inc/fields/js/order-field.js
@@ -17,7 +17,7 @@
 				}
 			} );
 
-			$$.change( function ( event, params ) {
+			$$.on( 'change', function ( event, params ) {
 				if ( ! ( params && params.silent ) ) {
 					var values = $valField.val() === '' ? [] : $valField.val().split(',');
 					if ( values.length ) {

--- a/base/inc/fields/js/posts-field.js
+++ b/base/inc/fields/js/posts-field.js
@@ -4,7 +4,7 @@
 
 	$( document ).on( 'sowsetupform', '.siteorigin-widget-field-type-posts', function ( e ) {
 		var $postsField = $( this );
-		$postsField.change( function ( event ) {
+		$postsField.on( 'change', function( event ) {
 			var postsValues = sowbForms.getWidgetFormValues( $postsField );
 			var queryObj = postsValues.hasOwnProperty( 'posts' ) ? postsValues.posts : null;
 

--- a/base/inc/fields/js/presets-field.js
+++ b/base/inc/fields/js/presets-field.js
@@ -12,7 +12,7 @@
 		$undoLink.hide();
 		
 		var presets = $presetSelect.data( 'presets' );
-		$presetSelect.change( function () {
+		$presetSelect.on( 'change', function() {
 			
 			var selectedPreset = $presetSelect.val();
 			if ( selectedPreset && presets.hasOwnProperty( selectedPreset ) ) {
@@ -48,7 +48,7 @@
 				}
 				if ( $undoLink.not( ':visible' ) ) {
 					$undoLink.show();
-					$undoLink.click( function ( event ) {
+					$undoLink.on( 'click', function ( event ) {
 						event.preventDefault();
 						$undoLink.hide();
 						sowbForms.setWidgetFormValues( $formContainer, previousValues, true );

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -701,22 +701,22 @@ var sowbForms = window.sowbForms || {};
 			} );
 
 			var readonly = typeof $el.attr('readonly') !== 'undefined';
-			var item = $('<div class="siteorigin-widget-field-repeater-item ui-draggable" />')
+			var item = $( '<div class="siteorigin-widget-field-repeater-item ui-draggable"></div>' )
 				.append(
-					$('<div class="siteorigin-widget-field-repeater-item-top" />')
+					$( '<div class="siteorigin-widget-field-repeater-item-top"></div>' )
 						.append(
-							$('<div class="siteorigin-widget-field-expand" />')
+							$( '<div class="siteorigin-widget-field-expand"></div>' )
 						)
 						.append(
-							readonly ? '' : $('<div class="siteorigin-widget-field-copy" />')
+							readonly ? '' : $( '<div class="siteorigin-widget-field-copy"></div>')
 						)
 						.append(
-							readonly ? '' : $('<div class="siteorigin-widget-field-remove" />')
+							readonly ? '' : $( '<div class="siteorigin-widget-field-remove"></div>' )
 						)
-						.append($('<h4 />').html($el.data('item-name')))
+						.append( $( '<h4></h4>' ).html( $el.data( 'item-name' ) ) )
 				)
 				.append(
-					$('<div class="siteorigin-widget-field-repeater-item-form" />')
+					$( '<div class="siteorigin-widget-field-repeater-item-form"></div>' )
 						.html(repeaterHtml)
 				);
 

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -181,7 +181,7 @@ var sowbForms = window.sowbForms || {};
 				$mainForm = $el;
 
 				var $teaser = $el.find('.siteorigin-widget-teaser');
-				$teaser.find('.dashicons-dismiss').click(function () {
+				$teaser.find( '.dashicons-dismiss' ).on( 'click', function() {
 					var $$ = $(this);
 					$.get($$.data('dismiss-url'));
 
@@ -227,7 +227,7 @@ var sowbForms = window.sowbForms || {};
 							sessionStorage.removeItem( _sow_form_id );
 						}
 					}
-					$el.change( function () {
+					$el.on( 'change', function() {
 						$timestampField.val( new Date().getTime() );
 						var data = sowbForms.getWidgetFormValues( $el );
 						sessionStorage.setItem( _sow_form_id, JSON.stringify( data ) );
@@ -286,7 +286,7 @@ var sowbForms = window.sowbForms || {};
 				$(this).toggleClass('siteorigin-widget-section-visible');
 				$(this).parent().find('> .siteorigin-widget-section, > .siteorigin-widget-widget > .siteorigin-widget-section')
 					.slideToggle('fast', function () {
-						$(window).resize();
+						$( window ).trigger( 'resize' );
 						$(this).find('> .siteorigin-widget-field-container-state').val($(this).is(':visible') ? 'open' : 'closed');
 
 						if ( $( this ).is( ':visible' ) ) {
@@ -295,8 +295,8 @@ var sowbForms = window.sowbForms || {};
 						}
 					} );
 			};
-			$fields.filter('.siteorigin-widget-field-type-widget, .siteorigin-widget-field-type-section').find('> label').click(expandContainer);
-			$fields.filter('.siteorigin-widget-field-type-posts').find('.posts-container-label-wrapper').click(expandContainer);
+			$fields.filter( '.siteorigin-widget-field-type-widget, .siteorigin-widget-field-type-section' ).find( '> label' ).on( 'click', expandContainer );
+			$fields.filter( '.siteorigin-widget-field-type-posts' ).find( '.posts-container-label-wrapper' ).on( 'click', expandContainer );
 
 			///////////////////////////////////////
 			// Handle the slider fields
@@ -317,7 +317,7 @@ var sowbForms = window.sowbForms || {};
 						$$.find('.siteorigin-widget-slider-value').html(ui.value);
 					},
 				});
-				$input.change(function(event, data) {
+				$input.on( 'change', function( event, data ) {
 					if ( ! ( data && data.silent ) ) {
 						$c.slider( 'value', parseFloat( $input.val() ) );
 					}
@@ -365,10 +365,10 @@ var sowbForms = window.sowbForms || {};
 				};
 
 				// Toggle display of the existing content
-				$$.find('.select-content-button, .button-close').click(function (e) {
+				$$.find( '.select-content-button, .button-close' ).on( 'click', function( e ) {
 					e.preventDefault();
 
-					$(this).blur();
+					$(this).trigger( 'blur' );
 					var $s = $$.find('.existing-content-selector');
 					$s.toggle();
 
@@ -383,12 +383,12 @@ var sowbForms = window.sowbForms || {};
 					e.preventDefault();
 					var $li = $(this);
 					$$.find('input.siteorigin-widget-input').val('post: ' + $li.data('value'));
-					$$.change();
+					$$.trigger( 'change' );
 					$$.find('.existing-content-selector').toggle();
 				});
 
 				var interval = null;
-				$$.find('.content-text-search').keyup(function () {
+				$$.find( '.content-text-search' ).on( 'keyup', function() {
 					if (interval !== null) {
 						clearTimeout(interval);
 					}
@@ -537,7 +537,7 @@ var sowbForms = window.sowbForms || {};
 		var $el = $(this);
 		var previewButton = $el.siblings('.siteorigin-widget-preview');
 
-		previewButton.find('> a').click(function (e) {
+		previewButton.find( '> a' ).on( 'click', function( e ) {
 			e.preventDefault();
 
 			var data = sowbForms.getWidgetFormValues($el);
@@ -549,9 +549,9 @@ var sowbForms = window.sowbForms || {};
 			modal.find('iframe').on('load', function () {
 				$(this).css('visibility', 'visible');
 			});
-			modal.find('form').submit();
+			modal.find( 'form' ).trigger( 'submit' );
 
-			modal.find('.close').click(function () {
+			modal.find( '.close' ).on( 'click', function() {
 				modal.remove();
 			});
 		});
@@ -654,19 +654,19 @@ var sowbForms = window.sowbForms || {};
 			});
 			$items.trigger('updateFieldPositions');
 
-			$el.find('> .siteorigin-widget-field-repeater-add').disableSelection().click(function (e) {
+			$el.find( '> .siteorigin-widget-field-repeater-add' ).disableSelection().on( 'click', function( e ) {
 				e.preventDefault();
 				$el.closest('.siteorigin-widget-field-repeater')
 					.sowAddRepeaterItem()
 					.find('> .siteorigin-widget-field-repeater-items').slideDown('fast', function () {
-					$(window).resize();
+					$( window ).trigger( 'resize' );
 				});
 			});
 
-			$el.find('> .siteorigin-widget-field-repeater-top > .siteorigin-widget-field-repeater-expand').click(function (e) {
+			$el.find( '> .siteorigin-widget-field-repeater-top > .siteorigin-widget-field-repeater-expand' ).on( 'click', function( e ) {
 				e.preventDefault();
 				$el.closest('.siteorigin-widget-field-repeater').find('> .siteorigin-widget-field-repeateritems-').slideToggle('fast', function () {
-					$(window).resize();
+					$( window ).trigger( 'resize' );
 				});
 			});
 		});
@@ -724,7 +724,7 @@ var sowbForms = window.sowbForms || {};
 			$el.find('> .siteorigin-widget-field-repeater-items').append(item).sortable("refresh").trigger('updateFieldPositions');
 			item.sowSetupRepeaterItems();
 			item.hide().slideDown('fast', function () {
-				$(window).resize();
+				$( window ).trigger( 'resize' );
 			});
 			$el.trigger( 'change' );
 		});
@@ -778,13 +778,13 @@ var sowbForms = window.sowbForms || {};
 					$el.bind(eventName, updateLabel);
 				}
 
-				itemTop.click(function (e) {
+				itemTop.on( 'click', function( e ) {
 					if (e.target.className === "siteorigin-widget-field-remove" || e.target.className === "siteorigin-widget-field-copy") {
 						return;
 					}
 					e.preventDefault();
 					$(this).closest('.siteorigin-widget-field-repeater-item').find('.siteorigin-widget-field-repeater-item-form').eq(0).slideToggle('fast', function () {
-						$(window).resize();
+						$( window ).trigger( 'resize' );
 						if ($(this).is(':visible')) {
 							$(this).trigger('slideToggleOpenComplete');
 							
@@ -803,14 +803,14 @@ var sowbForms = window.sowbForms || {};
 					});
 				});
 
-				itemTop.find('.siteorigin-widget-field-remove').click(function (e, params) {
+				itemTop.find( '.siteorigin-widget-field-remove' ).on( 'click', function( e, params ) {
 					e.preventDefault();
 					var $s = $( this ).closest( '.siteorigin-widget-field-repeater-items' );
 					var $item = $( this ).closest( '.siteorigin-widget-field-repeater-item' );
 					var removeItem = function () {
 						$item.remove();
 						$s.sortable( "refresh" ).trigger( 'updateFieldPositions' );
-						$( window ).resize();
+						$( window ).trigger( 'resize' );
 						$parentRepeater.trigger( 'change' );
 					};
 					if ( params && params.silent ) {
@@ -819,7 +819,7 @@ var sowbForms = window.sowbForms || {};
 						$item.slideUp('fast', removeItem );
 					}
 				});
-				itemTop.find('.siteorigin-widget-field-copy').click(function (e) {
+				itemTop.find( '.siteorigin-widget-field-copy' ).on( 'click', function( e ) {
 					e.preventDefault();
 					var $form = $(this).closest('.siteorigin-widget-form-main');
 					var $item = $(this).closest('.siteorigin-widget-field-repeater-item');
@@ -938,7 +938,7 @@ var sowbForms = window.sowbForms || {};
 					$items.append($copyItem).sortable("refresh").trigger('updateFieldPositions');
 					$copyItem.sowSetupRepeaterItems();
 					$copyItem.hide().slideDown('fast', function () {
-						$(window).resize();
+						$( window ).trigger( 'resize' );
 					});
 					$el.trigger( 'change' );
 				});
@@ -1181,7 +1181,7 @@ var sowbForms = window.sowbForms || {};
 				if ( numItems > numChildren ) {
 					// If data items > child items, create extra child items.
 					for ( var i = 0; i < numItems - numChildren; i++) {
-						$repeater.find( '> .siteorigin-widget-field-repeater-add' ).click();
+						$repeater.find( '> .siteorigin-widget-field-repeater-add' ).trigger( 'click' );
 					}
 
 				} else if ( ! skipMissingValues && numItems < numChildren ) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -620,7 +620,8 @@ var sowbForms = window.sowbForms || {};
 				var scrollCount = $el.data('scroll-count') ? parseInt($el.data('scroll-count')) : 0;
 				if (scrollCount > 0 && $rptrItems.length > scrollCount) {
 					var itemHeight = $rptrItems.first().outerHeight();
-					$$.css('max-height', itemHeight * scrollCount).css('overflow', 'auto');
+					$$.css( 'max-height', itemHeight * scrollCount + 'px' );
+					$$.css( 'overflow', 'auto' );
 				}
 				else {
 					//TODO: Check whether there was a value before overriding and set it back to that.

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1,12 +1,12 @@
-( function ( editor, blocks, i18n, element, components, compose ) {
+( function ( editor, blocks, i18n, element, components, compose, blockEditor ) {
 
 	var el = element.createElement;
 	var registerBlockType = blocks.registerBlockType;
-	var BlockControls = editor.BlockControls;
+	var BlockControls = blockEditor.BlockControls;
 	var SelectControl = components.SelectControl;
 	var withState = compose.withState;
 	var Toolbar = components.Toolbar;
-	var IconButton = components.IconButton;
+	var ToolbarButton = components.ToolbarButton;
 	var Placeholder = components.Placeholder;
 	var Spinner  = components.Spinner;
 	var __ = i18n.__;
@@ -159,12 +159,17 @@
 				return [
 					!! widgetForm && el(
 						BlockControls,
-						{ key: 'controls' },
+						{
+							key: 'controls',
+
+						},
 						el(
 							Toolbar,
-							null,
+							{
+								label: __( 'Preview widget.', 'so-widgets-bundle' ),
+							},
 							el(
-								IconButton,
+								ToolbarButton,
 								{
 									className: 'components-icon-button components-toolbar__control',
 									label: __( 'Preview widget.', 'so-widgets-bundle' ),
@@ -249,9 +254,11 @@
 						{ key: 'controls' },
 						el(
 							Toolbar,
-							null,
+							{
+								label: __( 'Preview widget.', 'so-widgets-bundle' ),
+							},
 							el(
-								IconButton,
+								ToolbarButton,
 								{
 									className: 'components-icon-button components-toolbar__control',
 									label: __( 'Edit widget.', 'so-widgets-bundle' ),
@@ -292,4 +299,4 @@
 			return null;
 		}
 	} );
-} )( window.wp.editor, window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.compose );
+} )( window.wp.editor, window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.compose, window.wp.blockEditor );

--- a/compat/visual-composer/sowb-vc-widget.js
+++ b/compat/visual-composer/sowb-vc-widget.js
@@ -17,7 +17,7 @@ sowbForms.setupVcWidgetForm = function () {
 	} );
 
 	var prevWidget;
-	$widgetDropdown.mousedown( function () {
+	$widgetDropdown.on( 'mousedown', function() {
 		prevWidget = $widgetDropdown.find( 'option:selected' );
 	} );
 

--- a/js/jquery.cycle.js
+++ b/js/jquery.cycle.js
@@ -208,7 +208,7 @@
             var startSlideshow = false;
             var len;
 
-            if ( $.type(slides) == 'string')
+            if ( typeof slides === 'string' )
                 slides = slides.trim();
 
             $( slides ).each(function(i) {
@@ -1398,7 +1398,7 @@
         if ( type == 'array' ) {
             slides = opts.progressive;
         }
-        else if ($.isFunction( opts.progressive ) ) {
+        else if ( typeof opts.progressive === 'function' ) {
             slides = opts.progressive( opts );
         }
         else if ( type == 'string' ) {

--- a/js/jquery.cycle.js
+++ b/js/jquery.cycle.js
@@ -100,7 +100,7 @@
             var opts = this.opts();
             opts.API.trigger('cycle-pre-initialize', [ opts ]);
             var tx = $.fn.cycle.transitions[opts.fx];
-            if (tx && $.isFunction(tx.preInit))
+            if (tx && typeof tx.preInit === 'function' )
                 tx.preInit( opts );
             opts._preInitialized = true;
         },
@@ -109,7 +109,7 @@
             var opts = this.opts();
             opts.API.trigger('cycle-post-initialize', [ opts ]);
             var tx = $.fn.cycle.transitions[opts.fx];
-            if (tx && $.isFunction(tx.postInit))
+            if (tx && typeof tx.postInit === 'function')
                 tx.postInit( opts );
         },
 
@@ -417,7 +417,7 @@
             }
             if ( opts.continueAuto !== undefined ) {
                 if ( opts.continueAuto === false ||
-                    ($.isFunction(opts.continueAuto) && opts.continueAuto() === false )) {
+                    ( typeof opts.continueAuto === 'function' && opts.continueAuto() === false )) {
                     opts.API.log('terminating automatic transitions');
                     opts.timeout = 0;
                     if ( opts.timeoutId )
@@ -703,7 +703,7 @@
 
     $(document).on( 'cycle-initialized', function( e, opts ) {
         var autoHeight = opts.autoHeight;
-        var t = $.type( autoHeight );
+        var t = typeof autoHeight;
         var resizeThrottle = null;
         var ratio;
 
@@ -754,7 +754,7 @@
         else if ( opts._autoHeightRatio ) {
             opts.container.height( opts.container.width() / opts._autoHeightRatio );
         }
-        else if ( autoHeight === 'calc' || ( $.type( autoHeight ) == 'number' && autoHeight >= 0 ) ) {
+        else if ( autoHeight === 'calc' || ( typeof autoHeight === 'number' && autoHeight >= 0 ) ) {
             if ( autoHeight === 'calc' )
                 sentinelIndex = calcSentinelIndex( e, opts );
             else if ( autoHeight >= opts.slides.length )
@@ -876,11 +876,11 @@
         var cmd, cmdFn, opts;
         var args = $.makeArray( arguments );
 
-        if ( $.type( options ) == 'number' ) {
+        if ( typeof options === 'number' ) {
             return this.cycle( 'goto', options );
         }
 
-        if ( $.type( options ) == 'string' ) {
+        if ( typeof options === 'string' ) {
             return this.each(function() {
                 var cmdArgs;
                 cmd = options;
@@ -893,7 +893,7 @@
                 else {
                     cmd = cmd == 'goto' ? 'jump' : cmd; // issue #3; change 'goto' to 'jump' internally
                     cmdFn = opts.API[ cmd ];
-                    if ( $.isFunction( cmdFn )) {
+                    if ( typeof cmdFn === 'function' ) {
                         cmdArgs = $.makeArray( args );
                         cmdArgs.shift();
                         return cmdFn.apply( opts.API, cmdArgs );
@@ -942,7 +942,7 @@
             this.stop(); //#204
 
             var opts = this.opts();
-            var clean = $.isFunction( $._data ) ? $._data : $.noop;  // hack for #184 and #201
+            var clean = typeof $._data === 'function' ? $._data : $.noop;  // hack for #184 and #201
             clearTimeout(opts.timeoutId);
             opts.timeoutId = 0;
             opts.API.stop();
@@ -1126,9 +1126,9 @@
 
         function add( slides, prepend ) {
             var slideArr = [];
-            if ( $.type( slides ) == 'string' )
+            if ( typeof slides == 'string' )
                 slides = slides.trim();
-            else if ( $.type( slides) === 'array' ) {
+            else if ( typeof slides === 'array' ) {
                 for (var i=0; i < slides.length; i++ )
                     slides[i] = $(slides[i])[0];
             }
@@ -1392,7 +1392,7 @@
         var nextFn = API.next;
         var prevFn = API.prev;
         var prepareTxFn = API.prepareTx;
-        var type = $.type( opts.progressive );
+        var type = typeof opts.progressive;
         var slides, scriptEl;
 
         if ( type == 'array' ) {
@@ -1537,7 +1537,7 @@
                         prop = obj[str];
                     }
 
-                    if ($.isFunction(prop))
+                    if ( typeof prop === 'function' )
                         return prop.apply(obj, args);
                     if (prop !== undefined && prop !== null && prop != str)
                         return prop;

--- a/js/jquery.cycle.js
+++ b/js/jquery.cycle.js
@@ -134,10 +134,13 @@
                 if ( opts.pauseOnHover !== true )
                     pauseObj = $( opts.pauseOnHover );
 
-                pauseObj.hover(
-                    function(){ opts.API.pause( true ); },
-                    function(){ opts.API.resume( true ); }
-                );
+                pauseObj.on( 'mouseenter', function() {
+                    opts.API.pause( true );
+                } );
+
+                pauseObj.on( 'mouseleave', function() {
+                    opts.API.resume( true );
+                } );
             }
 
             // stage initial transition

--- a/js/jquery.cycle.js
+++ b/js/jquery.cycle.js
@@ -206,7 +206,7 @@
             var len;
 
             if ( $.type(slides) == 'string')
-                slides = $.trim( slides );
+                slides = slides.trim();
 
             $( slides ).each(function(i) {
                 var slideOpts;
@@ -1124,7 +1124,7 @@
         function add( slides, prepend ) {
             var slideArr = [];
             if ( $.type( slides ) == 'string' )
-                slides = $.trim( slides );
+                slides = slides.trim();
             else if ( $.type( slides) === 'array' ) {
                 for (var i=0; i < slides.length; i++ )
                     slides[i] = $(slides[i])[0];
@@ -1400,7 +1400,7 @@
         }
         else if ( type == 'string' ) {
             scriptEl = $( opts.progressive );
-            slides = $.trim( scriptEl.html() );
+            slides = scriptEl.html().trim();
             if ( !slides )
                 return;
             // is it json array?

--- a/js/jquery.cycle.js
+++ b/js/jquery.cycle.js
@@ -1156,7 +1156,7 @@
                         imageLoaded();
                     }
                     else {
-                        $(this).load(function() {
+                        $( this ).on( 'load', function() {
                             imageLoaded();
                         }).on("error", function() {
                             if ( --count === 0 ) {

--- a/js/lib/slick.js
+++ b/js/lib/slick.js
@@ -1861,7 +1861,7 @@
         var _ = this, breakpoint, currentBreakpoint, l,
             responsiveSettings = _.options.responsive || null;
 
-        if ( $.type(responsiveSettings) === 'array' && responsiveSettings.length ) {
+        if ( typeof responsiveSettings === 'array' && responsiveSettings.length ) {
 
             _.respondTo = _.options.respondTo || 'window';
 
@@ -2125,19 +2125,19 @@
 
         var _ = this, l, item, option, value, refresh = false, type;
 
-        if( $.type( arguments[0] ) === 'object' ) {
+        if( typeof arguments[0] === 'object' ) {
 
             option =  arguments[0];
             refresh = arguments[1];
             type = 'multiple';
 
-        } else if ( $.type( arguments[0] ) === 'string' ) {
+        } else if ( typeof arguments[0] === 'string' ) {
 
             option =  arguments[0];
             value = arguments[1];
             refresh = arguments[2];
 
-            if ( arguments[0] === 'responsive' && $.type( arguments[1] ) === 'array' ) {
+            if ( arguments[0] === 'responsive' && typeof arguments[1] === 'array' ) {
 
                 type = 'responsive';
 
@@ -2167,7 +2167,7 @@
 
             for ( item in value ) {
 
-                if( $.type( _.options.responsive ) !== 'array' ) {
+                if( typeof _.options.responsive !== 'array' ) {
 
                     _.options.responsive = [ value[item] ];
 

--- a/js/lib/slick.js
+++ b/js/lib/slick.js
@@ -52,7 +52,7 @@
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return $('<button type="button" />').text(i + 1);
+                    return $( '<button type="button"></button>' ).text(i + 1);
                 },
                 dots: false,
                 dotsClass: 'slick-dots',
@@ -488,10 +488,10 @@
 
             _.$slider.addClass('slick-dotted');
 
-            dot = $('<ul />').addClass(_.options.dotsClass);
+            dot = $( '<ul></ul>' ).addClass( _.options.dotsClass );
 
             for (i = 0; i <= _.getDotCount(); i += 1) {
-                dot.append($('<li />').append(_.options.customPaging.call(this, _, i)));
+                dot.append( $( '<li></li>' ).append( _.options.customPaging.call( this, _, i ) ) );
             }
 
             _.$dots = dot.appendTo(_.options.appendDots);
@@ -522,11 +522,11 @@
         _.$slider.addClass('slick-slider');
 
         _.$slideTrack = (_.slideCount === 0) ?
-            $('<div class="slick-track"/>').appendTo(_.$slider) :
-            _.$slides.wrapAll('<div class="slick-track"/>').parent();
+            $( '<div class="slick-track"></div>' ).appendTo( _.$slider ) :
+            _.$slides.wrapAll( '<div class="slick-track"></div>' ).parent();
 
         _.$list = _.$slideTrack.wrap(
-            '<div class="slick-list"/>').parent();
+            '<div class="slick-list"></div>' ).parent();
         _.$slideTrack.css('opacity', 0);
 
         if (_.options.centerMode === true || _.options.swipeToSlide === true) {

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -87,7 +87,7 @@ jQuery( function($){
 				var urlData = $slide.data('url');
 
 				if( urlData !== undefined && urlData.hasOwnProperty( 'url' ) ) {
-					$slide.click(function(event) {
+					$slide.on( 'click', function(event) {
 
 						event.preventDefault();
 						var sliderWindow = window.open(
@@ -96,7 +96,7 @@ jQuery( function($){
 						);
 						sliderWindow.opener = null;
 					} );
-					$slide.find( 'a' ).click( function ( event ) {
+					$slide.find( 'a' ).on( 'click', function ( event ) {
 						event.stopPropagation();
 					} );
 				}
@@ -123,7 +123,7 @@ jQuery( function($){
 					} );
 				};
 				// Setup each of the slider frames
-				$(window).on('resize panelsStretchRows', resizeFrames ).resize();
+				$( window ).on('resize panelsStretchRows', resizeFrames ).trigger( 'resize' );
 				$(sowb).on('setup_widgets', resizeFrames );
 
 				// Set up the Cycle with videos
@@ -157,7 +157,7 @@ jQuery( function($){
 								$n.hide();
 							}
 
-							$(window).resize();
+							$( window ).trigger( 'resize' );
 
 							setTimeout(function() {
 								resizeFrames();
@@ -189,11 +189,11 @@ jQuery( function($){
 
 						var toHide = false;
 						$base
-							.mouseenter(function(){
+							.on( 'mouseenter', function() {
 								$p.add($n).clearQueue().fadeIn(150);
 								toHide = false;
 							})
-							.mouseleave(function(){
+							.on( 'mouseleave', function() {
 								toHide = true;
 								setTimeout(function(){
 									if( toHide ) {
@@ -216,18 +216,18 @@ jQuery( function($){
 				$( sowb ).on( 'setup_widgets', setupActiveSlide );
 
 				// Setup clicks on the pagination
-				$p.find( '> li > a' ).click( function(e){
+				$p.find( '> li > a' ).on( 'click', function(e){
 					e.preventDefault();
 					$$.cycle( 'goto', $(this).data('goto') );
 				} );
 
 				// Clicking on the next and previous navigation buttons
-				$n.find( '> a' ).click( function(e){
+				$n.find( '> a' ).on( 'click', function(e){
 					e.preventDefault();
 					$$.cycle( $(this).data('action') );
 				} );
 
-				$base.keydown(
+				$base.on( 'keydown',
 					function(event) {
 						if(event.which === 37) {
 							//left

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -28,7 +28,7 @@ sowb.SiteOriginSlider = function($) {
 				video = active.find('video.sow-background-element');
 
 			if( speed === undefined ) {
-				sentinel.css( 'height', active.outerHeight() );
+				sentinel.css( 'height', active.outerHeight() + 'px' );
 			}
 			else {
 				sentinel.animate( {height: active.outerHeight()}, speed );
@@ -119,7 +119,7 @@ jQuery( function($){
 				var resizeFrames = function () {
 					$$.find( '.sow-slider-image' ).each( function () {
 						var $i = $( this );
-						$i.css( 'height', $i.find( '.sow-slider-image-wrapper' ).outerHeight() );
+						$i.css( 'height', $i.find( '.sow-slider-image-wrapper' ).outerHeight() + 'px' );
 					} );
 				};
 				// Setup each of the slider frames

--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -120,7 +120,7 @@ sowb.SiteOriginGoogleMap = function($) {
 					}
 				} );
 
-				$autocompleteElement.focusin( function () {
+				$autocompleteElement.on( 'focusin', function () {
 					if ( !this.resultsObserver ) {
 						var autocompleteResultsContainer = document.querySelector( '.pac-container' );
 						this.resultsObserver = new MutationObserver( function () {
@@ -505,7 +505,7 @@ jQuery(function ($) {
 			}
 
 			if ( soWidgetsGoogleMap.map_consent ) {
-				$( '.sow-google-map-consent button' ).click( function() {
+				$( '.sow-google-map-consent button' ).on( 'click', function() {
 					$( '.sow-google-map-consent' ).remove();
 					$( '.sow-google-map-canvas' ).show();
 					$( 'body' ).append( '<script async type="text/javascript" src="' + apiUrl + '">' );

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -19,10 +19,10 @@ sowb.SiteOriginContactForm = {
 					formPosition = $container.offset().top;
 					// If the closest visible ancestor is either SOWB Accordion or Tabs widget, try to open the panel.
 					if ( $container.is( '.sow-accordion-panel' ) ) {
-						$container.find( '> .sow-accordion-panel-header' ).click();
+						$container.find( '> .sow-accordion-panel-header' ).trigger( 'click' );
 					} else if ( $container.is( '.sow-tabs-panel-container' ) ) {
 						var tabIndex = $el.closest( '.sow-tabs-panel' ).index();
-						$container.siblings( '.sow-tabs-tab-container' ).find( '> .sow-tabs-tab' ).eq( tabIndex ).click();
+						$container.siblings( '.sow-tabs-tab-container' ).find( '> .sow-tabs-tab' ).eq( tabIndex ).trigger( 'click' );
 					}
 				}
 				$( 'html, body' ).scrollTop( formPosition );
@@ -55,7 +55,7 @@ sowb.SiteOriginContactForm = {
 			}
 
 			// Disable the submit button on click to avoid multiple submits.
-			$contactForms.submit( function () {
+			$contactForms.on( 'submit', function() {
 				$submitButton.prop( 'disabled', true );
 				// Preserve existing anchors, if any.
 				var locationHash = window.location.hash;

--- a/widgets/cta/js/cta.js
+++ b/widgets/cta/js/cta.js
@@ -11,7 +11,7 @@ jQuery( function ( $ ) {
 				$t = $$.find( '.sow-cta-text' );
 			
 			if ( $t.outerHeight() > $b.outerHeight() ) {
-				$b.css( 'margin-top', ( $t.outerHeight() - $b.outerHeight() ) / 2 );
+				$b.css( 'margin-top', ( $t.outerHeight() - $b.outerHeight() ) / 2 + 'px' );
 			}
 		} );
 	};

--- a/widgets/image-grid/js/image-grid.js
+++ b/widgets/image-grid/js/image-grid.js
@@ -40,7 +40,7 @@ jQuery( function ( $ ) {
 				};
 				alignImages();
 				
-				$( window ).resize( alignImages );
+				$( window ).on( 'resize', alignImages );
 
 				var event = document.createEvent('Event');
 				event.initEvent('layoutComplete', true, true);

--- a/widgets/image-grid/js/image-grid.js
+++ b/widgets/image-grid/js/image-grid.js
@@ -27,7 +27,7 @@ jQuery( function ( $ ) {
 						
 						if ( width.length ) {
 							width = Math.min.apply( Math, width );
-							$img.css( 'max-width', width );
+							$img.css( 'max-width', width + 'px' );
 						}
 						
 					} );

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -148,7 +148,7 @@ jQuery( function ( $ ) {
 				return;
 			}
 			e.preventDefault();
-			$( this ).click();
+			$( this ).trigger( 'click' );
 		} );
 
 		// Keyboard Navigation of carousel items.

--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -153,6 +153,11 @@ jQuery( function ( $ ) {
 
 		// Keyboard Navigation of carousel items.
 		$( document ).on( 'keyup', '.sow-carousel-item', function( e ) {
+			// Was enter pressed?
+			if ( e.keyCode == 13 ) {
+				$( this ).find( 'h3 a' )[0].click();
+			}
+
 			// Ensure left/right key was pressed
 			if ( e.keyCode != 37 && e.keyCode != 39 ) {
 				return;

--- a/widgets/price-table/js/pricetable.js
+++ b/widgets/price-table/js/pricetable.js
@@ -43,8 +43,8 @@ jQuery( function ( $ ) {
 
 					if ($('#so-pt-icon-' + icon).length) {
 						var svg = $('#so-pt-icon-' + icon + ' svg').clone().css({
-							'max-width': 24,
-							'max-height': 24
+							'max-width': '24px',
+							'max-height': '24px',
 						});
 
 						if ($$.data('icon-color') !== '') {

--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -38,7 +38,7 @@ jQuery( function ( $ ) {
 						rowSpan = Math.max( Math.min( rowSpan, layout.numColumns ), 1 );
 						//Use rowHeight if non-zero else fall back to matching columnWidth.
 						var rowHeight = layout.rowHeight || columnWidth;
-						$$.css( 'height', ( rowHeight * rowSpan ) + ( layout.gutter * ( rowSpan - 1 ) ) );
+						$$.css( 'height', ( rowHeight * rowSpan ) + ( layout.gutter * ( rowSpan - 1 ) ) + 'px' );
 						
 						var $img = $$.find( '> img,> a > img' );
 						var imgAR = $img.height() > 0 ? $img.width() / $img.height() : 1;

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -98,11 +98,11 @@ jQuery( function ( $ ) {
 				}
 			};
 			
-			$tabs.click( function() {
+			$tabs.on( 'click', function() {
 				selectTab( this );
 			} );
 
-			$tabs.keyup( function( e ) {
+			$tabs.on( 'keyup', function( e ) {
 				var $currentTab = $( this );
 
 				if ( e.keyCode !== 37 && e.keyCode !== 39 ){
@@ -132,7 +132,7 @@ jQuery( function ( $ ) {
 				if ( $currentTab === $newTab ){
 					return;
 				}
-				$newTab.focus();
+				$newTab.trigger( 'focus' );
 				selectTab( $newTab.get(0) );
 			} );
 			


### PR DESCRIPTION
PB PR (required): https://github.com/siteorigin/siteorigin-panels/pull/827

Any form fields that have been altered should be tested.
Widgets to test (the rest weren't altered):

Contact Form in Accordion and Tabs Widget (have panel set to close by default)
	(please note https://github.com/siteorigin/so-widgets-bundle/pull/1207/files)

Image Grid (ensure alignment is maintained after resizing the window)

Post Carousel keyboard navigation

Notes:
- pikaday.js and Slick aren't using jQuery, and instead uses native JS (ignore blur(), and click()).
- After closing the Add Media window, "JQMIGRATE: jQuery.fn.undelegate() is deprecated" will be triggered by a WP script.
- Slick changes tracked here https://github.com/siteorigin/slick/pull/1
- Cycle2 changes tracked here https://github.com/siteorigin/cycle2/pull/1