### PR TITLE
Widgets Block: Activate Widgets Automatically

### DIFF
--- a/base/inc/routes/siteorigin-widgets-resource.class.php
+++ b/base/inc/routes/siteorigin-widgets-resource.class.php
@@ -90,7 +90,6 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 		$widget = SiteOrigin_Widgets_Widget_Manager::get_widget_instance( $widget_class );
 		// Attempt to activate the widget if it's not already active.
 		if ( ! empty( $widget_class ) && empty( $widget ) ) {
-			global $wp_widget_factory;
 			$widget = SiteOrigin_Widgets_Bundle::single()->load_missing_widget( false, $widget_class );
 		}
 
@@ -142,7 +141,6 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 		$widget = SiteOrigin_Widgets_Widget_Manager::get_widget_instance( $widget_class );
 		// Attempt to activate the widget if it's not already active.
 		if ( ! empty( $widget_class ) && empty( $widget ) ) {
-			global $wp_widget_factory;
 			$widget = SiteOrigin_Widgets_Bundle::single()->load_missing_widget( false, $widget_class );
 		}
 

--- a/base/inc/routes/siteorigin-widgets-resource.class.php
+++ b/base/inc/routes/siteorigin-widgets-resource.class.php
@@ -88,6 +88,11 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 
 		/* @var $widget SiteOrigin_Widget */
 		$widget = SiteOrigin_Widgets_Widget_Manager::get_widget_instance( $widget_class );
+		// Attempt to activate the widget if it's not already active.
+		if ( ! empty( $widget_class ) && empty( $widget ) ) {
+			global $wp_widget_factory;
+			$widget = SiteOrigin_Widgets_Bundle::single()->load_missing_widget( false, $widget_class );
+		}
 
 		if ( ! empty( $widget ) && is_object( $widget ) && is_subclass_of( $widget, 'SiteOrigin_Widget' ) ) {
 			if ( ! empty( $widget_data ) ) {
@@ -135,6 +140,12 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 		$widget_data = $request['widgetData'];
 
 		$widget = SiteOrigin_Widgets_Widget_Manager::get_widget_instance( $widget_class );
+		// Attempt to activate the widget if it's not already active.
+		if ( ! empty( $widget_class ) && empty( $widget ) ) {
+			global $wp_widget_factory;
+			$widget = SiteOrigin_Widgets_Bundle::single()->load_missing_widget( false, $widget_class );
+		}
+
 		// This ensures styles are added inline.
 		add_filter( 'siteorigin_widgets_is_preview', '__return_true' );
 		$GLOBALS[ 'SO_WIDGETS_BUNDLE_PREVIEW_RENDER' ] = true;

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -34,8 +34,22 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		$widgets_metadata_list = SiteOrigin_Widgets_Bundle::single()->get_widgets_list();
 		$widgets_manager = SiteOrigin_Widgets_Widget_Manager::single();
 
-		global $wp_widget_factory;
 		$so_widgets = array();
+		// Add data for any inactive widgets.
+		foreach ( $widgets_metadata_list as $widget ) {
+			if ( ! $widget['Active'] ) {
+				include_once wp_normalize_path( $widget['File'] );
+				// The last class will always be from the widget file we just loaded.
+				$widget_class = end( get_declared_classes() );
+
+				$so_widgets[] = array(
+					'name' => $widget['Name'],
+					'class' => $widget_class,
+				);
+			}
+		}
+
+		global $wp_widget_factory;
 		$third_party_widgets = array();
 		foreach ( $wp_widget_factory->widgets as $class => $widget_obj ) {
 			if ( ! empty( $widget_obj ) && is_object( $widget_obj ) && is_subclass_of( $widget_obj, 'SiteOrigin_Widget' ) ) {

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -104,6 +104,10 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		global $wp_widget_factory;
 
 		$widget = ! empty( $wp_widget_factory->widgets[ $widget_class ] ) ? $wp_widget_factory->widgets[ $widget_class ] : false;
+		// Attempt to activate the widget if it's not already active.
+		if ( ! empty( $widget_class ) && empty( $widget ) ) {
+			$widget = SiteOrigin_Widgets_Bundle::single()->load_missing_widget( false, $widget_class );
+		}
 
 		$instance = $attributes['widgetData'];
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/850

To test:
- Deactivate Headline widget
- Attempt to use it in a SiteOrgin WIdgets Block, and widget will be activated.
- Add some placeholder data and then save.
- Deactivate Headline widget.
- Reload Block Editor with recently added SiteOrigin Widgets Block with Headline widget.
- Widget will be activated and should preview as expected and the form should be accessiable.