### PR TITLE
Post Carousel: Prevent loading more items if complete

### DIFF
--- a/widgets/post-carousel/js/carousel.js
+++ b/widgets/post-carousel/js/carousel.js
@@ -63,7 +63,7 @@ jQuery( function ( $ ) {
 				e.preventDefault();
 				var $items = $$.find( '.sow-carousel-items' ),
 					numItems = $items.find( '.sow-carousel-item' ).length,
-					complete = numItems === $$.data( 'post-count' ),
+					complete = numItems >= $$.data( 'post-count' ),
 					numVisibleItems = Math.ceil( $items.outerWidth() / $items.find( '.sow-carousel-item' ).outerWidth( true ) ),
 					lastPosition = numItems - numVisibleItems + 1,
 					slidesToScroll = $items.slick( 'slickGetOption', 'slidesToScroll' );


### PR DESCRIPTION
Due to https://github.com/siteorigin/so-widgets-bundle/pull/1220, there's a situation where the number of items may be higher after initial load (this is corrected after loading more posts). This PR accounts for this and will prevent more posts from being loaded if the number of items exceeds the total number of posts.