### PR TITLE
Slider Widgets: Update Automatic Item Labels

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -50,11 +50,22 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				'label' => __('Hero frames', 'so-widgets-bundle'),
 				'item_name' => __('Frame', 'so-widgets-bundle'),
 				'item_label' => array(
-					'selector' => "[id*='frames-title']",
-					'update_event' => 'change',
-					'value_method' => 'val'
+					'selectorArray' => array(
+						array(
+							'selector' => '.siteorigin-widget-field-background .media-field-wrapper .current .title',
+							'valueMethod' => 'html',
+						),
+						array(
+							'selector' => '.siteorigin-widget-field-videos .siteorigin-widget-field-repeater-items  .media-field-wrapper .current .title',
+							'valueMethod' => 'html',
+						),
+						array(
+							'selector' => ".siteorigin-widget-field-videos [id*='url']",
+							'update_event' => 'change',
+							'value_method' => 'val',
+						),
+					),
 				),
-
 				'fields' => array(
 
 					'content' => array(
@@ -138,9 +149,17 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 								'item_name' => __('Video', 'so-widgets-bundle'),
 								'label' => __('Background videos', 'so-widgets-bundle'),
 								'item_label' => array(
-									'selector' => "[id*='frames-background_videos-url']",
-									'update_event' => 'change',
-									'value_method' => 'val'
+									'selectorArray' => array(
+										array(
+											'selector' => "[id*='url']",
+											'update_event' => 'change',
+											'value_method' => 'val',
+										),
+										array(
+											'selector' => '.siteorigin-widget-field-file .media-field-wrapper .current .title',
+											'valueMethod' => 'html',
+										),
+									),
 								),
 								'fields' => $this->video_form_fields(),
 							),

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -41,11 +41,20 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 					'selectorArray' => array(
 						array(
 							'selector' => '.siteorigin-widget-field-image .media-field-wrapper .current .title',
-							'valueMethod' => 'html'
+							'valueMethod' => 'html',
 						),
 						array(
 							'selector' => '.siteorigin-widget-field-videos .siteorigin-widget-field-repeater-items  .media-field-wrapper .current .title',
-							'valueMethod' => 'html'
+							'valueMethod' => 'html',
+						),
+						array(
+							'selector' => '.siteorigin-widget-field-videos .siteorigin-widget-field-repeater-items  .media-field-wrapper .current .title',
+							'valueMethod' => 'html',
+						),
+						array(
+							'selector' => ".siteorigin-widget-field-videos [id*='url']",
+							'update_event' => 'change',
+							'value_method' => 'val',
 						),
 					),
 				),
@@ -108,9 +117,17 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 								'item_name' => __('Video', 'so-widgets-bundle'),
 								'label' => __('Background videos', 'so-widgets-bundle'),
 								'item_label' => array(
-									'selector' => "[id*='frames-background_videos-url']",
-									'update_event' => 'change',
-									'value_method' => 'val'
+									'selectorArray' => array(
+										array(
+											'selector' => '.siteorigin-widget-field-file .media-field-wrapper .current .title',
+											'valueMethod' => 'html',
+										),
+										array(
+											'selector' => "[id*='url']",
+											'update_event' => 'change',
+											'value_method' => 'val',
+										),
+									),
 								),
 								'fields' => $this->video_form_fields(),
 							),

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -37,15 +37,20 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 					'selectorArray' => array(
 						array(
 							'selector' => '.siteorigin-widget-field-background_image .media-field-wrapper .current .title',
-							'valueMethod' => 'html'
+							'valueMethod' => 'html',
 						),
 						array(
 							'selector' => '.siteorigin-widget-field-background_videos .siteorigin-widget-field-repeater-items  .media-field-wrapper .current .title',
-							'valueMethod' => 'html'
+							'valueMethod' => 'html',
+						),
+						array(
+							'selector' => ".siteorigin-widget-field-background_videos [id*='url']",
+							'update_event' => 'change',
+							'value_method' => 'val',
 						),
 						array(
 							'selector' => '.siteorigin-widget-field-foreground_image .media-field-wrapper .current .title',
-							'valueMethod' => 'html'
+							'valueMethod' => 'html',
 						),
 					),
 				),
@@ -55,9 +60,17 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						'item_name' => __('Video', 'so-widgets-bundle'),
 						'label' => __('Background videos', 'so-widgets-bundle'),
 						'item_label' => array(
-							'selector' => "[id*='frames-background_videos-url']",
-							'update_event' => 'change',
-							'value_method' => 'val'
+							'selectorArray' => array(
+								array(
+									'selector' => '.siteorigin-widget-field-file .media-field-wrapper .current .title',
+									'valueMethod' => 'html',
+								),
+								array(
+									'selector' => "[id*='url']",
+									'update_event' => 'change',
+									'value_method' => 'val',
+								),
+							),
 						),
 						'fields' => $this->video_form_fields(),
 					),


### PR DESCRIPTION
This PR updates all slider widgets to ensure item labels are set wherever possible for repeaters rather than the generic Frame/Title. 

Item label priority order:

Slider frame:
	- Background Image
	- Background Video
	- Background Video URL
	- Background Foreground

Hero and Layout Slider:
	- Background Image
	- Background Video
	- Background Video URL

All Video Backgrounds
	- Local Video
	- External video URL
