### PR TITLE
Social Media Buttons: Add IMDb

### DIFF
--- a/widgets/social-media-buttons/data/networks.php
+++ b/widgets/social-media-buttons/data/networks.php
@@ -196,6 +196,12 @@ return array(
 		'icon_color' => '#FFFFFF',
 		'button_color' => '#FF6600'
 	),
+	'imdb'   => array(
+		'label'    => __( 'IMDb', 'so-widgets-bundle' ),
+		'base_url' => 'https://www.imdb.com/',
+		'icon_color' => '#F3CE13',
+		'button_color' => '#000'
+	),
 	'jsfiddle'   => array(
 		'label'    => __( 'JSFiddle', 'so-widgets-bundle' ),
 		'base_url' => 'http://jsfiddle.net/',


### PR DESCRIPTION
Resolve #1245 

I opted for the base Network URL to be https://www.imdb.com/ as the urls for movies are different to people and there are valid use cases for both.