### PR TITLE
Contact: Allow whitelisted HTML in Checkboxes options

### DIFF
--- a/widgets/contact/fields/checkboxes.class.php
+++ b/widgets/contact/fields/checkboxes.class.php
@@ -13,7 +13,7 @@ class SiteOrigin_Widget_ContactForm_Field_Checkboxes extends SiteOrigin_Widget_C
 					<li>
 						<label>
 							<input type="checkbox" value="<?php echo esc_attr( $option['value'] ) ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>[]" id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"<?php echo checked( in_array( $option['value'], $options['value'] ), true, false ) ?>/>
-							<?php echo esc_html( $option['value'] ); ?>
+							<?php echo wp_kses_post( $option['value'] ); ?>
 						</label>
 					</li>
 				<?php endforeach; ?>

--- a/widgets/contact/fields/checkboxes.class.php
+++ b/widgets/contact/fields/checkboxes.class.php
@@ -11,8 +11,8 @@ class SiteOrigin_Widget_ContactForm_Field_Checkboxes extends SiteOrigin_Widget_C
 			<ul>
 				<?php foreach ( $options['field']['options'] as $i => $option ): ?>
 					<li>
-						<label>
-							<input type="checkbox" value="<?php echo esc_attr( $option['value'] ) ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>[]" id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"<?php echo checked( in_array( $option['value'], $options['value'] ), true, false ) ?>/>
+						<input type="checkbox" value="<?php echo esc_attr( $option['value'] ) ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>[]" id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"<?php echo checked( in_array( $option['value'], $options['value'] ), true, false ) ?>/>
+						<label for="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>">
 							<?php echo wp_kses_post( $option['value'] ); ?>
 						</label>
 					</li>

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -151,9 +151,9 @@
 			padding: 0;
 
 			li {
-				margin: 0;
-				display: flex;
 				align-items: center;
+				display: flex;
+				margin: 0;
 			}
 
 			label {
@@ -161,8 +161,8 @@
 			}
 
 			input {
-				margin-right: 0.5em;
 				height: auto;
+				margin-right: 0.5em;
 			}
 		}
 	}

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -120,7 +120,7 @@
 		.font(@field_font_family, @field_font_weight);
 	}
 
-	&.sow-form-field-checkboxes, &.sow-form-field-radio {
+	&.sow-form-field-radio {
 		ul {
 			list-style: none;
 			margin: 0;
@@ -138,6 +138,29 @@
 
 			input {
 				float: left;
+				margin-right: 0.5em;
+				height: auto;
+			}
+		}
+	}
+
+	&.sow-form-field-checkboxes {
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+
+			li {
+				margin: 0;
+				display: flex;
+				align-items: center;
+			}
+
+			label {
+				margin-bottom: 0;
+			}
+
+			input {
 				margin-right: 0.5em;
 				height: auto;
 			}


### PR DESCRIPTION
This PR will allow users to add HTML to checkboxes options. A use case for this is for GDPR type validations ("here's a link to our privacy policy").