### PR TITLE
Tabs: When hash change opens tab, scroll to it

### DIFF
--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -90,7 +90,7 @@ jQuery( function ( $ ) {
 								complete: function() {
 									$( this ).trigger( 'show' );
 
-									if ( shouldScroll( $tab ) ) {
+									if ( preventHashChange || shouldScroll( $tab ) ) {
 										scrollToTab( true );
 									}
 								}


### PR DESCRIPTION
Tab version of https://github.com/siteorigin/so-widgets-bundle/pull/1213

This PR will result in external Tab Anchor links triggering the scroll to. It ignores the scroll to setting as the hashchange will only ever happen if the user is intentionally linking to the Tab.