### PR TITLE
Fonts Array: Add A Space Between Weight and Variant

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -272,9 +272,9 @@ function siteorigin_widgets_font_families( ){
 		foreach ( $variants as $variant ) {
 			if ( $variant == 'regular' || $variant == 400 ) {
 				$font_families[ $font ] = $font;
-			}
-			else {
-				$font_families[ $font . ':' . $variant ] = $font . ' (' . $variant . ')';
+			} else {
+				$label_variant = is_numeric( $variant ) && $variant != 'italic'? $variant : filter_var( $variant, FILTER_SANITIZE_NUMBER_INT ) . ' italic';
+				$font_families[ $font . ':' . $variant ] = $font . ' (' . $label_variant . ')';
 			}
 		}
 	}


### PR DESCRIPTION
This PR will add a space after the Weight and Variant (300 italic). Previously there would be one (eg. (300italic).

<img width="277" alt="2021-05-31_18-59-22-1486" src="https://user-images.githubusercontent.com/17275120/120168898-bed21080-c242-11eb-9098-c9f47827849c.png">
