### PR TITLE
Improve Measurement field spacing for more consistent field sizing/padding

### DIFF
--- a/base/inc/fields/css/measurement-field.less
+++ b/base/inc/fields/css/measurement-field.less
@@ -10,12 +10,12 @@
 
 	select.sow-measurement-select-unit {
 		min-width: inherit;
-		padding: 5px 24px 0;
+		padding: 0 24px 0;
 	}
 
 	input[type="text"].siteorigin-widget-input-measurement,
 	select.sow-measurement-select-unit {
-		line-height: 1.25em;
+		line-height: 2em;
 	}
 
 	@media (max-width: 680px) {

--- a/base/inc/fields/css/measurement-field.less
+++ b/base/inc/fields/css/measurement-field.less
@@ -3,12 +3,19 @@
 		float: left;
 		max-width: 58px;
 		margin-right: 1px;
-		min-height: 28px;
+		min-height: 30px;
 		vertical-align: middle;
+		padding: 0 8px;
 	}
 
 	select.sow-measurement-select-unit {
 		min-width: inherit;
+		padding: 5px 24px 0;
+	}
+
+	input[type="text"].siteorigin-widget-input-measurement,
+	select.sow-measurement-select-unit {
+		line-height: 1.25em;
 	}
 
 	@media (max-width: 680px) {


### PR DESCRIPTION
Related https://github.com/siteorigin/so-widgets-bundle/pull/1261#issuecomment-805142949

This PR ensures the measurement field is more consistently sized. It also prevents the unit from being clipped due to a smaller than intended line-height (this is visible in the linked comment).

This affects both the Block Editor and Classic Editor.
This PR is compatible with #1261.