### PR TITLE
Features: Ensure title tag exists before using it

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -300,7 +300,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 
 		$less_vars['container_size'] = $instance['container_size'];
 		$less_vars['icon_size'] = $instance['icon_size'];
-		$less_vars['title_tag'] = $instance['title_tag'];
+		$less_vars['title_tag'] = ! empty( $instance['title_tag'] ) ? $instance['title_tag'] : 'h5';
 		$less_vars['per_row'] = $instance['per_row'];
 		$less_vars['use_icon_size'] = empty( $instance['icon_size_custom'] ) ? 'false' : 'true';
 


### PR DESCRIPTION
This PR resolves an issue that can occur if the features widget was created before the title tag was introduced. To test this, import the Consultent prebuilt layout and the notice will be added to the debug.log.

`[25-Dec-2020 11:31:19 UTC] PHP Warning:  Undefined array key "title_tag" in C:\Users\Alex S\Local Beta Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\widgets\features\features.php on line 303`