### PR TITLE
Multiple media: Improved Image Support & `image_dimensions` parameter 

### DIFF
--- a/base/inc/fields/css/multiple-media-field.less
+++ b/base/inc/fields/css/multiple-media-field.less
@@ -24,10 +24,8 @@
 				border: 1px solid #999;
 				box-shadow: 0px 1px 1px #fff;
 				box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
-				height: 75px;
 				.gradient(#cfcfcf, #cccccc, #cfcfcf);
 				line-height: 0;
-				width: 75px;
 			}
 
 			.title {

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -62,7 +62,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 				<?php
 				if ( is_array( $attachments ) ) {
 					foreach ( $attachments as $attachment ) {
-						$post = get_post( $attachment );
+						$title = get_the_title( $attachment );
 						$src = wp_get_attachment_image_src( $attachment, 'thumbnail' );
 
 						if ( empty( $src ) ) {
@@ -74,13 +74,13 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 						?>
 						<div class="multiple-media-field-item" data-id="<?php echo esc_attr( $attachment ); ?>">
 							<?php if ( ! empty( $src ) ) : ?>
-								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $post->post_title ); ?>"/>
+								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $title ); ?>"/>
 							<?php endif; ?>
 							<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
 							<div class="title">
 								<?php
-								if ( ! empty( $post ) ) {
-									echo esc_attr( $post->post_title );
+								if ( ! empty( $title ) ) {
+									echo esc_attr( $title );
 								}
 								?>		
 							</div>

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -31,11 +31,23 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 	 */
 	protected $library;
 
+	/**
+	 * The dimensions of each thumbnail item. Only used when editing widgets. The default is 75x75.
+	 *
+	 * @access protected
+	 * @var array
+	 */
+	protected $thumbnail_dimensions;
+
 	protected function get_default_options() {
 		return array(
 			'choose' => __( 'Add Media', 'so-widgets-bundle' ),
 			'update' => __( 'Set Media', 'so-widgets-bundle' ),
-			'library' => 'image'
+			'library' => 'image',
+			'thumbnail_dimensions' => array(
+				64,
+				64
+			),
 		);
 	}
 
@@ -43,6 +55,17 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 		if ( version_compare( get_bloginfo('version'), '3.5', '<' ) ){
 			printf( __( 'You need to <a href="%s">upgrade</a> to WordPress 3.5 to use media fields', 'so-widgets-bundle'), admin_url('update-core.php' ) );
 			return;
+		}
+
+		// Ensure thumbnail_dimensions are valid. 
+		if (
+			empty( $this->thumbnail_dimensions ) ||
+			empty( $this->thumbnail_dimensions[0] ) ||
+			empty( $this->thumbnail_dimensions[1] ) ||
+			! is_numeric( $this->thumbnail_dimensions[0] ) ||
+			! is_numeric( $this->thumbnail_dimensions[1] )
+		) {
+			$this->thumbnail_dimensions = array( 64, 64 );
 		}
 
 		// If library is set to all, convert it to a wildcard as all isn't valid
@@ -74,7 +97,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 						?>
 						<div class="multiple-media-field-item" data-id="<?php echo esc_attr( $attachment ); ?>">
 							<?php if ( ! empty( $src ) ) : ?>
-								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $title ); ?>"/>
+								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $title ); ?>" width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
 							<?php endif; ?>
 							<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
 							<div class="title">

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -66,11 +66,16 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 						$src = wp_get_attachment_image_src( $attachment, 'thumbnail' );
 
 						if ( empty( $src ) ) {
-							continue;
+							// If item doesn't have an image src, use the WP icon for its media type.
+							$src = wp_mime_type_icon( $attachment );
+						} else {
+							$src = $src[0];
 						}
 						?>
 						<div class="multiple-media-field-item" data-id="<?php echo esc_attr( $attachment ); ?>">
-							<img src="<?php echo sow_esc_url( $src[0] ); ?>" class="thumbnail" title="<?php echo esc_attr( $post->post_title ); ?>"/>
+							<?php if ( ! empty( $src ) ) : ?>
+								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $post->post_title ); ?>"/>
+							<?php endif; ?>
 							<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
 							<div class="title">
 								<?php

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -116,7 +116,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 			
 			<div class="multiple-media-field-template" style="display:none">
 				<div class="multiple-media-field-item">
-					<img class="thumbnail" />
+					<img class="thumbnail"  width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
 					<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
 					<div class="title"></div>
 				</div>

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -39,15 +39,14 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 	 */
 	protected $thumbnail_dimensions;
 
+	static $default_thumbnail_dimensions = array( 64, 64 ); 
+
 	protected function get_default_options() {
 		return array(
 			'choose' => __( 'Add Media', 'so-widgets-bundle' ),
 			'update' => __( 'Set Media', 'so-widgets-bundle' ),
 			'library' => 'image',
-			'thumbnail_dimensions' => array(
-				64,
-				64
-			),
+			'thumbnail_dimensions' => self::$default_thumbnail_dimensions,
 		);
 	}
 
@@ -65,7 +64,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 			! is_numeric( $this->thumbnail_dimensions[0] ) ||
 			! is_numeric( $this->thumbnail_dimensions[1] )
 		) {
-			$this->thumbnail_dimensions = array( 64, 64 );
+			$this->thumbnail_dimensions = self::$default_thumbnail_dimensions;
 		}
 
 		// If library is set to all, convert it to a wildcard as all isn't valid


### PR DESCRIPTION
This PR allows for non-Image to be seen in the widget after saving the page (previously you could add them, but couldn't select/view them when editing the widget after loading), and adds the `image_dimensions` parameter to allow for developers to set specific dimensions.

[Test widget](https://drive.google.com/uc?id=14vytZ86-OK8xNPvzE6MRUD8I9JlXrwlp)

This PR also reduces the thumbnail dimensions from 75x75 to 64x64. This is to reduce stretching with WP Media Type Icons.