### PR TITLE
Preset: Always Remove Default if default-preset is set

### DIFF
--- a/base/inc/fields/js/presets-field.js
+++ b/base/inc/fields/js/presets-field.js
@@ -63,12 +63,15 @@
 			}
 		} );
 
-		// If no value is selected, and there's a default preset, load it.
-		if ( $presetSelect.val() == 'default' && $presetSelect.data( 'default-preset' ) != '' ) {
+		if ( $presetSelect.data( 'default-preset' ) != '' ) {
+			// There's a default preset set, remove the empty default.
 			$( this ).find( 'select[class="siteorigin-widget-input"] option[value="default"]' ).remove();
-			addingDefault = true;
-			$presetSelect.val( $presetSelect.data( 'default-preset' ) );
-			$presetSelect.trigger( 'change' );
+			// If no value is selected, and there's a default preset, load it.
+			if ( $presetSelect.val() == 'default' ) {
+				addingDefault = true;
+				$presetSelect.val( $presetSelect.data( 'default-preset' ) );
+				$presetSelect.trigger( 'change' );
+			}
 		}
 
 		$presetSelect.data( 'initialized', true );


### PR DESCRIPTION
This PR will always remove the default placeholder field if `default-preset` is set.

You can test this PR using https://github.com/siteorigin/so-widgets-bundle/pull/1359
- Add a Blog widget.
- Save and reload.
- Open Blog widget and note that there's an empty option in the Template (presets) option.
- Add the changes in this PR to that branch and refresh the page again.
- Open the Blog widget and note that there's no longer an empty field in the Template (presets) option.

![2021-07-19_18-24-39-1532](https://user-images.githubusercontent.com/17275120/126128263-25897a15-b10a-4621-aa5b-77b96b27273c.jpg)
