### PR TITLE
Post Selector: If No Taxonomy Set, Default to Previous Taxonomy or Category

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -36,7 +36,13 @@ function siteorigin_widget_post_selector_process_query( $query, $exclude_current
 		$query['tax_query'] = array();
 		$query['tax_query']['relation'] = isset( $query['tax_query_relation'] ) ? $query['tax_query_relation'] : 'OR';
 		foreach($tax_queries as $tq) {
-			list($tax, $term) = explode(':', $tq);
+			if ( strpos( $tq, ':' ) !== false ) {
+				list( $tax, $term ) = explode( ':', $tq );
+			} else {
+				// There's no separator, try using the previous $tax.
+				$tax = empty( $tax ) ? 'category' : $tax;
+				$term = $tq;
+			}
 
 			if( empty($tax) || empty($term) ) continue;
 			$query['tax_query'][] = array(


### PR DESCRIPTION
This PR will resolve below warnign when you manually input another term rather than using the Post Selector. 

`Resolve Warning: Undefined array key 1 in wp-content/plugins/so-widgets-bundle/base/inc/post-selector.php on line 39`

This error occurs as no taxonomy is set. This PR will use the last taxonomy if it's valid, or default to category.

To test this open a post loop widget and select two taxonomies. Remove the second term and colon (eg. category:). So your taxonomy field should go from:

`category:test,category:test2`

To:

`category:test,test2`
