### PR TITLE
Headline: Prevent invalid font property

### DIFF
--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -287,6 +287,10 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			$font = siteorigin_widget_get_font( $instance['headline']['font'] );
 			$less_vars['headline_font'] = $font['family'];
 			if ( ! empty( $font['weight'] ) ) {
+				if ( ! is_numeric( $font['weight'] ) || $font['weight'] == 'italic' ) {
+					$font['weight'] = filter_var( $font['weight'], FILTER_SANITIZE_NUMBER_INT );
+					$less_vars['headline_font_style'] = 'italic';
+				}
 				$less_vars['headline_font_weight'] = $font['weight'];
 			}
 		}
@@ -305,6 +309,10 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			$font = siteorigin_widget_get_font( $instance['sub_headline']['font'] );
 			$less_vars['sub_headline_font'] = $font['family'];
 			if ( ! empty( $font['weight'] ) ) {
+				if ( ! is_numeric( $font['weight'] ) || $font['weight'] == 'italic' ) {
+					$font['weight'] = filter_var( $font['weight'], FILTER_SANITIZE_NUMBER_INT );
+					$less_vars['sub_headline_font_style'] = 'italic';
+				}
 				$less_vars['sub_headline_font_weight'] = $font['weight'];
 			}
 		}

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -287,11 +287,8 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			$font = siteorigin_widget_get_font( $instance['headline']['font'] );
 			$less_vars['headline_font'] = $font['family'];
 			if ( ! empty( $font['weight'] ) ) {
-				if ( ! is_numeric( $font['weight'] ) || $font['weight'] == 'italic' ) {
-					$font['weight'] = filter_var( $font['weight'], FILTER_SANITIZE_NUMBER_INT );
-					$less_vars['headline_font_style'] = 'italic';
-				}
-				$less_vars['headline_font_weight'] = $font['weight'];
+				$less_vars['headline_font_style'] = $font['style'];
+				$less_vars['headline_font_weight'] = $font['weight_raw'];
 			}
 		}
 
@@ -309,11 +306,8 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 			$font = siteorigin_widget_get_font( $instance['sub_headline']['font'] );
 			$less_vars['sub_headline_font'] = $font['family'];
 			if ( ! empty( $font['weight'] ) ) {
-				if ( ! is_numeric( $font['weight'] ) || $font['weight'] == 'italic' ) {
-					$font['weight'] = filter_var( $font['weight'], FILTER_SANITIZE_NUMBER_INT );
-					$less_vars['sub_headline_font_style'] = 'italic';
-				}
-				$less_vars['sub_headline_font_weight'] = $font['weight'];
+				$less_vars['sub_headline_font_style'] = $font['style'];
+				$less_vars['sub_headline_font_weight'] = $font['weight_raw'];
 			}
 		}
 

--- a/widgets/headline/styles/default.less
+++ b/widgets/headline/styles/default.less
@@ -4,6 +4,7 @@
 @headline_font: default;
 @headline_font_weight: 400;
 @headline_font_size: default;
+@headline_font_style: default;
 @headline_line_height: 1.4em;
 @headline_margin: default;
 @headline_align: center;
@@ -14,6 +15,7 @@
 @sub_headline_font: default;
 @sub_headline_font_weight: 400;
 @sub_headline_font_size: default;
+@sub_headline_font_style: default;
 @sub_headline_line_height: 1.4em;
 @sub_headline_margin: default;
 @sub_headline_align: center;
@@ -31,6 +33,7 @@
 
     @{headline_tag}.sow-headline {
         .font(@headline_font, @headline_font_weight);
+        font-style: @headline_font_style;
         text-align: @headline_align;
         color: @headline_color;
         line-height: @headline_line_height;
@@ -49,6 +52,7 @@
 
     @{sub_headline_tag}.sow-sub-headline {
         .font(@sub_headline_font, @sub_headline_font_weight);
+        font-style: @sub_headline_font_style;
         text-align: @sub_headline_align;
         color: @sub_headline_color;
         line-height: @sub_headline_line_height;


### PR DESCRIPTION
This PR prevents an invalid font-weight from being set. It'll ensure `font-style: italic;` is set when an italic font is selected and it'll correctly set a number `font-weight`. Both of these are important if the user is using multiple different variants of the same font because if they're not set in a valid way the wrong variant could show.

![](https://i.imgur.com/PqSDDjh.png)