### PR TITLE
Image Grid: Apply Vertical Padding evenly

### DIFF
--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -5,12 +5,12 @@
 	flex-wrap: wrap;
 	justify-content: center;
 	align-items: baseline;
-	padding-top: @spacing;
+	padding: @spacing/2 0;
 	line-height: 0;
 	text-align:center;
 
 	.sow-image-grid-image {
-		padding: 0 @spacing @spacing @spacing;
+		padding: @spacing/2 @spacing;
 		display: inline-block;
 
 		img {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1266

This PR will ensure padding is evenly vertically split between the items and ensure the offset outlined in https://github.com/siteorigin/so-widgets-bundle/issues/1266 doesn't happen. To test this set a few different spacing values, and add enough image grid items to result in at least four rows.

Please note that during testing you'll need to clear the contents of `wp-content/plugins/siteorigin-widgets` to see a difference.