### PR TITLE
Widgets Block: Ensure Icons are enqueued

### DIFF
--- a/base/inc/routes/siteorigin-widgets-resource.class.php
+++ b/base/inc/routes/siteorigin-widgets-resource.class.php
@@ -157,7 +157,19 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 			/* @var $widget SiteOrigin_Widget */
 			$instance = $widget->update( $widget_data, $widget_data );
 			$widget->widget( array(), $instance );
-			$rendered_widget = ob_get_clean();
+			$rendered_widget = array();
+			$rendered_widget['html'] = ob_get_clean();
+
+			// Check if this widget loaded any icons, and if it has, store them.
+			$styles = wp_styles();
+			if ( ! empty( $styles->queue ) ) {
+				$rendered_widget['icons'] = array();
+				foreach ( $styles->queue as $style ) {
+					if ( strpos( $style, 'siteorigin-widget-icon-font' ) !== false ) {
+						$rendered_widget['icons'][] = $style;
+					}
+				}
+			}
 		} else {
 			if ( empty( $valid_widget_class ) ) {
 				$rendered_widget = new WP_Error(

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -48,6 +48,9 @@
 			widgetHtml: {
 				type: 'string',
 			},
+			widgetIcons: {
+				type: 'array',
+			},
 		},
 
 		edit: withState( {
@@ -222,7 +225,10 @@
 					props.attributes.widgetClass &&
 					props.attributes.widgetData;
 				if ( loadWidgetPreview ) {
-					props.setAttributes( { widgetHtml: null } );
+					props.setAttributes( {
+						widgetHtml: null,
+						widgetIcons: null
+					} );
 					jQuery.post( {
 						url: sowbBlockEditorAdmin.restUrl + 'sowb/v1/widgets/previews',
 						beforeSend: function ( xhr ) {
@@ -235,11 +241,14 @@
 					} )
 					.done( function( widgetPreview ) {
 						props.setState( {
-							widgetPreviewHtml: widgetPreview,
+							widgetPreviewHtml: widgetPreview.html,
 							previewInitialized: false,
 						} );
 
-						props.setAttributes( { widgetHtml: widgetPreview } );
+						props.setAttributes( {
+							widgetHtml: widgetPreview.html,
+							widgetIcons: widgetPreview.icons
+						} );
 					} )
 					.fail( function ( response ) {
 

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -155,6 +155,17 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			} else {
 				$widget->generate_and_enqueue_instance_styles( $instance );
 				$widget->enqueue_frontend_scripts( $instance );
+
+				// Check if this widget uses any icons that need to be enqueued.
+				if ( ! empty( $attributes['widgetIcons'] ) ) {
+					$widget_icon_families = apply_filters('siteorigin_widgets_icon_families', array() );
+					foreach ( $attributes['widgetIcons'] as $icon_font ) {
+						if ( ! wp_style_is( $icon_font ) ) {
+							$font_family = explode( 'siteorigin-widget-icon-font-', $icon_font )[1];
+							wp_enqueue_style( $icon_font, $widget_icon_families[ $font_family ]['style_uri'] );
+						}
+					}
+				}
 				echo $attributes['widgetHtml'];
 			}
 

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -158,7 +158,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 				// Check if this widget uses any icons that need to be enqueued.
 				if ( ! empty( $attributes['widgetIcons'] ) ) {
-					$widget_icon_families = apply_filters('siteorigin_widgets_icon_families', array() );
+					$widget_icon_families = apply_filters( 'siteorigin_widgets_icon_families', array() );
 					foreach ( $attributes['widgetIcons'] as $icon_font ) {
 						if ( ! wp_style_is( $icon_font ) ) {
 							$font_family = explode( 'siteorigin-widget-icon-font-', $icon_font )[1];

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -33,7 +33,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		wp_enqueue_style(
 			'sowb-widget-block',
-			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.css', __FILE__ ),
+			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.css', __FILE__ )
 		);
 
 		$widgets_metadata_list = SiteOrigin_Widgets_Bundle::single()->get_widgets_list();


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/symbol-on-buttons-not-visible/)

This PR resolves an issue where users who use the Widgets Block not displaying icons correctly.

This issue was caused by https://github.com/siteorigin/so-widgets-bundle/pull/1234. Unlike fonts, icons are loaded in the template itself so they won't be enqueued by [the standard widget style enqueue](https://github.com/siteorigin/so-widgets-bundle/blob/1.18.1/compat/block-editor/widget-block.php#L133). That's not something we can change at this point as it's very likely other developers are doing it in the same manner as us, so instead this PR ensures icons are enqueued by storing the icons in an attribute and outputting them when rendering.

Only those who made a change to the SiteOrigin Widgets Block on 1.18.x, and used a widget that added an icon are impacted. Those users will need to resave the layout after updating for the newer data to be saved and rendered. Those who haven't made any changes since 1.18.x will be using the old PHP render so will be unaffected by this issue. 

To test this PR please add a SiteOrigin Widgets Block and select a widget that uses icons (eg. Button, Icons, Accordion, etc). Save and view the widget on the front end. The icons won't be present. Switch to this branch and then reload the editor (to allow for the updated JS). Save, and then view the page again.

