### PR TITLE
Media field CSS Changes

### DIFF
--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -12,7 +12,7 @@
 		.gradient(#f9f9f9, #f2f2f2, #f9f9f9);
 		height: 32px;
 		line-height: 18.2px;
-		overflow: auto;
+		overflow: visible;
 		position: relative;
 		.rounded(3px);
 

--- a/base/inc/fields/css/media-field.less
+++ b/base/inc/fields/css/media-field.less
@@ -105,7 +105,7 @@
 		color: #aaa;
 		float: left;
 		font-size: 11px;
-		line-height: 1em;
+		line-height: 18.2px;
 		margin-right: 25px;
 		opacity: 1;
 		padding: 11px 0 11px 6px;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1288

To test "Media: Increase line-height of Remove to allow for better collapse ", resize the browser to replicate #1288.

To test "Block Editor: Prevent Media Wrapper Overlay on Column Block Resize":
- Create/Open Block Editor powered page.
- Add a Columns block.
- Add a SiteOrigin Widget to one of the blocks, select a widget that uses the Media field (such as the Image widget).
- Resize the column (hover block icon and select the column, go over to the block settings sidebar on the right) to 25 and then clear the width.