### PR TITLE
Image Size: Don't bold custom size input

### DIFF
--- a/base/inc/fields/css/image-size-field.less
+++ b/base/inc/fields/css/image-size-field.less
@@ -10,6 +10,7 @@
 		}
 
 		.siteorigin-widget-input {
+			font-weight: 400;
 			width: 80px;
 		}
 	}


### PR DESCRIPTION
This PR unbolds the custom image size inputs.

Before:
![Screenshot_2021-04-16 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/115032555-c8125280-9f0c-11eb-85ff-98dbb6e0c7a9.png)

After:
![Screenshot_2021-04-16 Edit Page ‹ SiteOrigin — WordPress(1)](https://user-images.githubusercontent.com/17275120/115032527-c183db00-9f0c-11eb-844f-2a890a873e00.png)
