### PR TITLE
Anything Carousel: Don't escape before/after_title

### DIFF
--- a/base/inc/widgets/tpl/carousel.php
+++ b/base/inc/widgets/tpl/carousel.php
@@ -1,7 +1,7 @@
 <div class="sow-carousel-title<?php if ( ! empty( $settings['title'] ) ) echo ' has-title'; ?>">
 	<?php
 	if ( ! empty( $settings['title'] ) ) {
-		echo esc_attr( $args['before_title'] )  . esc_html( $settings['title'] )  . esc_attr( $args['after_title'] );
+		echo $args['before_title'] . esc_html( $settings['title'] ) . $args['after_title'];
 	}
 
 	if ( $settings['navigation'] == 'title' ) {


### PR DESCRIPTION
Escaping this here will only result in the HTML being output. The output itself doesn't need to be escaped as it's predefined elsewhere.