### PR TITLE
Improve widget block saving

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -94,7 +94,7 @@
 				wp.data.dispatch( 'core/editor' ).lockPostSaving();
 				jQuery.post( {
 					url: sowbBlockEditorAdmin.restUrl + 'sowb/v1/widgets/previews',
-					beforeSend: function ( xhr ) {
+					beforeSend: function( xhr ) {
 						xhr.setRequestHeader( 'X-WP-Nonce', sowbBlockEditorAdmin.nonce );
 					},
 					data: {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -91,6 +91,7 @@
 			}
 
 			function generateWidgetPreview( widgetData = false) {
+				wp.data.dispatch( 'core/editor' ).lockPostSaving();
 				jQuery.post( {
 					url: sowbBlockEditorAdmin.restUrl + 'sowb/v1/widgets/previews',
 					beforeSend: function ( xhr ) {
@@ -111,6 +112,7 @@
 						widgetHtml: widgetPreview.html,
 						widgetIcons: widgetPreview.icons
 					} );
+					wp.data.dispatch( 'core/editor' ).unlockPostSaving();
 				} )
 				.fail( ajaxErrorHandler );
 			}

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -11,6 +11,17 @@
 	var Spinner  = components.Spinner;
 	var __ = i18n.__;
 
+	var ajaxErrorHandler = function( response ) {
+		var errorMessage = '';
+		if ( response.hasOwnProperty( 'responseJSON' ) ) {
+			errorMessage = response.responseJSON.message;
+		} else if ( response.hasOwnProperty( 'responseText' ) ) {
+			errorMessage = response.responseText;
+		}
+
+		props.setState( { widgetFormHtml: '<div>' + errorMessage + '</div>', } );
+	}
+
 	registerBlockType( 'sowb/widget-block', {
 		title: __( 'SiteOrigin Widget', 'so-widgets-bundle' ),
 
@@ -79,6 +90,31 @@
 				}
 			}
 
+			function generateWidgetPreview( widgetData = false) {
+				jQuery.post( {
+					url: sowbBlockEditorAdmin.restUrl + 'sowb/v1/widgets/previews',
+					beforeSend: function ( xhr ) {
+						xhr.setRequestHeader( 'X-WP-Nonce', sowbBlockEditorAdmin.nonce );
+					},
+					data: {
+						widgetClass: props.attributes.widgetClass,
+						widgetData: widgetData ? widgetData : props.attributes.widgetData || {}
+					}
+				} )
+				.done( function( widgetPreview ) {
+					props.setState( {
+						widgetPreviewHtml: widgetPreview.html,
+						previewInitialized: false,
+					} );
+
+					props.setAttributes( {
+						widgetHtml: widgetPreview.html,
+						widgetIcons: widgetPreview.icons
+					} );
+				} )
+				.fail( ajaxErrorHandler );
+			}
+
 			function switchToEditing() {
 				props.setState( { editing: true, formInitialized: false } );
 			}
@@ -105,12 +141,16 @@
 						props.setAttributes( { widgetData: sowbForms.getWidgetFormValues( $mainForm ) } );
 					}
 					$mainForm.on( 'change', function () {
-						props.setAttributes( { widgetData: sowbForms.getWidgetFormValues( $mainForm ) } );
 						props.setState( {
 							widgetSettingsChanged: true,
 							widgetPreviewHtml: null,
 							previewInitialized: false
 						} );
+						
+						// As setAttributes doesn't support callbacks, we have to manully pass the widgetData to the preview.
+						var widgetData = sowbForms.getWidgetFormValues( $mainForm );
+						props.setAttributes( { widgetData: widgetData } );
+						generateWidgetPreview( widgetData );
 					} );
 					props.setState( { formInitialized: true } );
 				}
@@ -146,17 +186,7 @@
 					.done( function( widgetForm ) {
 						props.setState( { widgetFormHtml: widgetForm } );
 					} )
-					.fail( function ( response ) {
-
-						var errorMessage = '';
-						if ( response.hasOwnProperty( 'responseJSON' ) ) {
-							errorMessage = response.responseJSON.message;
-						} else if ( response.hasOwnProperty( 'responseText' ) ) {
-							errorMessage = response.responseText;
-						}
-
-						props.setState( { widgetFormHtml: '<div>' + errorMessage + '</div>', } );
-					});
+					.fail( ajaxErrorHandler );
 				}
 
 				var widgetForm = props.widgetFormHtml ? props.widgetFormHtml : '';
@@ -229,40 +259,7 @@
 						widgetHtml: null,
 						widgetIcons: null
 					} );
-					jQuery.post( {
-						url: sowbBlockEditorAdmin.restUrl + 'sowb/v1/widgets/previews',
-						beforeSend: function ( xhr ) {
-							xhr.setRequestHeader( 'X-WP-Nonce', sowbBlockEditorAdmin.nonce );
-						},
-						data: {
-							widgetClass: props.attributes.widgetClass,
-							widgetData: props.attributes.widgetData || {}
-						}
-					} )
-					.done( function( widgetPreview ) {
-						props.setState( {
-							widgetPreviewHtml: widgetPreview.html,
-							previewInitialized: false,
-						} );
-
-						props.setAttributes( {
-							widgetHtml: widgetPreview.html,
-							widgetIcons: widgetPreview.icons
-						} );
-					} )
-					.fail( function ( response ) {
-
-						var errorMessage = '';
-						if ( response.hasOwnProperty( 'responseJSON' ) ) {
-							errorMessage = response.responseJSON.message;
-						} else if ( response.hasOwnProperty( 'responseText' ) ) {
-							errorMessage = response.responseText;
-						}
-
-						props.setState( {
-							widgetPreviewHtml: '<div>' + errorMessage + '</div>',
-						} );
-					});
+					generateWidgetPreview();
 				}
 				var widgetPreview = props.widgetPreviewHtml ? props.widgetPreviewHtml : '';
 				return [


### PR DESCRIPTION
This PR brings the SiteOrigin Widgets Block in line with the SiteOrigin Layout Block. Previously, the data of the block would be saved in an inconsistent (to the user) manner, now it will happen after every change (ie. `.change()`). This will allow for more reliable `widgetHtml` generation.

This PR also implements the same update presentation method used by the SIteOrgin Layouts Block to prevent saving before `widgetHtml` is still being generated.

To test this PR, add a block and make some changes. Save the page and then open the page in a different tab. Make a change, save, and refresh the page in the other tab. Has the page updated correctly? Prior to this PR there's a chance that wouldn't be the case.