### PR TITLE
Image Grid: Display Using Flexbox to Prevent Unintended Spacing

### DIFF
--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -1,6 +1,9 @@
 @spacing: default;
 
 .sow-image-grid-wrapper {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
 	padding-top: @spacing;
 	line-height: 0;
 	text-align:center;
@@ -8,10 +11,6 @@
 	.sow-image-grid-image {
 		padding: 0 @spacing @spacing @spacing;
 		display: inline-block;
-
-		> a {
-			display: inline-block;
-		}
 
 		img {
 			opacity: 0;


### PR DESCRIPTION
This PR prevents undesired output due to whitespace being rendered by browsers. This happens due to how browsers output `display: inline-block;` and that doesn't happen when using flexbox. This unintended spacing can make it trickier to get the desired amount of spacing because the horizontal spacing will always be more than the vertical spacing.

To test:
- Add a series of images that you can easily tell the sides from (I used [this image](https://i.imgur.com/rdUR6n7.png))
- Set the Spacing to 0 
- Inspect resulting output
- Clear wp-content/uploads/siteorigin-widgets or make a design change to the Image Grid widget (this is required to regenerate the generated CSS stylesheet).
- Inspect resulting output

Before:
![Screenshot_2021-03-29 SiteOrigin](https://user-images.githubusercontent.com/17275120/112759946-9c502b00-9038-11eb-8383-c81edab6c168.png)

After:
![Screenshot_2021-03-29 SiteOrigin(1)](https://user-images.githubusercontent.com/17275120/112759953-a2dea280-9038-11eb-9409-1eb7f972c494.png)