### PR TITLE
Icon Form Field: Clear default if invalid

### DIFF
--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -15,6 +15,30 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 
 	protected $icons_callback;
 
+
+	protected function initialize() {
+		if ( ! empty( $this->default ) ) {
+			$widget_icon_families = $this->get_widget_icon_families();
+			// If there are no icon families, don't proceed.
+			if ( empty( $widget_icon_families ) ) {
+				return;
+			}
+
+			$icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
+			$value_parts = self::get_value_parts( $this->default, $icon_families_styles );
+
+			// Check if the font family of the default icon, and the icon exists.
+			// The last check accounts for the Font Awesome Migration code that adds a default style.
+			if (
+				! isset( $widget_icon_families[ $value_parts['family'] ] ) ||
+				! isset( $widget_icon_families[ $value_parts['family'] ]['icons'] ) ||
+				empty( $widget_icon_families[ $value_parts['family'] ]['icons'][ $value_parts['icon'] ] )
+			) {
+				$this->default = null;
+			}
+		}
+	}
+
 	protected function render_field( $value, $instance ) {
 		$widget_icon_families = $this->get_widget_icon_families();
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1309

This PR will clear the default icon if the icon font family doesn't exist, or if the style doesn't exist. If the style exists, the style will be stripped from the icon name so checking if the font icon allows you to confirm if the style is also set.

To test this open `widgets/icon/icon.php` and replace:
```
'icon' => array(
	'type'  => 'icon',
	'label' => __( 'Icon', 'so-widgets-bundle' ),
),
```

with:
```
'icon' => array(
	'type'  => 'icon',
	'label' => __( 'Icon', 'so-widgets-bundle' ),
	'default' => 'fontawesome-sow-far-address-card',
),
```
Add an icon widget to any page and confirm the default is set. Now add the following code snippet:
```
add_filter( 'siteorigin_widgets_icon_families', function( $families ) {
	unset( $families['fontawesome'] );
    return $families;
} );
```

This will clear the FontAwesome icons, and prevent the default from being valid. Add a new icon widget and confirm that a default hasn't been set - you can confirm this by checking the widget description, if a default icon is set the icon name will be listed. Once confirmed, remove the code snippet.

Open `icons/fontawesome/filter.php` and remove:

` 'sow-far' => __( 'Regular', 'so-widgets-bundle' ),`

Add a new icon widget and confirm the default hasn't been set.