### PR TITLE
Layout Slider: Slider Control Shortcode

### DIFF
--- a/widgets/layout-slider/js/slide-control.js
+++ b/widgets/layout-slider/js/slide-control.js
@@ -1,7 +1,7 @@
 /* globals jQuery */
 
 jQuery( function ( $ ) {
-	$( '.sow-slider-control' ).on( 'click', function(e) {
+	$( '.sow-slide-control' ).on( 'click', function(e) {
 		var $$ = $( this ),
 			cycleContainer = $$.parents( '.sow-slider-images' );
 			slideValue = $$.attr( 'href' ).substr(1);

--- a/widgets/layout-slider/js/slide-control.js
+++ b/widgets/layout-slider/js/slide-control.js
@@ -1,10 +1,10 @@
 /* globals jQuery */
 
 jQuery( function ( $ ) {
-	$( '.sow-slide-control' ).on( 'click', function(e) {
+	$( '.sow-slide-control' ).on( 'click', function( e ) {
 		var $$ = $( this ),
 			cycleContainer = $$.parents( '.sow-slider-images' );
-			slideValue = $$.attr( 'href' ).substr(1);
+			slideValue = $$.attr( 'href' ).substr( 1 );
 
 		e.preventDefault();
 

--- a/widgets/layout-slider/js/slide-control.js
+++ b/widgets/layout-slider/js/slide-control.js
@@ -9,7 +9,7 @@ jQuery( function ( $ ) {
 		e.preventDefault();
 
 		if ( ! isNaN( slideValue ) ) {
-			cycleContainer.cycle( 'goto', slideValue );
+			cycleContainer.cycle( 'goto', Math.abs( slideValue - 1 ) );
 		} else {
 			switch ( slideValue ) {
 				case 'first':

--- a/widgets/layout-slider/js/slider-control.js
+++ b/widgets/layout-slider/js/slider-control.js
@@ -1,10 +1,12 @@
 /* globals jQuery */
 
 jQuery( function ( $ ) {
-	$( '.sow-slider-control' ).on( 'click', function() {
+	$( '.sow-slider-control' ).on( 'click', function(e) {
 		var $$ = $( this ),
 			cycleContainer = $$.parents( '.sow-slider-images' );
-			slideValue = $$.data( 'slide' );
+			slideValue = $$.attr( 'href' ).substr(1);
+
+		e.preventDefault();
 
 		if ( ! isNaN( slideValue ) ) {
 			cycleContainer.cycle( 'goto', slideValue );

--- a/widgets/layout-slider/js/slider-control.js
+++ b/widgets/layout-slider/js/slider-control.js
@@ -1,0 +1,28 @@
+/* globals jQuery */
+
+jQuery( function ( $ ) {
+	$( '.sow-slider-control' ).on( 'click', function() {
+		var $$ = $( this ),
+			cycleContainer = $$.parents( '.sow-slider-images' );
+			slideValue = $$.data( 'slide' );
+
+		if ( ! isNaN( slideValue ) ) {
+			cycleContainer.cycle( 'goto', slideValue );
+		} else {
+			switch ( slideValue ) {
+				case 'first':
+					cycleContainer.cycle( 'goto', 0 );
+					break;
+				case 'last':
+					cycleContainer.cycle( 'goto', cycleContainer.find( '.sow-slider-image:not(.cycle-sentinel)' ).length - 1 );
+					break;
+				case 'next':
+					cycleContainer.cycle( 'next' );
+					break;
+				case 'previous':
+					cycleContainer.cycle( 'prev' );
+					break;
+			}
+		}
+	} );
+} );

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -316,7 +316,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 			// Handle label overriding.
 			$label = empty( $atts['label'] ) ? $label : $atts['label'];
 
-			echo '<span class="sow-slider-control" data-slide="' . esc_attr( $atts['slide'] ) . '">' . esc_attr( $label ) . '</span>';
+			echo '<a class="sow-slider-control" href="#' . esc_attr( $atts['slide'] ) . '" role="button">' . esc_attr( $label ) . '</a>';
 		}
 
 		return ob_get_clean();

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -26,6 +26,8 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 			false,
 			plugin_dir_path(__FILE__)
 		);
+
+		add_action( 'siteorigin_widgets_enqueue_frontend_scripts_sow-layout-slider', array( $this, 'register_shortcode_script' ) );
 	}
 
 	function get_widget_form(){
@@ -272,6 +274,54 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 		<?php
 	}
 
+	function register_shortcode_script() {
+		wp_register_script(
+			'sow-layout-slider-control',
+			plugin_dir_url( __FILE__ ) . 'js/slider-control' . SOW_BUNDLE_JS_SUFFIX . '.js',
+			array( 'jquery', 'sow-slider-slider' ),
+			SOW_BUNDLE_VERSION,
+			true
+		);
+	}
+
+	function add_shortcode( $atts ) {
+		ob_start();
+		$atts = shortcode_atts( array(
+			'slide' => 'next',
+			'label' => '',
+		), $atts );
+
+		wp_enqueue_script( 'sow-layout-slider-control' );
+
+		if ( is_numeric( $atts['slide'] ) ) {
+			$label = sprintf( __( 'Show slide %d', 'so-widgets-bundle' ), $atts['slide'] );
+		} elseif (
+			$atts['slide'] == 'next' ||
+			$atts['slide'] == 'prev' ||
+			$atts['slide'] == 'prev' ||
+			$atts['slide'] == 'previous' ||
+			$atts['slide'] == 'first' ||
+			$atts['slide'] == 'last'
+		) {
+			if ( $atts['slide'] == 'prev' ) {
+				$atts['slide'] = 'previous';
+			}
+
+			$label = sprintf( __( '%s slide', 'so-widgets-bundle' ), ucfirst( $atts['slide'] ) );
+		} else {
+			_e( 'Slider control shortcode error: invalid slide value.', 'so-widgets-bundle' );
+		}
+
+		if ( isset( $label ) ) {
+			// Handle label overriding.
+			$label = empty( $atts['label'] ) ? $label : $atts['label'];
+
+			echo '<span class="sow-slider-control" data-slide="' . esc_attr( $atts['slide'] ) . '">' . esc_attr( $label ) . '</span>';
+		}
+
+		return ob_get_clean();
+	}
+
 	/**
 	 * Process the content.
 	 *
@@ -282,8 +332,10 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 	 */
 	function process_content( $content, $frame ) {
 		if( function_exists( 'siteorigin_panels_render' ) ) {
+			add_shortcode( 'slider_control', array( $this, 'add_shortcode' ) );
 			$content_builder_id = substr( md5( json_encode( $content ) ), 0, 8 );
 			echo siteorigin_panels_render( 'w'.$content_builder_id, true, $content );
+			remove_shortcode( 'slider_control' );
 		}
 		else {
 			echo __( 'This widget requires Page Builder.', 'so-widgets-bundle' );

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -276,8 +276,8 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 
 	function register_shortcode_script() {
 		wp_register_script(
-			'sow-layout-slider-control',
-			plugin_dir_url( __FILE__ ) . 'js/slider-control' . SOW_BUNDLE_JS_SUFFIX . '.js',
+			'sow-layout-slide-control',
+			plugin_dir_url( __FILE__ ) . 'js/slide-control' . SOW_BUNDLE_JS_SUFFIX . '.js',
 			array( 'jquery', 'sow-slider-slider' ),
 			SOW_BUNDLE_VERSION,
 			true
@@ -291,7 +291,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 			'label' => '',
 		), $atts );
 
-		wp_enqueue_script( 'sow-layout-slider-control' );
+		wp_enqueue_script( 'sow-layout-slide-control' );
 
 		if ( is_numeric( $atts['slide'] ) ) {
 			$label = sprintf( __( 'Show slide %d', 'so-widgets-bundle' ), $atts['slide'] );
@@ -309,14 +309,14 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 
 			$label = sprintf( __( '%s slide', 'so-widgets-bundle' ), ucfirst( $atts['slide'] ) );
 		} else {
-			_e( 'Slider control shortcode error: invalid slide value.', 'so-widgets-bundle' );
+			_e( 'Slide control shortcode error: invalid slide value.', 'so-widgets-bundle' );
 		}
 
 		if ( isset( $label ) ) {
 			// Handle label overriding.
 			$label = empty( $atts['label'] ) ? $label : $atts['label'];
 
-			echo '<a class="sow-slider-control" href="#' . esc_attr( $atts['slide'] ) . '" role="button">' . esc_attr( $label ) . '</a>';
+			echo '<a class="sow-slide-control" href="#' . esc_attr( $atts['slide'] ) . '" role="button">' . esc_attr( $label ) . '</a>';
 		}
 
 		return ob_get_clean();
@@ -332,10 +332,10 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 	 */
 	function process_content( $content, $frame ) {
 		if( function_exists( 'siteorigin_panels_render' ) ) {
-			add_shortcode( 'slider_control', array( $this, 'add_shortcode' ) );
+			add_shortcode( 'slide_control', array( $this, 'add_shortcode' ) );
 			$content_builder_id = substr( md5( json_encode( $content ) ), 0, 8 );
 			echo siteorigin_panels_render( 'w'.$content_builder_id, true, $content );
-			remove_shortcode( 'slider_control' );
+			remove_shortcode( 'slide_control' );
 		}
 		else {
 			echo __( 'This widget requires Page Builder.', 'so-widgets-bundle' );


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/267

This PR introduces a shortcode for the Layout Slider called slider_control. The options for this shortcode are:

- Label - Optional label to use in navigation text.
- Slide - What slide to navigate to.

Slide options are:
- first
- last
- prev
- previous
- next
- slide number (eg. 3)

Unlike the code snippets we previously provided, the slide number isn't zero-based. This means if you wanted to link to the third slide, use 3 rather than 2.

`[slide_control slide="3"]`

[Test layout with slides with various shortcodes setup for testing.](https://drive.google.com/uc?id=1DLDQ3pB6j4S3rLK3jifvG83l7l4L_TXu)