### PR TITLE
Slider: Remove invalid default

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -127,13 +127,11 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 					'height' => array(
 						'type' => 'measurement',
 						'label' => __( 'Height', 'so-widgets-bundle' ),
-						'default' => 'default',
 					),
 
 					'height_responsive' => array(
 						'type' => 'measurement',
 						'label' => __( 'Responsive Height', 'so-widgets-bundle' ),
-						'default' => 'default',
 					),
 				),
 			),


### PR DESCRIPTION
This PR changes the height defaults to prevent a situation where the foreground is unintentionally given a height. `custom_height` checks for a value so if "default" is used, it'll pass and a height is set. Strangely, I haven't been able to replicate this locally so I'm unsure why default would ever actually be used/accepted.