### PR TITLE
Icon: Ensure Filter options are the same height

### DIFF
--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -81,10 +81,11 @@
 		.box-shadow(~"0 1px 2px rgba(0,0,0,0.0275)");
 		margin-top: 10px;
 
-		select.select.siteorigin-widget-icon-family,
+		select.siteorigin-widget-icon-family,
 		select.siteorigin-widget-icon-family-styles,
 		.siteorigin-widget-icon-search {
 			height: 30px;
+			line-height: 30px;
 			vertical-align: top;
 		}
 

--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -81,6 +81,13 @@
 		.box-shadow(~"0 1px 2px rgba(0,0,0,0.0275)");
 		margin-top: 10px;
 
+		select.select.siteorigin-widget-icon-family,
+		select.siteorigin-widget-icon-family-styles,
+		.siteorigin-widget-icon-search {
+			height: 30px;
+			vertical-align: top;
+		}
+
 		select.siteorigin-widget-icon-family {
 			font-size: 11px;
 			display: inline-block;

--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -89,15 +89,14 @@
 		}
 
 		select.siteorigin-widget-icon-family {
-			font-size: 11px;
 			display: inline-block;
 		}
 
 		.siteorigin-widget-icon-search {
-			font-size: 11px;
 			display: inline-block;
-			width: 260px;
+			font-size: 14px;
 			padding: 6px 8px;
+			width: 260px;
 		}
 
 		.siteorigin-widget-icon-icons {

--- a/base/inc/fields/css/icon-field.less
+++ b/base/inc/fields/css/icon-field.less
@@ -85,7 +85,6 @@
 		select.siteorigin-widget-icon-family-styles,
 		.siteorigin-widget-icon-search {
 			height: 30px;
-			line-height: 30px;
 			vertical-align: top;
 		}
 
@@ -96,6 +95,7 @@
 		.siteorigin-widget-icon-search {
 			display: inline-block;
 			font-size: 14px;
+			line-height: 30px;
 			padding: 6px 8px;
 			width: 260px;
 		}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1268

Vertical Align adjustment is to prevent a slight offset of the selectors. A build is required for this PR to be tested.