### PR TITLE
Twenty Twenty-One Block Editor: Restore Select Styling

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -128,6 +128,12 @@
 		}
 
 		select {
+			border: 1px solid #8c8f94;
+			border-radius: 3px;
+			box-shadow: none;
+			color: #2c3338;
+			font-size: 14px;
+			padding: 0 24px 0 8px;
 			min-width: 150px;
 
 			@media (max-width: 680px) {

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -128,12 +128,6 @@
 		}
 
 		select {
-			border: 1px solid #8c8f94;
-			border-radius: 3px;
-			box-shadow: none;
-			color: #2c3338;
-			font-size: 14px;
-			padding: 0 24px 0 8px;
 			min-width: 150px;
 
 			@media (max-width: 680px) {
@@ -759,6 +753,18 @@
 					min-width: unset;
 				}
 			}
+		}
+	}
+	
+	.so-widget-placeholder .components-base-control__field,
+	.siteorigin-widget-field {
+		select {
+			border: 1px solid #8c8f94;
+			border-radius: 3px;
+			box-shadow: none;
+			color: #2c3338;
+			font-size: 14px;
+			padding: 0 24px 0 8px;
 		}
 	}
 


### PR DESCRIPTION
How it looks in the Block Editor prior to this PR.
![Screenshot_2021-03-24 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/112172989-e99b5980-8c40-11eb-8929-120814ab50c5.png)


How it normally looks in Classic Editor:
![Screenshot_2021-03-24 Edit Page ‹ SiteOrigin — WordPress(1)](https://user-images.githubusercontent.com/17275120/112172956-e0aa8800-8c40-11eb-9280-79a8a78b5af4.png)


This CSS is from wp-admin/css/forms.min.css.