### PR TITLE
Post Selector: Add option to adjust taxonomies relationship

### DIFF
--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -54,12 +54,12 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 
 			'tax_query_relation' => array(
 				'type' => 'radio',
-				'label' => __( 'Taxonomies Relationship', 'so-widgets-bundle' ),
+				'label' => __( 'Taxonomies relationship', 'so-widgets-bundle' ),
 				'options' => array(
 					'OR' => __( 'OR', 'so-widgets-bundle' ),
 					'AND' => __( 'AND', 'so-widgets-bundle' ),
 				),
-				'description' => __( 'The relationship between the taxonomies. AND requires posts to have all of the specified taxonomies, while OR requires posts to have at least one of the specified taxonomies.', 'so-widgets-bundle' ),
+				'description' => __( 'The relationship between taxonomies. OR requires posts to have at least one of the specified taxonomies. AND requires posts to have all of the specified taxonomies.', 'so-widgets-bundle' ),
 				'default' => 'OR',
 			),
 

--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -52,6 +52,17 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 				'description' => __( 'Taxonomies are groups such as categories, tags, posts and products.', 'so-widgets-bundle' ),
 			),
 
+			'tax_query_relation' => array(
+				'type' => 'radio',
+				'label' => __( 'Taxonomies Relationship', 'so-widgets-bundle' ),
+				'options' => array(
+					'OR' => __( 'OR', 'so-widgets-bundle' ),
+					'AND' => __( 'AND', 'so-widgets-bundle' ),
+				),
+				'description' => __( 'The relationship between the taxonomies. AND requires posts to have all of the specified taxonomies, while OR requires posts to have at least one of the specified taxonomies.', 'so-widgets-bundle' ),
+				'default' => 'OR',
+			),
+
 			'date_type' => array(
 				'type' => 'radio',
 				'label' => __( 'Date selection type', 'so-widgets-bundle' ),

--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -34,7 +34,7 @@ function siteorigin_widget_post_selector_process_query( $query, $exclude_current
 		$tax_queries = explode(',', $query['tax_query']);
 
 		$query['tax_query'] = array();
-		$query['tax_query']['relation'] = 'OR';
+		$query['tax_query']['relation'] = isset( $query['tax_query_relation'] ) ? $query['tax_query_relation'] : 'OR';
 		foreach($tax_queries as $tq) {
 			list($tax, $term) = explode(':', $tq);
 


### PR DESCRIPTION
This PR will add a new setting to the posts form field that will allow users to change the taxonomy relationship. Previously, it was only possible to adjust the taxonomies relationship by using the `siteorigin_widgets_posts_selector_query` hook.