### PR TITLE
Slider: Size Foreground Images using Custom Height 

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -178,6 +178,14 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 		);
 
 		if( !empty($foreground_src) ) {
+			// If a Custom Height is set, build the foreground style attribute.
+			if ( ! empty( $frame['custom_height'] ) ) {
+				$foreground_style_attr = 'height: ' . intval( $frame['custom_height'] ) . 'px; width: auto;';
+
+				if ( ! empty( $foreground_src[2] ) ) {
+					$foreground_style_attr .= 'max-height: ' . intval( $foreground_src[2] ) .'px';
+				}
+			}
 			?>
 			<div class="sow-slider-image-container">
 				<div class="sow-slider-image-wrapper" style="<?php if( ! empty( $foreground_src[1] ) ) echo 'max-width: ' . (int) $foreground_src[1] . 'px'; ?>">
@@ -198,7 +206,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 							array(
 								'class' => 'sow-slider-foreground-image',
 								'loading' => 'eager',
-								'style' => ! empty( $frame['custom_height'] ) && ! empty( $foreground_src[2] ) ? 'height: ' . intval( $foreground_src[2] ) . 'px' : '',
+								'style' => ! empty( $foreground_style_attr ) ? $foreground_style_attr : '',
 							)
 						);
 						?>
@@ -253,7 +261,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				}
 				$frame['link_attributes'] = $link_atts;
 
-				$frame['custom_height'] = ! empty( $instance['design']['height'] );
+				$frame['custom_height'] = ! empty( $instance['design']['height'] ) ? $instance['design']['height'] : 0;
 			}
 		}
 		return array(

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -178,7 +178,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 		);
 
 		if( !empty($foreground_src) ) {
-			// If a Custom Height is set, build the foreground style attribute.
+			// If a custom height is set, build the foreground style attribute.
 			if ( ! empty( $frame['custom_height'] ) ) {
 				$foreground_style_attr = 'height: ' . intval( $frame['custom_height'] ) . 'px; width: auto;';
 

--- a/widgets/slider/styles/default.less
+++ b/widgets/slider/styles/default.less
@@ -45,6 +45,11 @@
 					}
 				}
 			}
+
+			.sow-slider-image-foreground-wrapper {
+				margin-right: auto;
+				margin-left: auto;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR changes how the foreground images are sized. Previously, the image height was being used and now it's the custom height. The image size is now used as the `max-height` to prevent distortion if the user picks a height that's larger than the image.