### PR TITLE
Video Player: sow_video_add_controls filter

### DIFF
--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -5,7 +5,6 @@
  * @var $player_id
  * @var $autoplay
  * @var $related_videos
- * @var $controls
  * @var $skin_class
  * @var $is_skinnable_video_host
  * @var $sources
@@ -53,7 +52,7 @@ do_action( 'siteorigin_widgets_sow-video_before_video', $instance );
 			<?php foreach ( $video_args as $k => $v ) : ?>
 				<?php echo $k . '="' . $v . '" '; ?>
 			<?php endforeach; ?>
-			<?php if ( ! empty( $controls ) ): ?>
+			<?php if ( apply_filters( 'sow_video_add_contorls', false ) ): ?>
 				<?php echo 'controls'; ?>
 			<?php endif; ?>
 		>

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -52,7 +52,7 @@ do_action( 'siteorigin_widgets_sow-video_before_video', $instance );
 			<?php foreach ( $video_args as $k => $v ) : ?>
 				<?php echo $k . '="' . $v . '" '; ?>
 			<?php endforeach; ?>
-			<?php if ( apply_filters( 'sow_video_add_contorls', false ) ): ?>
+			<?php if ( apply_filters( 'sow_video_add_controls', false ) ): ?>
 				<?php echo 'controls'; ?>
 			<?php endif; ?>
 		>

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -131,16 +131,6 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 							'video_type[self]'     => array( 'hide' ),
 						)
 					),
-					'controls' => array(
-						'type'          => 'checkbox',
-						'default'       => false,
-						'label'         => __( 'Controls', 'so-widgets-bundle' ),
-						'description'   => __( 'Enable browser video controls.', 'so-widgets-bundle' ),
-						'state_handler' => array(
-							'video_type[self]'     => array( 'show' ),
-							'video_type[external]' => array( 'hide' ),
-						)
-					),
 				),
 			),
 		);
@@ -238,7 +228,6 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'autoplay'                => ! empty( $instance['playback']['autoplay'] ),
 			'loop'                    => ! empty( $instance['playback']['loop'] ),
 			'related_videos'          => ! empty( $instance['playback']['related_videos'] ),
-			'controls'                => ! empty( $instance['playback']['controls'] ),
 			'skin_class'              => 'default',
 			'fitvids'                 => ! empty( $instance['playback']['fitvids'] ),
 		);


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1368

This PR removes the Video Player Controls setting in favour of a filter.

To test this filter:

- Add a SiteOrigin Video Player widget.
- Add a local self hosted video.
- Use widget preview. Note no controls.
- Add the following code snippet:

`add_filter( 'sow_video_add_controls', '__return_true' );`
- Preview widget again and note controls.