### PR TITLE
Sliders: Add Always show navigation on desktop setting

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -118,6 +118,11 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				'default' => '25',
 			),
 
+			'nav_always_show_desktop' => array(
+				'type' => 'checkbox',
+				'label' => __( 'Always show navigation on desktop', 'so-widgets-bundle' ),
+			),
+
 			'nav_always_show_mobile' => array(
 				'type' => 'checkbox',
 				'label' => __( 'Always show navigation on mobile', 'so-widgets-bundle' ),
@@ -192,6 +197,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			'paused'                   => empty( $controls['autoplay'] ) ?: false,
 			'pause_on_hover'           => ! empty( $controls['autoplay_hover'] ) ?: false,
 			'swipe'                    => $controls['swipe'],
+			'nav_always_show_desktop'  => ! empty( $controls['nav_always_show_desktop'] ) ? true : '',
 			'nav_always_show_mobile'   => ! empty( $controls['nav_always_show_mobile'] ) ? true : '',
 			'breakpoint'               => ! empty( $controls['breakpoint'] ) ? $controls['breakpoint'] : '780px',
 		);

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -186,22 +186,26 @@ jQuery( function($){
 				$p.add($n).hide();
 				if( $slides.length > 1 ) {
 					if( !$base.hasClass('sow-slider-is-mobile') ) {
-
-						var toHide = false;
-						$base
-							.on( 'mouseenter', function() {
-								$p.add($n).clearQueue().fadeIn(150);
-								toHide = false;
-							})
-							.on( 'mouseleave', function() {
-								toHide = true;
-								setTimeout(function(){
-									if( toHide ) {
-										$p.add($n).clearQueue().fadeOut(150);
-									}
+						if ( settings.nav_always_show_desktop && window.matchMedia( '(min-width: ' + settings.breakpoint + ')' ).matches ) {
+						$p.show();
+						$n.show();
+						} else {
+							var toHide = false;
+							$base
+								.on( 'mouseenter', function() {
+									$p.add( $n ).clearQueue().fadeIn( 150 );
 									toHide = false;
-								}, 750);
-							});
+								} )
+								.on( 'mouseleave', function() {
+									toHide = true;
+									setTimeout( function() {
+										if( toHide ) {
+											$p.add( $n ).clearQueue().fadeOut( 150 );
+										}
+										toHide = false;
+									}, 750) ;
+								} );
+						}
 					} else if ( settings.nav_always_show_mobile && window.matchMedia('(max-width: ' + settings.breakpoint + ')').matches) {
 						$p.show();
 						$n.show();

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -187,8 +187,8 @@ jQuery( function($){
 				if( $slides.length > 1 ) {
 					if( !$base.hasClass('sow-slider-is-mobile') ) {
 						if ( settings.nav_always_show_desktop && window.matchMedia( '(min-width: ' + settings.breakpoint + ')' ).matches ) {
-						$p.show();
-						$n.show();
+							$p.show();
+							$n.show();
 						} else {
 							var toHide = false;
 							$base


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/906

I went with a separate setting as implementing migration code would require modifying each individual widget (less than ideal as the central slider class was introduced to avoid that need). It would be a good idea to remove the slider dependency on [wp_is_mobile()](https://developer.wordpress.org/reference/functions/wp_is_mobile/) as that isn't cache-friendly, and it's redundant due to the slider breakpoint.