### PR TITLE
Image Grid: Spacing Setting Rework

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -110,8 +110,8 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 						'type' => 'number',
 					),
 
-					'spacing' => array(
-						'label' => __( 'Image spacing', 'so-widgets-bundle' ),
+					'padding' => array(
+						'label' => __( 'Image padding', 'so-widgets-bundle' ),
 						'type' => 'multi-measurement',
 						'autofill' => true,
 						'default' => '5px 5px 5px 5px',
@@ -212,16 +212,19 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 				$instance['display']['max_width'] = (int) $instance['display']['max_width'];
 			}
 
-			// Image spacing changed from `number` field to `multi-measurement` field.
-			if ( is_numeric( $instance['display']['spacing'] ) ) {
-				$spacing = $instance['display']['spacing'] . 'px';
-			} else if ( isset( $instance['display']['spacing_unit'] ) ) {
-				// Image spacing changed from `measurement` field to `multi-measurement` field.
-				$spacing = $instance['display']['spacing'];
-				unset( $instance['display']['spacing_unit'] );
-			}
-			if ( isset( $spacing ) ) {
-				$instance['display']['spacing'] = "0 $spacing $spacing $spacing";
+			// Migrate the Spacing setting to the Padding setting.
+			if ( isset( $instance['display']['spacing'] ) ) {
+				// The Spacing setting was initially a `number` field.
+				if ( is_numeric( $instance['display']['spacing'] ) ) {
+					$spacing = $instance['display']['spacing'] . 'px';
+				} else if ( isset( $instance['display']['spacing_unit'] ) ) {
+					// Prior to the rename, it was a `measurement` field.
+					$spacing = $instance['display']['spacing'];
+				}
+
+				if ( isset( $spacing ) ) {
+					$instance['display']['padding'] = "0 $spacing $spacing $spacing";
+				}
 			}
 		}
 		
@@ -237,9 +240,9 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	 */
 	function get_less_variables( $instance ) {
 		$less = array();
-		if ( ! empty( $instance['display']['spacing'] ) ) {
-			$less['spacing'] = $instance['display']['spacing']
-;		}
+		if ( ! empty( $instance['display']['padding'] ) ) {
+			$less['padding'] = $instance['display']['padding'];
+		}
 
 		return $less;
 	}

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -111,10 +111,24 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					),
 
 					'spacing' => array(
-						'label' => __( 'Spacing', 'so-widgets-bundle' ),
-						'description' => __( 'Amount of spacing between images.', 'so-widgets-bundle' ),
-						'type' => 'measurement',
-						'default' => '10px',
+						'label' => __( 'Image spacing', 'so-widgets-bundle' ),
+						'type' => 'multi-measurement',
+						'autofill' => true,
+						'default' => '5px 5px 5px 5px',
+						'measurements' => array(
+							'top' => array(
+							'label' => __( 'Top', 'so-widgets-bundle' ),
+							),
+							'right' => array(
+								'label' => __( 'Right', 'so-widgets-bundle' ),
+							),
+							'bottom' => array(
+								'label' => __( 'Bottom', 'so-widgets-bundle' ),
+							),
+							'left' => array(
+								'label' => __( 'Left', 'so-widgets-bundle' ),
+							),
+						),
 					),
 				)
 			)
@@ -198,9 +212,16 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 				$instance['display']['max_width'] = (int) $instance['display']['max_width'];
 			}
 
-			// Input for `spacing` changed from `number` to `measurement` field.
+			// Image spacing changed from `number` field to `multi-measurement` field.
 			if ( is_numeric( $instance['display']['spacing'] ) ) {
-				$instance['display']['spacing'] = $instance['display']['spacing'] .'px';
+				$spacing = $instance['display']['spacing'] . 'px';
+			} else if ( isset( $instance['display']['spacing_unit'] ) ) {
+				// Image spacing changed from `measurement` field to `multi-measurement` field.
+				$spacing = $instance['display']['spacing'];
+				unset( $instance['display']['spacing_unit'] );
+			}
+			if ( isset( $spacing ) ) {
+				$instance['display']['spacing'] = "0 $spacing $spacing $spacing";
 			}
 		}
 		
@@ -217,8 +238,8 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	function get_less_variables( $instance ) {
 		$less = array();
 		if ( ! empty( $instance['display']['spacing'] ) ) {
-			$less['spacing'] = $instance['display']['spacing'];
-		}
+			$less['spacing'] = $instance['display']['spacing']
+;		}
 
 		return $less;
 	}

--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -5,12 +5,11 @@
 	flex-wrap: wrap;
 	justify-content: center;
 	align-items: baseline;
-	padding-top: @spacing;
 	line-height: 0;
-	text-align:center;
+	text-align: center;
 
 	.sow-image-grid-image {
-		padding: 0 @spacing @spacing @spacing;
+		padding: @spacing;
 		display: inline-block;
 
 		img {

--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -1,4 +1,4 @@
-@spacing: default;
+@padding: default;
 
 .sow-image-grid-wrapper {
 	display: flex;
@@ -9,7 +9,7 @@
 	text-align: center;
 
 	.sow-image-grid-image {
-		padding: @spacing;
+		padding: @padding;
 		display: inline-block;
 
 		img {


### PR DESCRIPTION
- Renamed Spacing to ~Image Spacing~ Image Padding.
- Removed setting description.
- Added migration code from legacy `measurement` and `number` based spacing to multi-measurement.
- Removed container top padding.

Before loading this PR, please set up a basic Image Grid with a few images to confirm the Spacing to Image spacing migration code works as expected.