### PR TITLE
Mutiple Media: Correct remove button detection

### DIFF
--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -113,7 +113,7 @@
 			frame.open();
 		});
 
-		$field.find( 'a.media-remove-button' ).on( 'click', function( e ) {
+		$( document ).on( 'click','.siteorigin-widget-field-type-multiple_media a.media-remove-button', function( e ) {
 			e.preventDefault();
 			var $currentItem = $( this ).parent();
 


### PR DESCRIPTION
This PR resolves an issue with the Remove button not working as expected after selecting media. Unsure why it previously worked without issue.

To test, add some media and then try and remove it by clicking the Remove button - this field will work for existing media. For an easy method of testing, I recommend using the plugin linked in [this comment](https://github.com/siteorigin/so-widgets-bundle/pull/1235#issuecomment-774980242).