### PR TITLE
Google Maps: Correct Marker JS Property Names

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -184,15 +184,15 @@ sowb.SiteOriginGoogleMap = function($) {
 				}
 				var geocodeMarker = function ( mrkr ) {
 					
-					var customIcon = mrkr.custom_marker_icon;
+					var customIcon = mrkr.customMarkerIcon;
 					var markerInfo = mrkr.hasOwnProperty( 'info' ) ? mrkr.info : null;
-					var infoMaxWidth = mrkr.hasOwnProperty( 'info_max_width' ) ? mrkr.info_max_width : null;
+					var infoMaxWidth = mrkr.hasOwnProperty( 'infoMaxWidth' ) ? mrkr.infoMaxWidth : null;
 					return this.getLocation( mrkr.place ).done( function ( location ) {
 						var mrkerIcon = options.markerIcon;
 						if ( customIcon ) {
 							mrkerIcon = customIcon;
 						}
-						
+
 						var marker = new google.maps.Marker( {
 							position: location,
 							map: map,


### PR DESCRIPTION
This PR corrects the marker property names to use the correct camelCase format. They were previously using variable names weren't camelCase so after https://github.com/siteorigin/so-widgets-bundle/pull/1199 they broke.

This PR can be tested by giving a marker a custom icon and the icon won't show. Once the branch is enabled, the icon will show.