### PR TITLE
Remove redundant Block Saving code.

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -303,12 +303,7 @@
 		} ),
 
 		save: function ( context ) {
-			if ( context.attributes == 'object' && context.attributes.hasOwnProperty( 'widgetHtml' ) ) {
-   				return React.createElement( wp.element.RawHTML, null, attributes.widgetHtml );
-			} else {
-				// Fallback to PHP Render.
-				return null;
-			}
+			return null;
 		}
 	} );
 } )( window.wp.editor, window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.compose, window.wp.blockEditor );


### PR DESCRIPTION
This doesn't work as expected and isn't required. To test it, save the SiteOrgin Widgets block. If it saves as expected, the change works.