### PR TITLE
Contact: Don't Set Current URL in Action

### DIFF
--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -28,7 +28,7 @@ else {
 		);
 	}
 	?>
-	<form action="<?php echo esc_url( add_query_arg( false, false ) ) ?>#contact-form-<?php echo esc_attr( $short_hash ) ?>"
+	<form action="#contact-form-<?php echo esc_attr( $short_hash ); ?>"
           method="POST" class="sow-contact-form" id="contact-form-<?php echo esc_attr( $short_hash ) ?>">
 
 		<?php if( !empty($result['errors']['_general']) ) : ?>


### PR DESCRIPTION
This PR will resolve a nonce error when submitting a contact form added using the SiteOrigin Widgets Block. To test this PR, add a SiteOrigin Widgets Block with a contact form and fill it out.

These PR are recommended while testing this:
https://github.com/siteorigin/so-widgets-bundle/pull/1306 (so the success message will show)
https://github.com/siteorigin/so-widgets-bundle/pull/1305 (so it's easier to update existing SiteOrgin Widget Blocks)