### PR TITLE
Video: If autoplay is enabled, add playsinline

### DIFF
--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -24,6 +24,7 @@ $video_args = array(
 );
 if ( $autoplay ) {
 	$video_args['autoplay'] = 1;
+	$video_args['playsinline'] = '';
 	// In most brwosers, Videos need to be muted to autoplay.
 	if ( apply_filters( 'sow_video_autoplay_mute_self_hosted', true ) ) {
 		$video_args['muted'] = true;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1248

This PR will ensure the video when viewed on mobile Safari is able to play inline and doesn't force full screen ([related MDN](https://developer.mozilla.org/en-US/docs/Learn/Performance/video#video_autoplay)).