### PR TITLE
Editor: Don't process more quicktag in previews

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -108,7 +108,17 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 
 			$instance['text'] = do_shortcode( shortcode_unautop( $instance['text'] ) );
 
-			$instance['text'] = $this->process_more_quicktag( $instance['text'] );
+			// Don't process more more quicktag if this is a preview.
+			if (
+				! $this->is_preview() &&
+				empty( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] ) &&
+				(
+					empty( $_POST['action'] ) &&
+					$_POST['action'] != 'so_widgets_preview'
+				)
+			) {
+				$instance['text'] = $this->process_more_quicktag( $instance['text'] );
+			}
 		}
 
 


### PR DESCRIPTION
This PR will prevent the more tag from being processed in previews. When processed, it can cause issues with widget previews, and the SEO analysis due to the read more text being used over other text.

To test this issue create a post and add a SiteOrigin Editor widget. Add some text and then insert more text. Add some more text after the more quicktag and then preview the editor widget. You can also test this using the SiteOrigin Layout Block Preview, and content analysis word count.