### PR TITLE
Google Maps: Avoid Jump on Load When InfoDisplay Always Enabled

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -215,7 +215,11 @@ sowb.SiteOriginGoogleMap = function($) {
 							var openEvent = infoDisplay;
 							if ( infoDisplay === 'always' ) {
 								openEvent = 'click';
-								infoWindow.open( map, marker );
+								infoWindow.open( {
+									map: map,
+									anchor: marker,
+									shouldFocus: false // Avoid jump on load
+								} );
 							}
 							marker.addListener( openEvent, function () {
 								infoWindow.open( map, marker );


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/google-maps-widget-is-scrolled-into-view-on-page-load/).

This PR will prevent the browser from being auto scrolled down to the Google Map on load when a marker is set and **When should Info Windows be displayed?**  is set to **Always**.

[Test Layout](https://drive.google.com/uc?id=1tKmYeMv7g5QTyeIvrw0p8eZLaTMvVwbP) (confirm the scroll doesn't occur when the PR is present)