### PR TITLE
Image widget: Add Support for Custom Image Size 

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -37,6 +37,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			'size' => array(
 				'type' => 'image-size',
 				'label' => __('Image size', 'so-widgets-bundle'),
+				'custom_size' => true,
 			),
 
 			'align' => array(
@@ -116,6 +117,18 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 
 	public function get_template_variables( $instance, $args ) {
 		$title = $this->get_image_title( $instance );
+
+		// Add support for custom sizes.
+		if (
+			$instance['size'] == 'custom_size' &&
+			! empty( $instance['size_width'] ) &&
+			! empty( $instance['size_height'] )
+		) {
+			$instance['size'] = array(
+				(int) $instance['size_width'],
+				(int) $instance['size_width'],
+			);
+		}
 
 		$src = siteorigin_widgets_get_attachment_image_src(
 			$instance['image'],


### PR DESCRIPTION
Requires https://github.com/siteorigin/so-widgets-bundle/pull/1243
Please note that if you revert this PR the image size will continue to be `custom_size` until you save the widget again.