### PR TITLE
Editor: Prevent notice when checking if preview

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -113,7 +113,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 				! $this->is_preview() &&
 				empty( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] ) &&
 				(
-					empty( $_POST['action'] ) &&
+					isset( $_POST['action'] ) &&
 					$_POST['action'] != 'so_widgets_preview'
 				)
 			) {


### PR DESCRIPTION
This PR prevents the following notice:

`Notice: Undefined index: action in wp-content/plugins/so-widgets-bundle/widgets/editor/editor.php on line 117`