### PR TITLE
Sliders: Remove Dependency on `wp_is_mobile`

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -14,14 +14,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			array( 'jquery' ),
 			SOW_BUNDLE_VERSION
 		);
-		if( function_exists('wp_is_mobile') && wp_is_mobile() ) {
-			$frontend_scripts[] = array(
-				'sow-slider-slider-cycle2-swipe',
-				plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/jquery.cycle.swipe' . SOW_BUNDLE_JS_SUFFIX . '.js',
-				array( 'jquery' ),
-				SOW_BUNDLE_VERSION
-			);
-		}
+
 		$frontend_scripts[] = array(
 			'sow-slider-slider',
 			plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/slider/jquery.slider' . SOW_BUNDLE_JS_SUFFIX . '.js',
@@ -39,6 +32,16 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 					SOW_BUNDLE_VERSION
 				)
 			)
+		);
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_cycle_swipe' ) );
+	}
+
+	function register_cycle_swipe() {
+		wp_register_script(
+			'sow-slider-slider-cycle2-swipe',
+			plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/jquery.cycle.swipe' . SOW_BUNDLE_JS_SUFFIX . '.js',
+			array( 'jquery' ),
+			SOW_BUNDLE_VERSION
 		);
 	}
 
@@ -219,10 +222,13 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 	function render_template_part( $part, $controls, $frames ) {
 		switch( $part ) {
 			case 'before_slider':
-				?><div class="sow-slider-base <?php if( wp_is_mobile() ) echo 'sow-slider-is-mobile' ?>" style="display: none"><?php
+				?><div class="sow-slider-base" style="display: none"><?php
 				break;
 			case 'before_slides':
 				$settings = $this->slider_settings( $controls );
+				if ( $settings['swipe'] ) {
+					wp_enqueue_script( 'sow-slider-slider-cycle2-swipe' );
+				}
 				?><ul class="sow-slider-images" data-settings="<?php echo esc_attr( json_encode($settings) ) ?>"><?php
 				break;
 			case 'after_slides':

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -82,6 +82,17 @@ jQuery( function($){
 			var $slides = $$.find('.sow-slider-image');
 			var settings = $$.data('settings');
 
+			// Add mobile identifer to slider.
+			if ( settings.breakpoint ) {
+				$( window ).on( 'load resize', function() {
+					if ( window.matchMedia( '(max-width: ' + settings.breakpoint + ')' ).matches ) {
+						$base.addClass( 'sow-slider-is-mobile' );
+					} else {
+						$base.removeClass( 'sow-slider-is-mobile' );
+					}
+				} );
+			}
+
 			$slides.each(function( index, el) {
 				var $slide = $(el);
 				var urlData = $slide.data('url');


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1253

This PR will ensure that swipe JS will load if a cache is active. To test this PR, please check that `.sow-slider-base` has `.sow-slider-is-mobile` set sub `780px`, and that the swipe JS loads as expected on mobile.

For reference, you can adjust the breakpoint by adjusting the global settings of the widget you're testing.