### PR TITLE
Google Font Import: Ensure all weights and styles are imported

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -120,6 +120,7 @@ function siteorigin_widget_get_icon($icon_value, $icon_styles = false, $title = 
  *
  * @return array
  */
+$sow_registered_fonts = array();
 function siteorigin_widget_get_font($font_value) {
 
 	$web_safe = array(
@@ -134,8 +135,9 @@ function siteorigin_widget_get_font($font_value) {
 	$font = array();
 	if ( isset( $web_safe[ $font_value ] ) ) {
 		$font['family'] = $web_safe[ $font_value ];
-	}
-	else if( siteorigin_widgets_is_google_webfont( $font_value ) ) {
+	} elseif ( siteorigin_widgets_is_google_webfont( $font_value ) ) {
+		global $sow_registered_fonts;
+
 		$font_parts = explode( ':', $font_value );
 		$font['family'] = $font_parts[0];
 		$font_url_param = urlencode( $font_parts[0] );
@@ -148,12 +150,27 @@ function siteorigin_widget_get_font($font_value) {
 		$font['url'] = 'https://fonts.googleapis.com/css?family=' . $font_url_param;
 		$style_name = 'sow-google-font-' . strtolower( $font['family'] );
 
+
+		if ( ! empty( $font['weight'] ) ) {
+			$font_slug = $font['weight_raw'] . ( ! empty( $font['style'] ) ? 'i' : '' );
+		} else {
+			// Default to 400 if no weight is set.
+			$font_slug = 400;
+		}
+		$sow_registered_fonts[ $font['family'] ][ $font_slug ] = true;
+
 		// Check if WB (or something else has) has already enqueued the font.
 		if ( ! wp_style_is( $style_name ) ) {
 			wp_enqueue_style( $style_name,  $font['url'] . '&display=swap' );
+		} elseif ( ! empty( $sow_registered_fonts[ $font['family'] ] ) ) {
+			// Font already present. Update URL.
+			global $wp_styles;
+			global $sow_registered_fonts;
+
+			$font_weight_styles = array_keys( $sow_registered_fonts[ $font['family'] ]  );
+			$wp_styles->registered[ $style_name ]->src = 'https://fonts.googleapis.com/css?family=' . urlencode( $font['family'] . ':' . implode( ',', $font_weight_styles ) );
 		}
-	}
-	else {
+	} else {
 		$font['family'] = $font_value;
 		$font = apply_filters( 'siteorigin_widget_get_custom_font_family', $font );
 	}


### PR DESCRIPTION
This PR ensures every selected instance of a Google Font is imported. It'll avoid a situation where one widget imports a font at a specific weight, and another widget attempts to import the same font with a different weight but it fails as the font has already been imported once.

[Here's a test layout](https://drive.google.com/uc?id=11tWzPWgxQQ5YT9GMnWnkDDTTwWI_tqiV) to test this PR. Once imported, view the page source and search for the Google Font import (search for `fonts.googleapis.com`) and open the URL in a different tab. Ensure all of the selected fonts sizes and styles are imported. For reference, that layout should have the following fonts weights and styles imported:

- 600 italic
- 300
- 400
- 600