### PR TITLE
Block Editor: Correct input line-height and padding

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -761,8 +761,8 @@
 			text-align: left;
 
 			input {
-				line-height: 1;
-				padding: 8px 5px;
+				padding: 0 8px;
+				line-height: 2;
 
 				&[type=checkbox] {
 					background-color: #ffffff;

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -761,7 +761,8 @@
 			text-align: left;
 
 			input {
-				padding: 3px 5px;
+				line-height: 1;
+				padding: 5px;
 
 				&[type=checkbox] {
 					background-color: #ffffff;

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -762,7 +762,7 @@
 
 			input {
 				line-height: 1;
-				padding: 5px;
+				padding: 8px 5px;
 
 				&[type=checkbox] {
 					background-color: #ffffff;


### PR DESCRIPTION
This PR corrects the line-height and spacing of inputs. This corrects the alignment of the `link` and `measurement` field. It also makes inputs more consistent with the Classic Editor look.

![Screenshot_2021-03-24 Edit Page ‹ SiteOrigin — WordPress(4)](https://user-images.githubusercontent.com/17275120/112174586-421f2680-8c42-11eb-8555-ec42d66c639c.png)
![Screenshot_2021-03-24 Edit Page ‹ SiteOrigin — WordPress(3)](https://user-images.githubusercontent.com/17275120/112174593-43505380-8c42-11eb-9f64-d9121c3e3309.png)
