### PR TITLE
Update Various Widgets To Use Font Helper Updated Options

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -390,7 +390,8 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			$font = siteorigin_widget_get_font( $instance['design']['font'] );
 			$less_vars['button_font'] = $font['family'];
 			if ( ! empty( $font['weight'] ) ) {
-				$less_vars['button_font_weight'] = $font['weight'];
+				$less_vars['button_font_weight'] = $font['weight_raw'];
+				$less_vars['button_font_style'] = $font['style'];
 			}
 		}
 		return $less_vars;

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -14,6 +14,7 @@
 
 @button_font: default;
 @button_font_weight: default;
+@button_font_style: default;
 
 @font_size: 1em;
 @rounding: 0.25em;
@@ -47,6 +48,7 @@
 			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
+		font-style: @button_font_style;
 
 		font-size: @font_size;
 		padding: @padding @padding*2;

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -14,6 +14,7 @@
 
 @button_font: default;
 @button_font_weight: default;
+@button_font_style: default;
 
 @font_size: 1em;
 @rounding: 0.25em;
@@ -48,6 +49,7 @@
 			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
+		font-style: @button_font_style;
 
 		font-size: @font_size;
 		padding: @padding @padding*2;

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -13,6 +13,7 @@
 
 @button_font: default;
 @button_font_weight: default;
+@button_font_style: default;
 
 @font_size: 1em;
 @rounding: 0.25em;
@@ -47,6 +48,7 @@
 			max-width: 100%;
 		}
 		.font(@button_font, @button_font_weight);
+		font-style: @button_font_style;
 
 		font-size: @font_size;
 		padding: @padding @padding*2;

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -830,7 +830,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 			// Field labels
 			'label_font_family'          => $label_font['family'],
-			'label_font_weight'          => ! empty( $label_font['weight'] ) ? $label_font['weight'] : '',
 			'label_font_size'            => $instance['design']['labels']['size'],
 			'label_font_color'           => $instance['design']['labels']['color'],
 			'label_position'             => $label_position,
@@ -839,7 +838,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 			// Fields
 			'field_font_family'          => $field_font['family'],
-			'field_font_weight'          => ! empty( $field_font['weight'] ) ? $field_font['weight'] : '',
 			'field_font_size'            => $instance['design']['fields']['font_size'],
 			'field_font_color'           => $instance['design']['fields']['color'],
 			'field_margin'               => $instance['design']['fields']['margin'],
@@ -885,6 +883,16 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'outline_color'              => $instance['design']['focus']['color'],
 			'outline_width'              => $instance['design']['focus']['width'],
 		);
+
+		if ( ! empty( $label_font['weight'] ) ) {
+			$vars['label_font_weight'] = $label_font['weight_raw'];
+			$lessvars_vars['label_font_style'] = $label_font['style'];
+		}
+
+		if ( ! empty( $field_font['weight'] ) ) {
+			$vars['field_font_weight'] = $field_font['weight_raw'];
+			$lessvars_vars['field_font_style'] = $field_font['style'];
+		}
 
 		$global_settings = $this->get_global_settings();
 		if ( ! empty( $global_settings['responsive_breakpoint'] ) ) {

--- a/widgets/contact/styles/default.less
+++ b/widgets/contact/styles/default.less
@@ -19,7 +19,9 @@
 		strong {
 			@label_font_family: default;
 			@label_font_weight: default;
+			@label_font_style: default;
 			.font(@label_font_family, @label_font_weight);
+			font-style: @label_font_style;
 
 			@label_font_size: default;
 			font-size: @label_font_size;
@@ -56,6 +58,7 @@
 
 	@field_font_family: default;
 	@field_font_weight: default;
+	@field_font_style: default;
 	@field_font_size: default;
 	@field_font_color: default;
 
@@ -118,6 +121,7 @@
 
 		font-size: @field_font_size;
 		.font(@field_font_family, @field_font_weight);
+		font-style: @field_font_style;
 	}
 
 	&.sow-form-field-radio {

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -292,7 +292,8 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 					$font = siteorigin_widget_get_font( $styles['font'] );
 					$less_vars[$field_name.'_font'] = $font['family'];
 					if ( ! empty( $font['weight'] ) ) {
-						$less_vars[$field_name.'_font_weight'] = $font['weight'];
+						$less_vars[ $field_name . '_font_weight' ] = $font['weight_raw'];
+						$less_vars[ $field_name . '_font_style' ] = $font['style'];
 					}
 				}
 			}

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -9,7 +9,7 @@
 
 @text_font: default;
 @text_font_weight: 400;
-@text_font_style: default;;
+@text_font_style: default;
 @text_size: default;
 @text_color: default;
 

--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -2,17 +2,20 @@
 
 @title_font: default;
 @title_font_weight: 400;
+@title_font_style: default;
 @title_size: default;
 @title_color: default;
 @title_tag: h5;
 
 @text_font: default;
 @text_font_weight: 400;
+@text_font_style: default;;
 @text_size: default;
 @text_color: default;
 
 @more_text_font: default;
 @more_text_font_weight: 400;
+@more_text_font_style: default;
 @more_text_size: default;
 @more_text_color: default;
 @per_row: 3;
@@ -160,17 +163,20 @@
         .textwidget {
             margin: auto;
             .font(@text_font, @text_font_weight);
+            font-style: @text_font_style;
             font-size: @text_size;
             color: @text_color;
             
             > @{title_tag} {
                 .font(@title_font, @title_font_weight);
+                font-style: @title_font_style;
                 font-size: @title_size;
                 color: @title_color;
             }
 
             > p.sow-more-text {
                 .font(@more_text_font, @more_text_font_weight);
+                font-style: @more_text_font_style;
                 font-size: @more_text_size;
                 color: @more_text_color;
             }

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -427,14 +427,16 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		$heading_font = siteorigin_widget_get_font( $instance['design']['heading_font'] );
 		$less['heading_font'] = $heading_font['family'];
 		if ( ! empty( $heading_font['weight'] ) ) {
-			$less['heading_font_weight'] = $heading_font['weight'];
+			$less['heading_font_weight'] = $heading_font['weight_raw'];
+			$less['heading_font_style'] = $heading_font['style'];
 		}
 		
 		if ( ! empty( $instance['design']['text_font'] ) ) {
 			$text_font = siteorigin_widget_get_font( $instance['design']['text_font'] );
 			$less['text_font'] = $text_font['family'];
 			if ( ! empty( $text_font['weight'] ) ) {
-				$less['text_font_weight'] = $text_font['weight'];
+				$less['text_font_weight'] = $text_font['weight_raw'];
+				$less['text_font_style'] = $text_font['style'];
 			}
 		}
 

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -14,12 +14,14 @@
 @text_shadow: 0.25;
 @text_font: default;
 @text_font_weight: 500;
+@text_font_style: default;
 
 @link_color: default;
 @link_color_hover: default;
 
 @heading_font: default;
 @heading_font_weight: 400;
+@heading_font_style: default;
 @heading_color: #FFFFFF;
 @heading_shadow: 50;
 
@@ -77,6 +79,7 @@
 				margin: 0.1em 0;
 
 				.font(@heading_font, @heading_font_weight);
+				font-style: @heading_font_style;
 			}
 
 			h1 {
@@ -119,6 +122,7 @@
 				font-size: @text_size;
 
 				.font(@text_font, @text_font_weight);
+				font-style: @text_font_style;
 			}
 
 			.sow-hero-buttons {


### PR DESCRIPTION
This PR implements https://github.com/siteorigin/so-widgets-bundle/pull/1278 for the following widgets:

- Button
- Contact
- Features
- Hero

This PR ensures the correct font is loaded by setting the correct font weight and style as needed. Prior to this PR, it was possible the font wouldn't be loaded correctly and/or be overridden by other instances of the font being loaded. I've created a basic test layout that tests all of the adjusted font fields and it can be downloaded by [clicking here](https://drive.google.com/uc?id=1jkfnAmCAc3BBmV3NAt4PWaCZ12sbbAcm). Please test this PR by confirming the font [the font-weight and font-style is correctly set for the text](https://i.imgur.com/DMZOPif.png).

For reference, here's the Headline version of this PR: https://github.com/siteorigin/so-widgets-bundle/pull/1278 PR.
