### PR TITLE
CSS Cache: Don't add page id to widgets in builders

### DIFF
--- a/base/inc/fields/builder.class.php
+++ b/base/inc/fields/builder.class.php
@@ -66,6 +66,13 @@ class SiteOrigin_Widget_Field_Builder extends SiteOrigin_Widget_Field_Base {
 			$value['widgets'] = siteorigin_panels_process_raw_widgets( $value['widgets'] );
 		}
 
+		// Add record of widget being inside of a builder field.
+		if ( ! empty( $value['widgets'] ) ) {
+			foreach( $value['widgets'] as $widget_id => $widget ) {
+				$value['widgets'][ $widget_id ]['panels_info']['builder'] = true;
+			}
+		}
+
 		return $value;
 	}
 

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -295,7 +295,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		if( !empty($style) ) {
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) && ! isset( $instance['panels_info']['builder'] ) ? '-' . get_the_id() : '' );
 
 			//Ensure styles aren't generated and enqueued more than once.
 			$in_preview = $this->is_preview( $instance ) || ( isset( $_POST['action'] ) &&  $_POST['action'] == 'so_widgets_preview' );
@@ -749,7 +749,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		$style = $this->get_style_name($instance);
 		$hash = $this->get_style_hash( $instance );
-		$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' ) . '.css';
+		$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) && ! isset( $instance['panels_info']['builder'] ) ? '-' . get_the_id() : '' ) . '.css';
 
 		$css = $this->get_instance_css($instance);
 
@@ -801,7 +801,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 			$style = $this->get_style_name($instance);
 			$hash = $this->get_style_hash( $instance );
-			$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
+			$name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) && ! isset( $instance['panels_info']['builder'] ) ? '-' . get_the_id() : '' );
 
 			$wp_filesystem->delete($upload_dir['basedir'] . '/siteorigin-widgets/' . $name . '.css');
 			if ( in_array( $name, $this->generated_css ) ) {
@@ -880,7 +880,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		if( ! empty( $less ) ) {
 			$style = $this->get_style_name( $instance );
 			$hash = $this->get_style_hash( $instance );
-			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) ? '-' . get_the_id() : '' );
+			$css_name = $this->id_base . '-' . $style . '-' . $hash . ( ! empty( $instance['panels_info'] ) && ! isset( $instance['panels_info']['builder'] ) ? '-' . get_the_id() : '' );
 
 			//we assume that any remaining @imports are plain css imports and should be kept outside selectors
 			$css_imports = '';


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1361
Layout Builder: https://github.com/siteorigin/siteorigin-panels/pull/905

This change was done to prevent Builder widgets in widget areas from generating a CSS file for every page. It will exclude non-widget area fields, but there's no way around that.

Pre-existing widgets with builder fields (eg. Accordion widget) will need to be saved to be excluded.