### PR TITLE
Post Carousel: Add siteorigin_widgets_post_carousel_post_limit filter

### DIFF
--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -121,10 +121,6 @@ jQuery( function ( $ ) {
 						if ( $$.data( 'loop-posts-enabled' ) ) {
 							$items.slick( 'slickGoTo', 0 );
 						}
-					// Check if the next slide is the last slide and prevent blank spacing.
-					} else if ( complete && $items.slick( 'slickCurrentSlide' ) + numVisibleItems >= lastPosition ) {
-						$items.setSlideTo( lastPosition );
-
 					// Check if the number of slides to scroll exceeds lastPosition, go to the last slide.
 					} else if ( $items.slick( 'slickCurrentSlide' ) + slidesToScroll > lastPosition - 1 ) {
 						$items.setSlideTo( lastPosition );

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -23,12 +23,16 @@ function sow_carousel_handle_post_limit( $posts, $paged = 0 ) {
 
 	if ( is_numeric( $post_limit ) && $posts->found_posts > $post_limit ) {
 		$posts_per_page = $posts->query['posts_per_page'];
-		$current = $posts_per_page * $paged;
+		$current = $posts_per_page * ( $paged - 1 );
+
+		if ( $current < 0 ) {
+			$current = $posts_per_page;
+		}
 
 		set_query_var( 'sow-total_posts', $post_limit - 1 );
-		if ( $current > $post_limit ) {
+		if ( $current >= $post_limit ) {
 			// Check if we've exceeded the expected pagination.
-			if ( $posts_per_page * $paged + 1 > $post_limit + $posts_per_page ) {
+			if ( $current + 1 > $post_limit + $posts_per_page ) {
 				$posts->posts = null;
 			} else {
 				// Work out how many posts we need to return

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -15,6 +15,32 @@ function sow_carousel_register_image_sizes(){
 }
 add_action('init', 'sow_carousel_register_image_sizes');
 
+/**
+ * This function allows for users to limit the total number of posts.
+ */
+function sow_carousel_handle_post_limit( $posts, $paged = 0 ) {
+	$post_limit = apply_filters( 'siteorigin_widgets_post_carousel_post_limit', false );
+
+	if ( is_numeric( $post_limit ) && $posts->found_posts > $post_limit ) {
+		$posts_per_page = $posts->query['posts_per_page'];
+		$current = $posts_per_page * $paged;
+
+		set_query_var( 'sow-total_posts', $post_limit - 1 );
+		if ( $current > $post_limit ) {
+			// Check if we've exceeded the expected pagination.
+			if ( $posts_per_page * $paged + 1 > $post_limit + $posts_per_page ) {
+				$posts->posts = null;
+			} else {
+				// Work out how many posts we need to return
+				$posts->post_count = $post_limit % $posts_per_page;
+				$posts->posts = array_slice( $posts->posts, $current % $posts_per_page, $posts->post_count );
+			}
+		}
+	}
+
+	return $posts;
+}
+
 function sow_carousel_get_next_posts_page() {
 	if ( empty( $_REQUEST['_widgets_nonce'] ) || !wp_verify_nonce( $_REQUEST['_widgets_nonce'], 'widgets_action' ) ) return;
 
@@ -26,17 +52,26 @@ function sow_carousel_get_next_posts_page() {
 		$widget = ! empty ( $wp_widget_factory->widgets['SiteOrigin_Widget_PostCarousel_Widget'] ) ?
             $wp_widget_factory->widgets['SiteOrigin_Widget_PostCarousel_Widget'] : null;
 		if ( ! empty( $widget ) ) {
-            $instance = $widget->get_stored_instance($instance_hash);
-            $instance['paged'] = $_GET['paged'];
-            $template_vars = $widget->get_template_variables($instance, array());
-        }
+			$instance = $widget->get_stored_instance( $instance_hash );
+			$instance['paged'] = (int) $_GET['paged'];
+			$template_vars = $widget->get_template_variables( $instance, array() );
+
+			$template_vars['posts'] = sow_carousel_handle_post_limit(
+				$template_vars['posts'],
+				$instance['paged']
+			);
+		}
 	}
-	ob_start();
-	extract( $template_vars );
-	include 'tpl/carousel-post-loop.php';
-	$result = array( 'html' => ob_get_clean() );
-	header('content-type: application/json');
-	echo json_encode( $result );
+
+	// Don't output anything if there are no posts to return;
+	if ( ! empty( $template_vars['posts']->posts ) ) {
+		ob_start();
+		extract( $template_vars );
+		include 'tpl/carousel-post-loop.php';
+		$result = array( 'html' => ob_get_clean() );
+		header( 'content-type: application/json' );
+		echo json_encode( $result );
+	}
 
 	exit();
 }
@@ -333,7 +368,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget {
 
 		return array(
 			'title' => $instance['title'],
-			'posts' => $posts,
+			'posts' => sow_carousel_handle_post_limit( $posts ),
 			'default_thumbnail' => ! empty( $default_thumbnail ) ? $default_thumbnail[0] : '',
 			'loop_posts' => ! empty( $instance['loop_posts'] ),
 			'link_target' => ! empty( $instance['link_target'] ) ? $instance['link_target'] : 'same',

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -36,6 +36,8 @@ function sow_carousel_handle_post_limit( $posts, $paged = 0 ) {
 				$posts->posts = array_slice( $posts->posts, $current % $posts_per_page, $posts->post_count );
 			}
 		}
+	} else {
+		set_query_var( 'sow-total_posts', $posts->found_posts );
 	}
 
 	return $posts;

--- a/widgets/post-carousel/tpl/base.php
+++ b/widgets/post-carousel/tpl/base.php
@@ -28,7 +28,7 @@
 		<a href="#" class="sow-carousel-next" title="<?php esc_attr_e('Next', 'so-widgets-bundle') ?>" aria-label="<?php esc_attr_e( 'Next Posts', 'so-widgets-bundle') ?>" role="button"></a>
 
 		<div class="sow-carousel-wrapper"
-		     data-post-count="<?php echo esc_attr($posts->found_posts) ?>"
+		     data-post-count="<?php echo esc_attr( get_query_var( 'sow-total_posts' ) ); ?>"
 		     data-loop-posts-enabled="<?php echo esc_attr( $loop_posts ) ?>"
 		     data-ajax-url="<?php echo sow_esc_url( wp_nonce_url( admin_url('admin-ajax.php'), 'widgets_action', '_widgets_nonce' ) ) ?>"
 		     data-page="1"


### PR DESCRIPTION
This filter is used to limit the total posts returned by the widget.

Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1210

This PR highlighted an issue introduced by https://github.com/siteorigin/so-widgets-bundle/pull/1171. The carousel was still factoring in the total number of visible items so it would sometimes skip to the last item - you can check this issue by setting the post limit to 12 and then removing [this commit](https://github.com/siteorigin/so-widgets-bundle/pull/1220/commits/96e68a6eeb244a44169e51baa6975c24c1804223).

Test Code:

```
add_filter( 'siteorigin_widgets_post_carousel_post_limit', function( $limit ) {
	return 12;
} );
```