### PR TITLE
Allow form field class prefix and path filering

### DIFF
--- a/base/inc/fields/siteorigin-widget-field-class-loader.class.php
+++ b/base/inc/fields/siteorigin-widget-field-class-loader.class.php
@@ -88,7 +88,7 @@ class SiteOrigin_Widget_Field_Class_Loader {
 			$filepath = $class_path . $filename . '.class.php';
 			if ( file_exists( $filepath ) ) {
 				require_once $filepath;
-				continue;
+				break;
 			}
 		}
 	}
@@ -106,6 +106,9 @@ class SiteOrigin_Widget_Field_Class_Loader {
 			apply_filters( 'siteorigin_widgets_field_class_paths', array() ),
 			'base'
 		);
+
+		$this->class_prefixes = apply_filters( 'siteorigin_widgets_field_registered_class_prefixes', $this->class_prefixes );
+		$this->class_paths = apply_filters( 'siteorigin_widgets_field_registered_class_paths', $this->class_paths );
 	}
 }
 


### PR DESCRIPTION
Resolve #711

This PR adds two filters to allow for developers to replace all registered prefixes and paths. The filters are:

- `siteorigin_widgets_field_registered_class_prefixes`
- `siteorigin_widgets_field_registered_class_paths`

Here's an example plugin that will replace the TinyMCE with a simple message (it's an example of a major change a developer could make).

[so-override-field.zip](https://drive.google.com/uc?id=18ia1AhnTP70rKsk56i3J592Pkb5Lc1ra)

Screenshot of example plugin:
![Screenshot_2021-03-09 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/110354422-dd7d9c80-8083-11eb-89b3-4957c921384a.png)

