### PR TITLE
Multiple Media: Optional Title

### DIFF
--- a/base/inc/fields/css/multiple-media-field.less
+++ b/base/inc/fields/css/multiple-media-field.less
@@ -30,8 +30,13 @@
 
 			.title {
 				display: none;
-			}
 
+				&.title-enabled {
+					display: block;
+					font-size: 12px;
+					word-break: break-all;
+				}
+			}
 			.media-remove-button {
 				color: #aaa;
 				display: block;

--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -62,7 +62,7 @@
 					$currentItem,
 					$thumbnail;
 
-				$.each( frame.state().get('selection').models, function() {
+				$.each( frame.state().get( 'selection' ).models, function() {
 					attachment = this.attributes;
 
 					// Don't process images that already exist.
@@ -72,6 +72,7 @@
 
 						$thumbnail = $currentItem.find( '.thumbnail' );
 						$thumbnail.attr( 'title', attachment.title );
+						$currentItem.find( '.title' ).text( attachment.title );
 
 						$currentItem.attr( 'data-id', attachment.id );
 

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -126,7 +126,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 				<div class="multiple-media-field-item">
 					<img class="thumbnail"  width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
 					<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
-					<div class="title"></div>
+					<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>"></div>
 				</div>
 
 			</div>

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -32,6 +32,14 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 	protected $library;
 
 	/**
+	 * Whether to display the item title or not. Default is `true`.
+	 *
+	 * @access protected
+	 * @var boolean
+	 */
+	protected $title;
+
+	/**
 	 * The dimensions of each thumbnail item. Only used when editing widgets. The default is 75x75.
 	 *
 	 * @access protected
@@ -46,6 +54,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 			'choose' => __( 'Add Media', 'so-widgets-bundle' ),
 			'update' => __( 'Set Media', 'so-widgets-bundle' ),
 			'library' => 'image',
+			'title' => true,
 			'thumbnail_dimensions' => self::$default_thumbnail_dimensions,
 		);
 	}
@@ -84,7 +93,7 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 				<?php
 				if ( is_array( $attachments ) ) {
 					foreach ( $attachments as $attachment ) {
-						$title = get_the_title( $attachment );
+						$item_title = get_the_title( $attachment );
 						$src = wp_get_attachment_image_src( $attachment, 'thumbnail' );
 
 						if ( empty( $src ) ) {
@@ -96,13 +105,13 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 						?>
 						<div class="multiple-media-field-item" data-id="<?php echo esc_attr( $attachment ); ?>">
 							<?php if ( ! empty( $src ) ) : ?>
-								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $title ); ?>" width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
+								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $item_title ); ?>" width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
 							<?php endif; ?>
 							<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
-							<div class="title">
+							<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>">
 								<?php
-								if ( ! empty( $title ) ) {
-									echo esc_attr( $title );
+								if ( ! empty( $item_title ) ) {
+									echo esc_attr( $item_title );
 								}
 								?>		
 							</div>


### PR DESCRIPTION
This PR adds an optional title field for the Multiple Media form field.

To test this PR install [this plugin](https://drive.google.com/uc?id=14vytZ86-OK8xNPvzE6MRUD8I9JlXrwlp) and enable the SiteOrigin Multiple Media Test widget. Add it to the page and add a few items, and you'll see the title below the image.

Now to test disabling the title open wp-content/plugins/siteorigin-multiple-media-widget-pr-1329/widgets/multiple-media/multiple-media.php and find:

`'label' => __( 'Multiple Media', 'sowb-multiple-media' ),`

Add to the next line:
`'title' => false,`