### PR TITLE
Font Variant: Correct Spacing When No Weight

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -273,7 +273,7 @@ function siteorigin_widgets_font_families( ){
 			if ( $variant == 'regular' || $variant == 400 ) {
 				$font_families[ $font ] = $font;
 			} else {
-				$label_variant = is_numeric( $variant ) && $variant != 'italic'? $variant : filter_var( $variant, FILTER_SANITIZE_NUMBER_INT ) . ' italic';
+				$label_variant = is_numeric( $variant ) || $variant == 'italic'? $variant : filter_var( $variant, FILTER_SANITIZE_NUMBER_INT ) . ' italic';
 				$font_families[ $font . ':' . $variant ] = $font . ' (' . $label_variant . ')';
 			}
 		}


### PR DESCRIPTION
This PR will ensure there's no spacing present there's a variant present, but no font weight (eg. " italic").