### PR TITLE
Image Grid: Prevent Empty Image Padding After Migration

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -223,7 +223,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 				}
 
 				if ( isset( $spacing ) ) {
-					$instance['display']['padding'] = "0 $spacing $spacing $spacing";
+					$instance['display']['padding'] = "0px $spacing $spacing $spacing";
 				}
 			}
 		}


### PR DESCRIPTION
This will prevent the top padding from not having an empty unit of measurement.