### PR TITLE
Widget Block: If $_POST isn't empty, render widget

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -143,7 +143,10 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			add_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
 			ob_start();
 
-			if ( empty( $attributes['widgetHtml'] ) ) {
+			// If we have pre-generated widgetHTML or there's a valid $_POST, generate the widget.
+			// We don't show the pre-generated widget when there's a valid $_POST
+			// as widgets will likely change when that happens.
+			if ( empty( $attributes['widgetHtml'] ) || ! empty( $_POST ) ) {
 				/* @var $widget SiteOrigin_Widget */
 				$instance = $widget->update( $instance, $instance );
 				$widget->widget( array(


### PR DESCRIPTION
If `$_POST` isn't empty, it's possible widgets could change so to avoid potential situations where the widget has changed (such as with the SO Contact Form on form submission), this PR generate the widget rather than serving `widgetHtml`.

To this PR, please add https://github.com/siteorigin/so-widgets-bundle/pull/1307 and then set up a SiteOrigin Widgets Block with a contact form. Save, and fill out the form. If you see the success message (or error messages) the PR worked as expected.