### PR TITLE
Fix #1309 : Default icon in field Icon with custom font families (wit…

### DIFF
--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -23,7 +23,7 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 
 		$value_parts = self::get_value_parts( $value, $icon_families_styles );
 
-		if ( ! empty( $value ) ) {
+		if ( ! empty( $value ) && array_key_exists( $value_parts['family'], $icon_families_styles ) ) {
 			$value_family = $value_parts['family'];
 			$value_style = empty( $value_parts['style'] ) ? '' : ( '-' . $value_parts['style'] );
 			$value = $value_parts['family'] . $value_style . '-' . $value_parts['icon'];


### PR DESCRIPTION
…hout that icon) prevent init.

To replicate : 
```php
//remove fontawesome from the font families list.
//use the icon field in a form with a default font-awesome icon set on that field.
function set_current_project_fonts_siteorigin( $families ) {
    // base icons families are set in so-widgets-bundle\icons\icons.php
    $families = array();//clear the base icon, since we need user ot use only the one that are loaded.
    $families["fontawesomepro"] = Icons\FontAwesomePro::get_family_data();
    return $families;
}
add_filter('siteorigin_widgets_icon_families', __NAMESPACE__.'\\set_current_project_fonts_siteorigin', 11);
```

If my logic is right, the bug would occur is fontawesome isn't there for the default icon. So I would suggest just to remove fontawesome, or just keep one font that isn't fontawesome.

Let me know, if there is anything I can do :)