### PR TITLE
Widgets Page: Prevent Menu Search Overlap on Mobile

### DIFF
--- a/admin/admin.less
+++ b/admin/admin.less
@@ -10,6 +10,10 @@
 		background: #f6f6f6;
 		position: relative;
 
+		@media (max-width: 505px) {
+			padding-right: 0;
+		}
+
 		.icon {
 			float: left;
 			display: inline-block;
@@ -50,6 +54,11 @@
 		h1 {
 			font: 300 2.3em/1.4em "proxima-nova", "Open Sans", Helvetica, Arial, sans-serif;
 			color: #666;
+
+			@media (max-width: 505px) {
+				font-size: 2em;
+				padding-top: 15px;
+			}
 		}
 
 

--- a/admin/admin.less
+++ b/admin/admin.less
@@ -58,6 +58,12 @@
 			bottom: -35px;
 			right: 19px;
 
+			@media (max-width: 505px) {
+				margin-top: 5px;
+				position: static;
+				text-align: center;
+			}
+
 			input{
 				box-sizing: border-box;
 				width: 200px;

--- a/admin/admin.less
+++ b/admin/admin.less
@@ -59,9 +59,8 @@
 			right: 19px;
 
 			@media (max-width: 505px) {
-				margin-top: 5px;
+				margin-top: 10px;
 				position: static;
-				text-align: center;
 			}
 
 			input{


### PR DESCRIPTION
Before:
![Screenshot_2021-05-03 SiteOrigin Widgets ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/116823673-11c79200-abc9-11eb-85fa-433d1feded2b.png)

After:
![Screenshot_2021-05-03 SiteOrigin Widgets ‹ SiteOrigin — WordPress(1)](https://user-images.githubusercontent.com/17275120/116823675-13915580-abc9-11eb-85a6-5bb752c531dd.png)