### PR TITLE
Image Grid: Align items using baseline

### DIFF
--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -4,6 +4,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
+	align-items: baseline;
 	padding-top: @spacing;
 	line-height: 0;
 	text-align:center;


### PR DESCRIPTION
This will prevent any potential alignment differences after updating to 1.18.x.

Before PR:
![Screenshot_2021-04-28 SiteOrigin](https://user-images.githubusercontent.com/17275120/116267985-39c98680-a7c0-11eb-86f7-5139b9897b94.png)

After PR (and how it previously looked):

![Screenshot_2021-04-28 Mono – Page Builder Layouts](https://user-images.githubusercontent.com/17275120/116267895-25858980-a7c0-11eb-8a1f-4ce5e213c326.png)
(from https://layouts.siteorigin.com/layout/mono/)

To test this PR:
- Import the Mono prebuilt layout, save, and then view the page.
- Switch to PR and make any change to the page (this won't be required for those updating the plugin as the widget CSS will automaetically be cleared). View the page and you'll see the expected alignment. Save, and view the page.