### PR TITLE
Slider: Avoid Potential PHP 8 Error with Overlay Attr Filter

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -357,8 +357,8 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				);
 				$overlay_attributes = apply_filters( 'siteorigin_widgets_slider_overlay_attributes', $overlay_attributes, $frame, $background );
 
-				$overlay_attributes['class'] = implode( ' ', $overlay_attributes['class'] );
-				$overlay_attributes['style'] = implode( ';', $overlay_attributes['style'] );
+				$overlay_attributes['class'] = empty( $overlay_attributes['class'] ) ? '' : implode( ' ', $overlay_attributes['class'] );
+				$overlay_attributes['style'] = empty( $overlay_attributes['style'] ) ? '' : implode( ' ', $overlay_attributes['style'] );
 
 				?><div <?php foreach( $overlay_attributes as $attr => $val ) echo $attr . '="' . esc_attr( $val ) . '" '; ?> ></div><?php
 			}


### PR DESCRIPTION
This PR will resolve the following error when something uses the `siteorigin_widgets_slider_overlay_attributes` and unsets either the `class` or `style` item.

`[07-Jun-2021 13:01:41 UTC] PHP Fatal error:  Uncaught TypeError: implode(): Argument #1 ($pieces) must be of type array, string given in /Users/amisplon/Sites/siteorigin/wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php:361`