### PR TITLE
Button: Mobile Align Setting

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -26,6 +26,17 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 
 	}
 
+	function get_settings_form() {
+		return array(
+			'responsive_breakpoint' => array(
+				'type'        => 'measurement',
+				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
+				'default'     => '780px',
+				'description' => __( 'This setting controls when the Mobile Align setting will be used. The default value is 780px.', 'so-widgets-bundle' ),
+			)
+		);
+	}
+
 	function initialize() {
 		$this->register_frontend_styles(
 			array(
@@ -121,7 +132,17 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 							'justify' => __('Justify', 'so-widgets-bundle'),
 						),
 					),
-
+					'mobile_align' => array(
+						'type' => 'select',
+						'label' => __( 'Mobile Align', 'so-widgets-bundle' ),
+						'default' => 'center',
+						'options' => array(
+							'left' => __( 'Left', 'so-widgets-bundle' ),
+							'right' => __( 'Right', 'so-widgets-bundle' ),
+							'center' => __( 'Center', 'so-widgets-bundle' ),
+							'justify' => __( 'Justify', 'so-widgets-bundle' ),
+						),
+					),
 					'theme' => array(
 						'type' => 'select',
 						'label' => __('Button theme', 'so-widgets-bundle'),
@@ -359,6 +380,8 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'rounding' => isset($instance['design']['rounding']) ? $instance['design']['rounding'] . 'em' : '',
 			'padding' => isset($instance['design']['padding']) ? $instance['design']['padding'] . 'em' : '',
 			'has_text' => empty( $instance['text'] ) ? 'false' : 'true',
+			'responsive_breakpoint' => $this->get_global_settings( 'responsive_breakpoint' ),
+			'mobile_align' => $instance['design']['mobile_align'],
 		);
 
 		if ( ! empty( $instance['design']['font'] ) ) {
@@ -412,6 +435,15 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 					}
 				}
 			}
+		}
+
+		// If the mobile_align setting isn't set, set it to the same value as the align value.
+		if (
+			! empty( $instance['design'] ) &&
+			! empty( $instance['design']['align'] ) &&
+			empty( $instance['design']['mobile_align'] )
+		) {
+			$instance['design']['mobile_align'] = $instance['design']['align'];
 		}
 
 		return $instance;

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -32,7 +32,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 				'type'        => 'measurement',
 				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
 				'default'     => '780px',
-				'description' => __( 'This setting controls when the Mobile Align setting will be used. The default value is 780px.', 'so-widgets-bundle' ),
+				'description' => __( 'This setting controls when the Mobile align setting will be used. The default value is 780px.', 'so-widgets-bundle' ),
 			)
 		);
 	}
@@ -134,7 +134,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 					),
 					'mobile_align' => array(
 						'type' => 'select',
-						'label' => __( 'Mobile Align', 'so-widgets-bundle' ),
+						'label' => __( 'Mobile align', 'so-widgets-bundle' ),
 						'default' => 'center',
 						'options' => array(
 							'left' => __( 'Left', 'so-widgets-bundle' ),

--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -381,6 +381,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'padding' => isset($instance['design']['padding']) ? $instance['design']['padding'] . 'em' : '',
 			'has_text' => empty( $instance['text'] ) ? 'false' : 'true',
 			'responsive_breakpoint' => $this->get_global_settings( 'responsive_breakpoint' ),
+			'align' => $instance['design']['align'],
 			'mobile_align' => $instance['design']['mobile_align'],
 		);
 

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -1,5 +1,8 @@
 @import "../../../base/less/mixins";
 
+@responsive_breakpoint: 780px;
+@mobile_align: center;
+
 @button_width: '';
 @button_color: #41a9d5;
 @border_color: darken(@button_color, 15%);
@@ -17,6 +20,23 @@
 @has_text: true;
 
 .ow-button-base {
+
+	@media (max-width: @responsive_breakpoint) {
+		text-align: @mobile_align;
+
+		& when not ( @mobile_align = justify ) {
+			&.ow-button-align-justify a {
+				display: inline-block;
+			}
+		}
+
+		& when ( @mobile_align = justify ) {
+			a {
+				dispaly: block;
+			}
+
+		}
+	}
 
 	a {
 		.box-sizing(border-box);

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -1,6 +1,7 @@
 @import "../../../base/less/mixins";
 
 @responsive_breakpoint: 780px;
+@align: center;
 @mobile_align: center;
 
 @button_width: '';
@@ -22,19 +23,20 @@
 .ow-button-base {
 
 	@media (max-width: @responsive_breakpoint) {
-		text-align: @mobile_align;
+		&.ow-button-align-@{align} {
+			text-align: @mobile_align;
 
-		& when not ( @mobile_align = justify ) {
-			&.ow-button-align-justify a {
-				display: inline-block;
-			}
-		}
-
-		& when ( @mobile_align = justify ) {
-			a {
-				display: block;
+			& when not ( @mobile_align = justify ) {
+				&.ow-button-align-justify a {
+					display: inline-block;
+				}
 			}
 
+			& when ( @mobile_align = justify ) {
+				a {
+					display: block;
+				}
+			}
 		}
 	}
 

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -32,7 +32,7 @@
 
 		& when ( @mobile_align = justify ) {
 			a {
-				dispaly: block;
+				display: block;
 			}
 
 		}

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -1,6 +1,7 @@
 @import "../../../base/less/mixins";
 
 @responsive_breakpoint: 780px;
+@align: center;
 @mobile_align: center;
 
 @button_width: '';
@@ -23,19 +24,20 @@
 	.clearfix();
 
 	@media (max-width: @responsive_breakpoint) {
-		text-align: @mobile_align;
+		&.ow-button-align-@{align} {
+			text-align: @mobile_align;
 
-		& when not ( @mobile_align = justify ) {
-			&.ow-button-align-justify a {
-				display: inline-block;
-			}
-		}
-
-		& when ( @mobile_align = justify ) {
-			a {
-				display: block;
+			& when not ( @mobile_align = justify ) {
+				&.ow-button-align-justify a {
+					display: inline-block;
+				}
 			}
 
+			& when ( @mobile_align = justify ) {
+				a {
+					display: block;
+				}
+			}
 		}
 	}
 

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -1,5 +1,8 @@
 @import "../../../base/less/mixins";
 
+@responsive_breakpoint: 780px;
+@mobile_align: center;
+
 @button_width: '';
 @button_color: #41a9d5;
 @border_color: darken(@button_color, 5%);
@@ -18,6 +21,23 @@
 
 .ow-button-base {
 	.clearfix();
+
+	@media (max-width: @responsive_breakpoint) {
+		text-align: @mobile_align;
+
+		& when not ( @mobile_align = justify ) {
+			&.ow-button-align-justify a {
+				display: inline-block;
+			}
+		}
+
+		& when ( @mobile_align = justify ) {
+			a {
+				dispaly: block;
+			}
+
+		}
+	}
 
 	a {
 		.box-sizing(border-box);

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -33,7 +33,7 @@
 
 		& when ( @mobile_align = justify ) {
 			a {
-				dispaly: block;
+				display: block;
 			}
 
 		}

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -1,5 +1,8 @@
 @import "../../../base/less/mixins";
 
+@responsive_breakpoint: 780px;
+@mobile_align: center;
+
 @button_width: '';
 @button_color: #41a9d5;
 @text_color: #FFFFFF;
@@ -17,6 +20,23 @@
 
 .ow-button-base {
 	.clearfix();
+
+	@media (max-width: @responsive_breakpoint) {
+		text-align: @mobile_align;
+
+		& when not ( @mobile_align = justify ) {
+			&.ow-button-align-justify a {
+				display: inline-block;
+			}
+		}
+
+		& when ( @mobile_align = justify ) {
+			a {
+				dispaly: block;
+			}
+
+		}
+	}
 
 	a {
 		.box-sizing(border-box);

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -1,6 +1,7 @@
 @import "../../../base/less/mixins";
 
 @responsive_breakpoint: 780px;
+@align: center;
 @mobile_align: center;
 
 @button_width: '';
@@ -22,19 +23,20 @@
 	.clearfix();
 
 	@media (max-width: @responsive_breakpoint) {
-		text-align: @mobile_align;
+		&.ow-button-align-@{align} {
+			text-align: @mobile_align;
 
-		& when not ( @mobile_align = justify ) {
-			&.ow-button-align-justify a {
-				display: inline-block;
-			}
-		}
-
-		& when ( @mobile_align = justify ) {
-			a {
-				display: block;
+			& when not ( @mobile_align = justify ) {
+				&.ow-button-align-justify a {
+					display: inline-block;
+				}
 			}
 
+			& when ( @mobile_align = justify ) {
+				a {
+					display: block;
+				}
+			}
 		}
 	}
 

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -32,7 +32,7 @@
 
 		& when ( @mobile_align = justify ) {
 			a {
-				dispaly: block;
+				display: block;
 			}
 
 		}


### PR DESCRIPTION
This PR adds a Mobile Align setting to the SO Button Widget. This allows users to change the alignment of the button on mobile to better suit their design. This PR also includes a Responsive Global Addon setting to allow the user to control when the mobile align setting kicks in.