### PR TITLE
Multi Measurement: Prevent Empty Unit

### DIFF
--- a/base/inc/fields/js/multi-measurement-field.js
+++ b/base/inc/fields/js/multi-measurement-field.js
@@ -23,7 +23,7 @@
 				var valueResult = values[ index ].match( /(\d+\.?\d*)([a-z%]+)*/ );
 				if ( valueResult && valueResult.length ) {
 					var amount = valueResult[ 1 ];
-					var unit = valueResult[ 2 ];
+					var unit = typeof valueResult[ 2 ] != 'undefined' ? valueResult[ 2 ] : 'px';
 					$( element ).val( amount );
 					$( element ).find( '+ .sow-multi-measurement-select-unit' ).val( unit );
 				}


### PR DESCRIPTION
Will default to px. Prevents the following from happening:

<img width="732" alt="10" src="https://user-images.githubusercontent.com/17275120/120169236-13758b80-c243-11eb-946e-c673c3054224.png">
