### PR TITLE
Slider: Unmute/Mute controls Draft

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -209,6 +209,8 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			'nav_always_show_desktop'  => ! empty( $controls['nav_always_show_desktop'] ) ? true : '',
 			'nav_always_show_mobile'   => ! empty( $controls['nav_always_show_mobile'] ) ? true : '',
 			'breakpoint'               => ! empty( $controls['breakpoint'] ) ? $controls['breakpoint'] : '780px',
+			'unmute'                   => ! empty( $controls['unmute'] ),
+			'unmute_position'          => ! empty( $controls['unmute_position'] ) ? $controls['unmute_position'] : false,
 		);
 	}
 
@@ -229,6 +231,11 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		switch( $part ) {
 			case 'before_slider':
 				?><div class="sow-slider-base" style="display: none"><?php
+				if ( isset( $controls['unmute'] ) && $controls['unmute'] ) {
+					?>
+					<span class="sow-player-controls-sound">&nbsp;</span>
+					<?php
+				}
 				break;
 			case 'before_slides':
 				$settings = $this->slider_settings( $controls );

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -27,7 +27,42 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 		);
 	}
 
-	function get_widget_form(){
+	function get_widget_form() {
+		$controls = $this->control_form_fields();
+		siteorigin_widgets_array_insert(
+			$controls,
+			'nav_always_show_mobile',
+			array(
+				'unmute' => array(
+					'type' => 'checkbox',
+					'label' => __( 'Unmute button', 'so-widgets-bundle' ),
+					'description' => __( 'To allow for slide backgrounds to autoplay, videos must be muted by default. This button will allow users to unmute videos.', 'so-widgets-bundle' ),
+					'default' => false,
+					'state_emitter' => array(
+						'callback' => 'conditional',
+						'args' => array(
+							'unmute[show]: val',
+							'unmute[hide]: ! val'
+						),
+					),
+				),
+				'unmute_position' => array(
+					'type' => 'select',
+					'label' => __( 'Unmute button position', 'so-widgets-bundle' ),
+					'options' => array(
+						'top_right' => __( 'Top right', 'so-widgets-bundle' ),
+						'bottom_right' => __( 'Bottom right', 'so-widgets-bundle' ),
+						'bottom_left' => __( 'Bottom left', 'so-widgets-bundle' ),
+						'top_left' => __( 'Top left', 'so-widgets-bundle' ),
+					),
+					'state_handler' => array(
+						'unmute[show]' => array( 'show' ),
+						'unmute[hide]' => array( 'hide' ),
+					),
+				),
+			)
+		);
+
 		return array(
 			'frames' => array(
 				'type' => 'repeater',


### PR DESCRIPTION
This is an early draft PR that will resolve https://github.com/siteorigin/so-widgets-bundle/issues/1027

- Unmute position hasn't been implmented
- Unmute button currently not visible (last-minute change, replace `&nbsp;` with some text to see it).
- Icons haven't been made (they were going to be added last)
- YouTube Unmute/mute support is whitelisted.
- It may be worth adding these settings to all widgets rather than just the slider widget.