### PR TITLE
Improve cache plugin support

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -734,7 +734,10 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		}
 
 		// Remove the old CSS, it'll be regenerated on page load.
-		$this->delete_css( $this->modify_instance( $old_instance ) );
+		if ( $form_type == 'widget' ) {
+			$this->delete_css( $this->modify_instance( $old_instance ) );
+		}
+
 		return $new_instance;
 	}
 

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -296,7 +296,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		if( !empty($style) ) {
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base.'-'.$style.'-'.$hash;
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id(); // Tested.
 
 			//Ensure styles aren't generated and enqueued more than once.
 			$in_preview = $this->is_preview( $instance ) || ( isset( $_POST['action'] ) &&  $_POST['action'] == 'so_widgets_preview' );
@@ -749,7 +749,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		$style = $this->get_style_name($instance);
 		$hash = $this->get_style_hash( $instance );
-		$name = $this->id_base.'-'.$style.'-'.$hash.'.css';
+		$name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id() . '.css'; //
 
 		$css = $this->get_instance_css($instance);
 
@@ -801,7 +801,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 			$style = $this->get_style_name($instance);
 			$hash = $this->get_style_hash( $instance );
-			$name = $this->id_base.'-'.$style.'-'.$hash;
+			$name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id();
 
 			$wp_filesystem->delete($upload_dir['basedir'] . '/siteorigin-widgets/' . $name . '.css');
 			if ( in_array( $name, $this->generated_css ) ) {
@@ -906,7 +906,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		if( ! empty( $less ) ) {
 			$style = $this->get_style_name( $instance );
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base . '-' . $style . '-' . $hash;
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id();
 
 			//we assume that any remaining @imports are plain css imports and should be kept outside selectors
 			$css_imports = '';

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -842,6 +842,9 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 						if( $file['lastmodunix'] < time() - self::$css_expire || $force_delete ) {
 							// Delete the file
 							$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $file['name'] );
+
+							// Alert other plugins that we've deleted a CSS file
+							do_action( 'siteorigin_widgets_stylesheet_deleted', $file['name'] );
 						}
 					}
 				}

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -819,9 +819,9 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Clear all old CSS files
+	 * Clear all old CSS files.
 	 *
-	 * @var bool $force Must we force a cache refresh.
+	 * @var bool $force_delete Whether to forcefully clear the file cache.
 	 */
 	public static function clear_file_cache( $force_delete = false ){
 		SiteOrigin_Widgets_Bundle::single()->clear_file_cache( $force_delete, self::$css_expire );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -295,7 +295,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		if( !empty($style) ) {
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id(); // Tested.
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
 
 			//Ensure styles aren't generated and enqueued more than once.
 			$in_preview = $this->is_preview( $instance ) || ( isset( $_POST['action'] ) &&  $_POST['action'] == 'so_widgets_preview' );
@@ -751,7 +751,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		$style = $this->get_style_name($instance);
 		$hash = $this->get_style_hash( $instance );
-		$name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id() . '.css'; //
+		$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' ) . '.css';
 
 		$css = $this->get_instance_css($instance);
 
@@ -803,7 +803,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 			$style = $this->get_style_name($instance);
 			$hash = $this->get_style_hash( $instance );
-			$name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id();
+			$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
 
 			$wp_filesystem->delete($upload_dir['basedir'] . '/siteorigin-widgets/' . $name . '.css');
 			if ( in_array( $name, $this->generated_css ) ) {
@@ -882,7 +882,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		if( ! empty( $less ) ) {
 			$style = $this->get_style_name( $instance );
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base . '-' . $style . '-' . $hash . '-' . get_the_id();
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
 
 			//we assume that any remaining @imports are plain css imports and should be kept outside selectors
 			$css_imports = '';

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -90,7 +90,6 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			w3tc_flush_all();
 		}
 
-
 		if ( class_exists( 'Swift_Performance_Cache' ) ) {
 			Swift_Performance_Cache::clear_all_cache();
 		}

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -63,10 +63,9 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 	/**
 	 * Tell cache plugins that they need to regenerate a page cache.
 	 *
-	 * @param $excluded
-	 * @param $content
+	 * @param $name The name of the file that's been deleted.
+	 * @param $instance The current instance of the related widget.
 	 *
-	 * @return string
 	 */
 	public function clear_page_cache( $name, $instance = array() ) {
 		$id = end( explode( '-', $name ) );
@@ -85,11 +84,6 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 
 	/**
 	 * Tell cache plugins that they need to regenerate their all page cache.
-	 *
-	 * @param $excluded
-	 * @param $content
-	 *
-	 * @return string
 	 */
 	public function clear_all_cache() {
 		if ( function_exists( 'w3tc_flush_all' ) ) {

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -68,7 +68,8 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 	 *
 	 */
 	public function clear_page_cache( $name, $instance = array() ) {
-		$id = end( explode( '-', $name ) );
+		$id = explode( '-', $name );
+		$id = end( $id );
 
 		if ( is_numeric( $id ) ) {
 

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -25,6 +25,11 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		if ( function_exists( 'register_block_type' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'block-editor/widget-block.php';
 		}
+
+		// These actions handle alerting cache plugins that they need to regenerate a page cache.
+		add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
+		add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
+		add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
 	}
 
 	function get_active_builder() {
@@ -32,7 +37,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		$builders = include_once 'builders.php';
 
 		foreach ( $builders as $builder ) {
-			if ( $this->is_active( $builder ) ) {
+			if ( $this->is_builder_active( $builder ) ) {
 				return $builder;
 			}
 		}
@@ -40,7 +45,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		return null;
 	}
 
-	function is_active( $builder ) {
+	function is_builder_active( $builder ) {
 		switch ( $builder[ 'name' ] ) {
 			case self::BEAVER_BUILDER:
 				return class_exists( 'FLBuilderModel', false );
@@ -51,6 +56,49 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			case self::VISUAL_COMPOSER:
 				return class_exists( 'Vc_Manager' );
 			break;
+		}
+	}
+
+
+	/**
+	 * Tell cache plugins that they need to regenerate a page cache.
+	 *
+	 * @param $excluded
+	 * @param $content
+	 *
+	 * @return string
+	 */
+	public function clear_page_cache( $name, $instance = array() ) {
+		$id = end( explode( '-', $name ) );
+
+		if ( is_numeric( $id ) ) {
+
+			if ( function_exists( 'w3tc_flush_post' ) ) {
+				w3tc_flush_post( $id );
+			}
+
+			if ( class_exists( 'Swift_Performance_Cache' ) ) {
+				Swift_Performance_Cache::clear_post_cache( $id );
+			}
+		}
+	}
+
+	/**
+	 * Tell cache plugins that they need to regenerate their all page cache.
+	 *
+	 * @param $excluded
+	 * @param $content
+	 *
+	 * @return string
+	 */
+	public function clear_all_cache() {
+		if ( function_exists( 'w3tc_flush_all' ) ) {
+			w3tc_flush_all();
+		}
+
+
+		if ( class_exists( 'Swift_Performance_Cache' ) ) {
+			Swift_Performance_Cache::clear_all_cache();
 		}
 	}
 

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -321,12 +321,13 @@ class SiteOrigin_Widgets_Bundle {
 	}
 
 	/**
-	 * Clear all old CSS files
+	 * Clear all old CSS files.
 	 *
-	 * @var bool $force Must we force a cache refresh.
+	 * @var bool $force_delete Whether to forcefully clear the file cache.
+	 * @var int $css_expire The maximum age of a file before it's removed.
 	 */
 	public static function clear_file_cache( $force_delete = false, $css_expire = 604800 ) {
-		// Use this variable to ensure this only runs once per request
+		// Use this variable to ensure this only runs once per request.
 		static $done = false;
 
 		if ( $done && ! $force_delete ) {
@@ -343,10 +344,10 @@ class SiteOrigin_Widgets_Bundle {
 				if ( ! empty( $list ) ) {
 					foreach( $list as $file ) {
 						if ( $file['lastmodunix'] < time() - $css_expire || $force_delete ) {
-							// Delete the file
+							// Delete the file.
 							$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $file['name'] );
 
-							// Alert other plugins that we've deleted a CSS file
+							// Alert other plugins that we've deleted a CSS file.
 							do_action( 'siteorigin_widgets_stylesheet_deleted', $file['name'] );
 						}
 					}

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -158,6 +158,8 @@ class SiteOrigin_Widgets_Bundle {
 	 */
 	function clear_widget_cache() {
 		// Remove all cached CSS for SiteOrigin Widgets
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
 		if( function_exists('WP_Filesystem') && WP_Filesystem() ) {
 			global $wp_filesystem;
 			$upload_dir = wp_upload_dir();

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -88,6 +88,11 @@ class SiteOrigin_Widgets_Bundle {
 		if ( class_exists('autoptimizeMain', false) ) {
 			add_filter( 'autoptimize_filter_css_exclude', array( $this, 'include_widgets_css_in_autoptimize'), 10, 2 );
 		}
+
+		// These actions handle telling cache plugins that they need to regenerate a page cache.
+		add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
+		add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
+		add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
 	}
 
 	/**
@@ -864,6 +869,33 @@ class SiteOrigin_Widgets_Bundle {
 		$excluded = implode( ',', array_filter( array_merge( $excl, $add ) ) );
 
 		return $excluded;
+	}
+
+	/**
+	 * Tell cache plugins that they need to regenerate a specific page's cache.
+	 *
+	 * @param $name
+	 * @param $instance
+	 */
+	public function clear_page_cache( $name, $instance = array() ) {
+		$id = end( explode( '-', $name ) );
+
+		if ( is_numeric( $id ) ) {
+			if ( class_exists( 'Swift_Performance_Cache' ) ) {
+				Swift_Performance_Cache::clear_post_cache( $id );
+			}
+		}
+	}
+
+	/**
+	 * Tell cache plugins that they need to regenerate their entire page cache.
+	 *
+	 * @return string
+	 */
+	public function clear_all_cache() {
+		if ( class_exists( 'Swift_Performance_Cache' ) ) {
+			Swift_Performance_Cache::clear_all_cache();
+		}
 	}
 
 }

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -922,6 +922,10 @@ class SiteOrigin_Widgets_Bundle {
 		$id = end( explode( '-', $name ) );
 
 		if ( is_numeric( $id ) ) {
+			if ( function_exists( 'w3tc_flush_post' ) ) {
+				w3tc_flush_post( $id );
+			}
+
 			if ( class_exists( 'Swift_Performance_Cache' ) ) {
 				Swift_Performance_Cache::clear_post_cache( $id );
 			}
@@ -934,6 +938,11 @@ class SiteOrigin_Widgets_Bundle {
 	 * @return string
 	 */
 	public function clear_all_cache() {
+		if ( function_exists( 'w3tc_flush_all' ) ) {
+			w3tc_flush_all();
+		}
+
+
 		if ( class_exists( 'Swift_Performance_Cache' ) ) {
 			Swift_Performance_Cache::clear_all_cache();
 		}

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -170,6 +170,9 @@ class SiteOrigin_Widgets_Bundle {
 					$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $file['name'] );
 				}
 			}
+
+			// Alert other plugins that we've deleted all CSS files.
+			do_action( 'siteorigin_widgets_stylesheet_cleared' );
 		}
 	}
 

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -47,6 +47,7 @@ class SiteOrigin_Widgets_Bundle {
 	function __construct(){
 		add_action('admin_init', array($this, 'admin_activate_widget') );
 		add_action('admin_menu', array($this, 'admin_menu_init') );
+		add_action('admin_init', array( $this, 'clear_file_cache' ) );
 		add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts') );
 		add_action('admin_enqueue_scripts', array($this, 'admin_register_scripts') );
 
@@ -323,7 +324,47 @@ class SiteOrigin_Widgets_Bundle {
 
 		}
 	}
-	
+
+	/**
+	 * Clear all old CSS files
+	 *
+	 * @var bool $force Must we force a cache refresh.
+	 */
+	public static function clear_file_cache( $force_delete = false, $css_expire = 604800 ) {
+		// Use this variable to ensure this only runs once per request
+		static $done = false;
+
+		if ( $done && ! $force_delete ) {
+			return;
+		}
+
+		if ( ! get_transient( 'sow:cleared' ) || $force_delete ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			if ( WP_Filesystem() ) {
+				global $wp_filesystem;
+				$upload_dir = wp_upload_dir();
+
+				$list = $wp_filesystem->dirlist( $upload_dir['basedir'] . '/siteorigin-widgets/' );
+				if ( ! empty( $list ) ) {
+					foreach( $list as $file ) {
+						if ( $file['lastmodunix'] < time() - $css_expire || $force_delete ) {
+							// Delete the file
+							$wp_filesystem->delete( $upload_dir['basedir'] . '/siteorigin-widgets/' . $file['name'] );
+
+							// Alert other plugins that we've deleted a CSS file
+							do_action( 'siteorigin_widgets_stylesheet_deleted', $file['name'] );
+						}
+					}
+				}
+			}
+
+			// Set this transient so we know when to clear all the generated CSS.
+			set_transient( 'sow:cleared', true, $css_expire );
+		}
+
+		$done = true;
+	}
+
 	/**
 	 * Register some common scripts used in forms.
 	 */

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -89,11 +89,6 @@ class SiteOrigin_Widgets_Bundle {
 		if ( class_exists('autoptimizeMain', false) ) {
 			add_filter( 'autoptimize_filter_css_exclude', array( $this, 'include_widgets_css_in_autoptimize'), 10, 2 );
 		}
-
-		// These actions handle telling cache plugins that they need to regenerate a page cache.
-		add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
-		add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
-		add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
 	}
 
 	/**
@@ -910,42 +905,6 @@ class SiteOrigin_Widgets_Bundle {
 		$excluded = implode( ',', array_filter( array_merge( $excl, $add ) ) );
 
 		return $excluded;
-	}
-
-	/**
-	 * Tell cache plugins that they need to regenerate a specific page's cache.
-	 *
-	 * @param $name
-	 * @param $instance
-	 */
-	public function clear_page_cache( $name, $instance = array() ) {
-		$id = end( explode( '-', $name ) );
-
-		if ( is_numeric( $id ) ) {
-			if ( function_exists( 'w3tc_flush_post' ) ) {
-				w3tc_flush_post( $id );
-			}
-
-			if ( class_exists( 'Swift_Performance_Cache' ) ) {
-				Swift_Performance_Cache::clear_post_cache( $id );
-			}
-		}
-	}
-
-	/**
-	 * Tell cache plugins that they need to regenerate their entire page cache.
-	 *
-	 * @return string
-	 */
-	public function clear_all_cache() {
-		if ( function_exists( 'w3tc_flush_all' ) ) {
-			w3tc_flush_all();
-		}
-
-
-		if ( class_exists( 'Swift_Performance_Cache' ) ) {
-			Swift_Performance_Cache::clear_all_cache();
-		}
 	}
 
 }


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/866

To test this please add the following PHP to [this line](https://github.com/siteorigin/so-widgets-bundle/pull/1258/files#diff-2dc7c68c2b6e69aef4ae1d74975cb590295990126bcd9a32c7f9614f0e0a6f0fR336).

`$force_delete = true;`

Then view WP Admin. View a page that has had its widget CSS cleared and new widget CSS should be generated (as well as the cache regenerated but that's harder to check). If those plugins aren't alerted (and minify isn't managed through their plugins directly) you'll end up with a bunch of 404 notices. If it's working as expected, the page display as expected, and new CSS files will be in the `wp-content/uploads/siteorigin-widgets` directory. Please note that you may need to clear your browser cache for the cache plugin to be able to regenerate the page .

To do:

- [x] Add Support for W3 Total Cache
- [x] Clear CSS Cache while viewing WP Admin (this will ensure that cache plugins are able to be reliably alerted).
- [x] Improve widget area support for new cached CSS filename.