### PR TITLE
Video Player: Add FitVids Support

### DIFF
--- a/js/lib/jquery.fitvids.js
+++ b/js/lib/jquery.fitvids.js
@@ -1,0 +1,87 @@
+/*jshint browser:true */
+/*!
+* FitVids 1.1
+*
+* Copyright 2013, Chris Coyier - http://css-tricks.com + Dave Rupert - http://daverupert.com
+* Credit to Thierry Koblentz - http://www.alistapart.com/articles/creating-intrinsic-ratios-for-video/
+* Released under the WTFPL license - http://sam.zoy.org/wtfpl/
+*
+*/
+
+;(function( $ ){
+
+  'use strict';
+
+  $.fn.fitVids = function( options ) {
+    var settings = {
+      customSelector: null,
+      ignore: null
+    };
+
+    if(!document.getElementById('fit-vids-style')) {
+      // appendStyles: https://github.com/toddmotto/fluidvids/blob/master/dist/fluidvids.js
+      var head = document.head || document.getElementsByTagName('head')[0];
+      var css = '.fluid-width-video-wrapper{width:100%;position:relative;padding:0;}.fluid-width-video-wrapper iframe,.fluid-width-video-wrapper object,.fluid-width-video-wrapper embed {position:absolute;top:0;left:0;width:100%;height:100%;}';
+      var div = document.createElement("div");
+      div.innerHTML = '<p>x</p><style id="fit-vids-style">' + css + '</style>';
+      head.appendChild(div.childNodes[1]);
+    }
+
+    if ( options ) {
+      $.extend( settings, options );
+    }
+
+    return this.each(function(){
+      var selectors = [
+        'iframe[src*="player.vimeo.com"]',
+        'iframe[src*="youtube.com"]',
+        'iframe[src*="youtube-nocookie.com"]',
+        'iframe[src*="kickstarter.com"][src*="video.html"]',
+        'object',
+        'embed'
+      ];
+
+      if (settings.customSelector) {
+        selectors.push(settings.customSelector);
+      }
+
+      var ignoreList = '.fitvidsignore';
+
+      if(settings.ignore) {
+        ignoreList = ignoreList + ', ' + settings.ignore;
+      }
+
+      var $allVideos = $(this).find(selectors.join(','));
+      $allVideos = $allVideos.not('object object'); // SwfObj conflict patch
+      $allVideos = $allVideos.not(ignoreList); // Disable FitVids on this video.
+
+      $allVideos.each(function(){
+        var $this = $(this);
+        if($this.parents(ignoreList).length > 0) {
+          return; // Disable FitVids on this video.
+        }
+        if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
+        if ((!$this.css('height') && !$this.css('width')) && (isNaN($this.attr('height')) || isNaN($this.attr('width'))))
+        {
+          $this.attr('height', 9);
+          $this.attr('width', 16);
+        }
+        var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
+            width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
+            aspectRatio = height / width;
+        if(!$this.attr('name')){
+          var videoName = 'fitvid' + $.fn.fitVids._count;
+          $this.attr('name', videoName);
+          $.fn.fitVids._count++;
+        }
+        $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+'%');
+        $this.removeAttr('height').removeAttr('width');
+      });
+    });
+  };
+  
+  // Internal counter for unique video names.
+  $.fn.fitVids._count = 0;
+  
+// Works with either jQuery or Zepto
+})( window.jQuery || window.Zepto );

--- a/widgets/video/js/so-video-widget.js
+++ b/widgets/video/js/so-video-widget.js
@@ -14,7 +14,7 @@ jQuery( function ( $ ) {
 		$video.mediaelementplayer();
 
 		if ( typeof $.fn.fitVids == 'function' ) {
-			$( '.sow-video-wrapper.use-fitvid' ).fitVids();
+			$( '.sow-video-wrapper.use-fitvids' ).fitVids();
 		}
 		
 		$video.data( 'initialized', true );

--- a/widgets/video/js/so-video-widget.js
+++ b/widgets/video/js/so-video-widget.js
@@ -12,6 +12,10 @@ jQuery( function ( $ ) {
 		}
 		
 		$video.mediaelementplayer();
+
+		if ( typeof $.fn.fitVids == 'function' ) {
+			$( '.sow-video-wrapper.use-fitvid' ).fitVids();
+		}
 		
 		$video.data( 'initialized', true );
 	};

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -10,6 +10,7 @@
  * @var $sources
  * @var $src
  * @var $video_type
+ * @var $fitvids
  */
 
 if ( ! empty( $instance['title'] ) ) {
@@ -45,7 +46,7 @@ $so_video = new SiteOrigin_Video();
 do_action( 'siteorigin_widgets_sow-video_before_video', $instance );
 ?>
 
-<div class="sow-video-wrapper">
+<div class="sow-video-wrapper<?php if ( $fitvids ) echo ' use-fitvid'; ?>">
 	<?php if ( $is_skinnable_video_host ) : ?>
 	<video
 		<?php foreach ( $video_args as $k => $v ) : ?>

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -46,7 +46,7 @@ $so_video = new SiteOrigin_Video();
 do_action( 'siteorigin_widgets_sow-video_before_video', $instance );
 ?>
 
-<div class="sow-video-wrapper<?php if ( $fitvids ) echo ' use-fitvid'; ?>">
+<div class="sow-video-wrapper<?php if ( $fitvids ) echo ' use-fitvids'; ?>">
 	<?php if ( $is_skinnable_video_host ) : ?>
 	<video
 		<?php foreach ( $video_args as $k => $v ) : ?>

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -109,6 +109,12 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 							'video_type[external]' => array( 'hide' ),
 						)
 					),
+					'fitvids' => array(
+						'type'    => 'checkbox',
+						'default' => true,
+						'label'   => __( 'Use FitVids', 'so-widgets-bundle' ),
+						'description'   => __( 'FitVids will scale the video to fill the width of the widget area while maintaining aspect ratio.', 'so-widgets-bundle' ),
+					),
 					'oembed'   => array(
 						'type'          => 'checkbox',
 						'default'       => true,
@@ -160,6 +166,15 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 					plugin_dir_url( __FILE__ ) . 'js/so-video-widget' . SOW_BUNDLE_JS_SUFFIX . '.js',
 					array( 'jquery', 'mediaelement' ),
 					SOW_BUNDLE_VERSION
+				);
+			}
+
+			if ( ! empty( $instance['playback']['fitvids'] ) && ! wp_script_is( 'fitvids' ) ) {
+				wp_enqueue_script(
+					'fitvids',
+					plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/lib/jquery.fitvids' . SOW_BUNDLE_JS_SUFFIX . '.js',
+					array( 'jquery' ),
+					1.1
 				);
 			}
 		}
@@ -217,7 +232,8 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'autoplay'                => ! empty( $instance['playback']['autoplay'] ),
 			'loop'                    => $video_host == 'self' && ! empty( $instance['playback']['loop'] ),
 			'related_videos'          => ! empty( $instance['playback']['related_videos'] ),
-			'skin_class'              => 'default'
+			'skin_class'              => 'default',
+			'fitvids'                 => ! empty( $instance['playback']['fitvids'] ),
 		);
 
 		// Force oEmbed for this video

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -169,9 +169,9 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 				);
 			}
 
-			if ( ! empty( $instance['playback']['fitvids'] ) && ! wp_script_is( 'fitvids' ) ) {
+			if ( ! empty( $instance['playback']['fitvids'] ) && ! wp_script_is( 'jquery-fitvids' ) ) {
 				wp_enqueue_script(
-					'fitvids',
+					'jquery-fitvids',
 					plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/lib/jquery.fitvids' . SOW_BUNDLE_JS_SUFFIX . '.js',
 					array( 'jquery' ),
 					1.1


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/426

This PR adds a setting to the Video Playback that allows users to enable FitVids for the current video player widget. This is handled on a widget by widget basis so if FitVids is disabled for a specific widget, it won't be affected by FitVids (in other words, it's not a global "all or nothing" setting).

Please note that to test this you'll need to use a theme that doesn't load FitVids.js and disable any plugins that enable it. I recommend testing using a Default WordPress theme.