### PR TITLE
Font: Allow italic variant with no font weight

### DIFF
--- a/base/inc/fields/font.class.php
+++ b/base/inc/fields/font.class.php
@@ -26,8 +26,8 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 	protected function sanitize_field_input( $value, $instance ) {
 		$sanitized_value = trim( $value );
 		// Any alphanumeric character followed by alphanumeric or whitespace characters (except newline),
-		// with optional colon followed by numeric and then further optional word.
-		if ( preg_match( '/[\w\d]+[\w\d\t\r ]*(:\d\w+)?/', $sanitized_value, $sanitized_matches ) ) {
+		// with optional colon followed by optional variant.
+		if ( preg_match( '/[\w\d]+[\w\d\t\r ]*(:\w+)?/', $sanitized_value, $sanitized_matches ) ) {
 			$sanitized_value = $sanitized_matches[0];
 		}
 		else {


### PR DESCRIPTION
This is a follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1237. That PR relied on a number always being present before italic, but that doesn't always happen. This PR will allow for all possible variant formats. For example:

Alegreya:italic
Alegreya:500
Alegreya:500italic