### PR TITLE
Get Font Helper: Extract Weight and Style

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -142,6 +142,8 @@ function siteorigin_widget_get_font($font_value) {
 		if ( count( $font_parts ) > 1 ) {
 			$font['weight'] = $font_parts[1];
 			$font_url_param .= ':' . $font_parts[1];
+			$font['weight_raw'] = filter_var( $font['weight'], FILTER_SANITIZE_NUMBER_INT );
+			$font['style'] = ! is_numeric( $font['weight'] ) || $font['weight'] == 'italic' ? 'italic' : '';
 		}
 		$font['url'] = 'https://fonts.googleapis.com/css?family=' . $font_url_param;
 		$style_name = 'sow-google-font-' . strtolower( $font['family'] );


### PR DESCRIPTION
This will make it easier for developers to set a valid font weight and font style without having to extract the information manually. Please test this PR using #1275. If that PR works as expected while PR is active, this PR is working as expected.

`weights_raw` is used instead of just `weight` for backwards compatibility. We can't be sure another developer isn't relying on that field to do something similar already so to prevent stepping on toes, we're storing the values separately. 

Here's an example of an array returned by `siteorigin_widget_get_font` can now look like:

```
array(
	'family' => 'Alegreya',
	'weight' => '600italic',
	'weight_raw' => '600',
	'style' => 'italic',
)
```