### PR TITLE
Preset Form Field Adjustments

### DIFF
--- a/base/inc/fields/js/presets-field.js
+++ b/base/inc/fields/js/presets-field.js
@@ -10,57 +10,67 @@
 		
 		var $undoLink = $presetSelect.find( '+ .sowb-presets-field-undo' );
 		$undoLink.hide();
-		
+
+		var addingDefault = false;
 		var presets = $presetSelect.data( 'presets' );
 		$presetSelect.on( 'change', function() {
-			
 			var selectedPreset = $presetSelect.val();
 			if ( selectedPreset && presets.hasOwnProperty( selectedPreset ) ) {
-				
 				var presetValues = presets[ selectedPreset ].values;
-				
 				var $formContainer = $presetSelect.closest( '.siteorigin-widget-form-main' );
-				var previousValues = $presetSelect.data( 'previousValues' );
-				if ( ! previousValues ) {
-					var presetClone = JSON.parse( JSON.stringify( presetValues ) );
-					var widgetData = sowbForms.getWidgetFormValues( $formContainer );
-					var recurseDepth = 0;
-					var copyValues = function( from, to ) {
-						if ( ++recurseDepth > 10 ) {
-							return to;
-						}
-						for ( var key in to ) {
-							if ( from.hasOwnProperty( key ) ) {
-								var fromItem = from[ key ];
-								var toItem = to[ key ];
-								if ( fromItem !== null && toItem !== null && typeof fromItem === 'object' ) {
-									copyValues( fromItem, toItem );
-								} else {
-									to[ key ] = fromItem;
+				
+				// If we're adding defaults, don't show undo.
+				if ( ! addingDefault) {
+					var previousValues = $presetSelect.data( 'previousValues' );
+					if ( ! previousValues ) {
+						var presetClone = JSON.parse( JSON.stringify( presetValues ) );
+						var widgetData = sowbForms.getWidgetFormValues( $formContainer );
+						var recurseDepth = 0;
+						var copyValues = function( from, to ) {
+							if ( ++recurseDepth > 10 ) {
+								return to;
+							}
+							for ( var key in to ) {
+								if ( from.hasOwnProperty( key ) ) {
+									var fromItem = from[ key ];
+									var toItem = to[ key ];
+									if ( fromItem !== null && toItem !== null && typeof fromItem === 'object' ) {
+										copyValues( fromItem, toItem );
+									} else {
+										to[ key ] = fromItem;
+									}
 								}
 							}
-						}
-						return to;
-					};
-					// Copy existing widget values for preset properties to allow for undo.
-					previousValues = copyValues( widgetData, presetClone );
-					$presetSelect.data( 'previousValues', previousValues );
+							return to;
+						};
+						// Copy existing widget values for preset properties to allow for undo.
+						previousValues = copyValues( widgetData, presetClone );
+						$presetSelect.data( 'previousValues', previousValues );
+					}
+					if ( $undoLink.not( ':visible' ) ) {
+						$undoLink.show();
+						$undoLink.on( 'click', function ( event ) {
+							event.preventDefault();
+							$undoLink.hide();
+							sowbForms.setWidgetFormValues( $formContainer, previousValues, true );
+							$presetSelect.removeData( 'previousValues' );
+							$presetSelect.val( '' );
+						} );
+					}
 				}
-				if ( $undoLink.not( ':visible' ) ) {
-					$undoLink.show();
-					$undoLink.on( 'click', function ( event ) {
-						event.preventDefault();
-						$undoLink.hide();
-						sowbForms.setWidgetFormValues( $formContainer, previousValues, true );
-						$presetSelect.removeData( 'previousValues' );
-						$presetSelect.val( '' );
-					} );
-				}
-				
+			
 				sowbForms.setWidgetFormValues( $formContainer, presetValues, true );
 			}
 		} );
-		
+
+		// If no value is selected, and there's a default preset, load it.
+		if ( $presetSelect.val() == 'default' && $presetSelect.data( 'default-preset' ) != '' ) {
+			$( this ).find( 'select[class="siteorigin-widget-input"] option[value="default"]' ).remove();
+			addingDefault = true;
+			$presetSelect.val( $presetSelect.data( 'default-preset' ) );
+			$presetSelect.trigger( 'change' );
+		}
+
 		$presetSelect.data( 'initialized', true );
 	} );
 })( jQuery );

--- a/base/inc/fields/presets.class.php
+++ b/base/inc/fields/presets.class.php
@@ -12,6 +12,14 @@ class SiteOrigin_Widget_Field_Presets extends SiteOrigin_Widget_Field_Base {
 	 * @var array
 	 */
 	protected $options;
+
+	/**
+	 * The default preset. If empty, a blank field will be used.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $default_preset;
 	
 	protected function get_default_options() {
 		return array(
@@ -21,18 +29,20 @@ class SiteOrigin_Widget_Field_Presets extends SiteOrigin_Widget_Field_Base {
 	
 	
 	protected function render_field( $value, $instance ) {
-		
 		$preset_options = array();
 		foreach ( $this->options as $name => $preset ) {
 			$preset_options[ $name ] = $preset['label'];
 		}
-		
+
 		?>
 		<select
 			name="<?php echo esc_attr( $this->element_name ); ?>"
 			id="<?php echo esc_attr( $this->element_id ); ?>"
 			class="siteorigin-widget-input"
 			data-presets="<?php echo esc_attr( json_encode( $this->options ) ); ?>"
+			<?php if ( ! empty( $this->default_preset ) ) : ?>
+				data-default-preset="<?php echo esc_attr( $this->default_preset ); ?>"
+			<?php endif; ?>
 		>
 
 			<option value="default"></option>

--- a/base/inc/fields/presets.class.php
+++ b/base/inc/fields/presets.class.php
@@ -28,9 +28,13 @@ class SiteOrigin_Widget_Field_Presets extends SiteOrigin_Widget_Field_Base {
 		}
 		
 		?>
-		<select id="<?php echo esc_attr( $this->element_id ) ?>"
-				class="siteorigin-widget-input"
-				data-presets="<?php echo esc_attr( json_encode( $this->options ) ) ?>">
+		<select
+			name="<?php echo esc_attr( $this->element_name ); ?>"
+			id="<?php echo esc_attr( $this->element_id ); ?>"
+			class="siteorigin-widget-input"
+			data-presets="<?php echo esc_attr( json_encode( $this->options ) ); ?>"
+		>
+
 			<option value="default"></option>
 			<?php if( ! empty( $preset_options ) ) : ?>
 				<?php foreach( $preset_options as $key => $val ) : ?>

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1350,4 +1350,35 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		return $values;
 	}
+
+	// Add state_handler for fields based on how they're adjusted by preset data.
+	protected function dynamic_preset_state_handler( $state_name, $preset_data, $fields ) {
+		$adjusted_fields = array();
+		// Build an array of all the adjusted fields by the preset data, and note which presets adjust them.
+		foreach ( $preset_data as $preset_id => $preset ) {
+			$extracted_fields = array_keys( $preset['values'] );
+			foreach ( $extracted_fields as $field ) {
+				$adjusted_fields[ $field ][] = $preset_id;
+			}
+		}
+
+		// Add state handlers for any of the $adjusted_fields. 
+		foreach ( $adjusted_fields as $field => $used_by ) {
+			// Skip field if it's not adjusted by of the presets, or if the field has a state_handler already.
+			if (
+				! isset( $fields[ $field ] ) ||
+				isset( $fields[ $field ]['state_handler'] )
+			) {
+				continue;
+			}
+
+			$used_by = implode( ',', $used_by ); 
+			$fields[ $field ]['state_handler'] = array(
+				$state_name . '[' . $used_by . ']' => array( 'show' ),
+				'_else[' . $state_name . ']' => array( 'hide' ),
+			);
+		}
+
+		return $fields;
+	}
 }

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1351,7 +1351,15 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		return $values;
 	}
 
-	// Add state_handler for fields based on how they're adjusted by preset data.
+	/**
+	 * Add state_handler for fields based on how they're adjusted by preset data.
+	 *
+	 * @param string $state_name
+	 * @param array $preset_data
+	 * @param array $fields The fields to apply state handlers too.
+	 *
+	 * @return array $fields with any state_handler's applied.
+	 */
 	protected function dynamic_preset_state_handler( $state_name, $preset_data, $fields ) {
 		// Build an array of all the adjusted fields by the preset data, and note which presets adjust them.
 		$adjusted_fields = array();
@@ -1366,14 +1374,21 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		}
 
 		// Apply state handlers to fields.
-		return $this->dynamic_preset_state_handler_section(
+		return $this->dynamic_preset_add_state_handler(
 			$state_name,
 			$adjusted_fields,
 			$fields
 		);
 	}
 
-	// Build an array of all the adjusted fields by the preset data, and note which presets adjust them.
+	/**
+	 * Build an array of all of fields adjusted by the preset data, and note which presets adjust them.
+	 *
+	 * @param array $fields The fields to extract preset usage from.
+	 * @param array $preset_id
+	 *
+	 * @return array An array containing extracted fields.
+	 */
 	private function dynamic_preset_extract_fields( $fields, $preset_id ) {
 		$extracted_fields = array();
 		foreach ( $fields as $field_key => $field ) {
@@ -1388,8 +1403,17 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		return $extracted_fields;
 	}
 
-	// Apply state handlers to fields.
-	private function dynamic_preset_state_handler_section( $state_name, $adjusted_fields, $fields ) {
+
+	/**
+	 * Add state_handler to fields based on preset adjusted fields.
+	 *
+	 * @param string $state_name
+	 * @param array $preset_adjusted_fields
+	 * @param array $fields The fields to apply state handlers too.
+	 *
+	 * @return array $fields with any state_handler's applied.
+	 */
+	private function dynamic_preset_add_state_handler( $state_name, $adjusted_fields, $fields ) {
 		foreach ( $adjusted_fields as $field => $field_value ) {
 			// Skip field if it's not adjusted by of the presets, or if the field has a state_handler already.
 			if (
@@ -1401,7 +1425,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 			// If this is a section field, we need to apply the state handlers for sub fields.
 			if ( $fields[ $field ]['type'] == 'section' ) {
-				$fields[ $field ]['fields'] = $this->dynamic_preset_state_handler_section(
+				$fields[ $field ]['fields'] = $this->dynamic_preset_add_state_handler(
 					$state_name,
 					$field_value,
 					$fields[ $field ]['fields']


### PR DESCRIPTION
This commit includes three preset specific changes:

**Preset Field: Store Selected Preset**
This commit allows for the selected preset to be saved.

**Preset: Add `default_preset` to allow default Preset** 
This commit allows the preset field to support a default preset. This change was complicated due to how state emitters work.
The `default_preset ` parameter was used over `default` due to how `default` being a valid form field option and it not allowing for reliable default detection in the preset JS.

**SiteOrigin Widget: dynamic_preset_state_handler** 

This commit allows a method of dynamically setting the state_handler of an array of `form_fields` based on the values used by the preset field. This basically means, we can easily show/hide fields based on the preset values. This is going to be used heavily by some of our upcoming widgets. 

---

You can test the above changes by using this [test plugin](https://siteorigin.com/wp-content/uploads/2021/06/siteorigin-preset-field-demo.zip). Once installed, navigate to Plugins > SiteOrigin Widgets and activate the `SiteOrigin Preset Field` widget. Add it to any page and you'll notice:

- That the default_preset "test-2" is loaded by default.
- Upon changing preset, certain fields will change and even display altogether.
- Upon saving, the selected preset is saved. 


Documentation: https://github.com/siteorigin/docs/pull/120.