### PR TITLE
Headline: Mobile Alignment Settings

### DIFF
--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -37,7 +37,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 				'type' => 'measurement',
 				'label' => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
 				'default' => '780px',
-				'description' => __( 'This setting controls when the Mobile alignment settings will be used. The default value is 780px.', 'so-widgets-bundle' ),
+				'description' => __( 'The pixel resolution when the mobile alignment settings will be applied.', 'so-widgets-bundle' ),
 			),
 		);
 	}

--- a/widgets/headline/headline.php
+++ b/widgets/headline/headline.php
@@ -31,6 +31,17 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 		add_filter( 'siteorigin_widgets_wrapper_data_' . $this->id_base, array( $this, 'wrapper_data_filter' ), 10, 2 );
 	}
 
+	function get_settings_form() {
+		return array(
+			'responsive_breakpoint' => array(
+				'type' => 'measurement',
+				'label' => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
+				'default' => '780px',
+				'description' => __( 'This setting controls when the Mobile alignment settings will be used. The default value is 780px.', 'so-widgets-bundle' ),
+			),
+		);
+	}
+
 	function get_widget_form(){
 		return array(
 			'headline' => array(
@@ -92,6 +103,16 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 							'right' => __( 'Right', 'so-widgets-bundle' ),
 							'justify' => __( 'Justify', 'so-widgets-bundle' )
 						)
+					),
+					'mobile_align' => array(
+						'type' => 'select',
+						'label' => __( 'Mobile alignment', 'so-widgets-bundle' ),
+						'options' => array(
+							'center' => __( 'Center', 'so-widgets-bundle' ),
+							'left' => __( 'Left', 'so-widgets-bundle' ),
+							'right' => __( 'Right', 'so-widgets-bundle' ),
+							'justify' => __( 'Justify', 'so-widgets-bundle' ),
+						),
 					),
 					'line_height' => array(
 						'type' => 'measurement',
@@ -164,6 +185,16 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 							'justify' => __( 'Justify', 'so-widgets-bundle' )
 						)
 					),
+					'mobile_align' => array(
+						'type' => 'select',
+						'label' => __( 'Mobile alignment', 'so-widgets-bundle' ),
+						'options' => array(
+							'center' => __( 'Center', 'so-widgets-bundle' ),
+							'left' => __( 'Left', 'so-widgets-bundle' ),
+							'right' => __( 'Right', 'so-widgets-bundle' ),
+							'justify' => __( 'Justify', 'so-widgets-bundle' ),
+						),
+					),
 					'line_height' => array(
 						'type' => 'measurement',
 						'label' => __('Line Height', 'so-widgets-bundle')
@@ -212,6 +243,15 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 						'type' => 'select',
 						'label' => __('Alignment', 'so-widgets-bundle'),
 						'default' => 'center',
+						'options' => array(
+							'center' => __( 'Center', 'so-widgets-bundle' ),
+							'left' => __( 'Left', 'so-widgets-bundle' ),
+							'right' => __( 'Right', 'so-widgets-bundle' ),
+						),
+					),
+					'mobile_align' => array(
+						'type' => 'select',
+						'label' => __( 'Mobile alignment', 'so-widgets-bundle' ),
 						'options' => array(
 							'center' => __( 'Center', 'so-widgets-bundle' ),
 							'left' => __( 'Left', 'so-widgets-bundle' ),
@@ -271,12 +311,15 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 	}
 
 	function get_less_variables( $instance ) {
-		$less_vars = array();
+		$less_vars = array(
+			'responsive_breakpoint' => $this->get_global_settings( 'responsive_breakpoint' ),
+		);
 
 		// All the headline attributes
 		$less_vars['headline_tag'] = isset( $instance['headline']['tag'] ) ? $instance['headline']['tag'] : false;
 		$less_vars['headline_hover_color'] = isset( $instance['headline']['hover_color'] ) ? $instance['headline']['hover_color'] : false;
 		$less_vars['headline_align'] = isset( $instance['headline']['align'] ) ? $instance['headline']['align'] : false;
+		$less_vars['headline_mobile_align'] = isset( $instance['headline']['mobile_align'] ) ? $instance['headline']['mobile_align'] : false;
 		$less_vars['headline_color'] = isset( $instance['headline']['color'] ) ? $instance['headline']['color'] : false;
 		$less_vars['headline_font_size'] = isset( $instance['headline']['font_size'] ) ? $instance['headline']['font_size'] : false;
 		$less_vars['headline_line_height'] = isset( $instance['headline']['line_height'] ) ? $instance['headline']['line_height'] : false;
@@ -294,6 +337,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 
 		// Set the sub headline attributes
 		$less_vars['sub_headline_align'] = isset( $instance['sub_headline']['align'] ) ? $instance['sub_headline']['align'] : false;
+		$less_vars['sub_headline_mobile_align'] = isset( $instance['sub_headline']['mobile_align'] ) ? $instance['sub_headline']['mobile_align'] : false;
 		$less_vars['sub_headline_hover_color'] = isset( $instance['sub_headline']['hover_color'] ) ? $instance['sub_headline']['hover_color'] : false;
 		$less_vars['sub_headline_tag'] = isset( $instance['sub_headline']['tag'] ) ? $instance['sub_headline']['tag'] : false;
 		$less_vars['sub_headline_color'] = isset( $instance['sub_headline']['color'] ) ? $instance['sub_headline']['color'] : false;
@@ -315,6 +359,7 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 		$less_vars['divider_width'] = isset( $instance['divider']['width'] ) ? $instance['divider']['width'] : false;
 		$less_vars['divider_thickness'] = isset( $instance['divider']['thickness'] ) ? (int) $instance['divider']['thickness'] . 'px' : false;
 		$less_vars['divider_align'] = isset( $instance['divider']['align'] ) ? $instance['divider']['align'] : false;
+		$less_vars['divider_mobile_align'] = isset( $instance['divider']['mobile_align'] ) ? $instance['divider']['mobile_align'] : false;
 		$less_vars['divider_color'] = isset( $instance['divider']['color'] ) ? $instance['divider']['color'] : false;
 		$less_vars['divider_margin'] = isset( $instance['divider']['margin'] ) ? $instance['divider']['margin'] : false;
 
@@ -414,6 +459,12 @@ class SiteOrigin_Widget_Headline_Widget extends SiteOrigin_Widget {
 		if( isset( $instance['divider']['top_margin'] ) && ! isset( $instance['divider']['bottom_margin'] ) ) {
 			$instance['divider']['bottom_margin'] = $instance['divider']['top_margin'];
 			$instance['divider']['bottom_margin_unit'] = $instance['divider']['top_margin_unit'];
+		}
+		// Set Mobile alignment settings to same value as the Alignment for existing widgets
+		if ( ! empty( $instance['headline']['align'] ) && empty( $instance['headline']['mobile_align'] ) ) {
+			$instance['headline']['mobile_align'] = $instance['headline']['align'];
+			$instance['sub_headline']['mobile_align'] = $instance['sub_headline']['align'];
+			$instance['divider']['mobile_align'] = $instance['divider']['align'];
 		}
 
 		return $instance;

--- a/widgets/headline/styles/default.less
+++ b/widgets/headline/styles/default.less
@@ -1,5 +1,7 @@
 @import "../../../base/less/mixins";
 
+@responsive_breakpoint: 780px;
+
 @headline_tag: h1;
 @headline_font: default;
 @headline_font_weight: 400;
@@ -8,6 +10,7 @@
 @headline_line_height: 1.4em;
 @headline_margin: default;
 @headline_align: center;
+@headline_mobile_align: center;
 @headline_color: default;
 @headline_hover_color: default;
 
@@ -19,6 +22,7 @@
 @sub_headline_line_height: 1.4em;
 @sub_headline_margin: default;
 @sub_headline_align: center;
+@sub_headline_mobile_align: center;
 @sub_headline_color: default;
 @sub_headline_hover_color: default;
 
@@ -28,6 +32,7 @@
 @divider_color: #EEEEEE;
 @divider_margin: 20px;
 @divider_align: center;
+@divider_mobile_align: center;
 
 .sow-headline-container {
 
@@ -41,6 +46,10 @@
 
         margin-top: @headline_margin;
         margin-bottom: @headline_margin;
+
+        @media (max-width: @responsive_breakpoint) {
+            text-align: @headline_mobile_align;
+        }
 
         & a {
             color: @headline_color;
@@ -61,6 +70,10 @@
         margin-top: @sub_headline_margin;
         margin-bottom: @sub_headline_margin;
 
+        @media (max-width: @responsive_breakpoint) {
+            text-align: @sub_headline_mobile_align;
+        }
+
         & a {
             color: @sub_headline_color;
             &:hover {
@@ -75,6 +88,10 @@
 
         margin-top: @divider_margin;
         margin-bottom: @divider_margin;
+
+        @media (max-width: @responsive_breakpoint) {
+            text-align: @divider_mobile_align;
+        }
 
         .decoration-inside {
             height: 1px;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1343

This PR adds mobile alignment settings for the headline, sub-headline, and divider. It also adds a global widget breakpoint setting that allows users to control the mobile alignment CSS is used.

Pre-existing widgets will have Mobile alignment set to the same value as the related Alignment setting. Please test to ensure the migration works as expected by setting up a few headlines prior to switching to the PR branch.