### PR TITLE
Image Size Adjustments

### DIFF
--- a/base/inc/fields/css/image-size-field.less
+++ b/base/inc/fields/css/image-size-field.less
@@ -7,6 +7,10 @@
 		label {
 			font-weight: bold;
 			font-size: 13px;
+
+			&:last-of-type {
+				margin-left: 15px;
+			}
 		}
 
 		.siteorigin-widget-input {

--- a/base/inc/fields/css/image-size-field.less
+++ b/base/inc/fields/css/image-size-field.less
@@ -9,7 +9,7 @@
 			font-size: 13px;
 
 			&:last-of-type {
-				margin-left: 15px;
+				margin-left: 12px;
 			}
 		}
 

--- a/base/inc/fields/css/image-size-field.less
+++ b/base/inc/fields/css/image-size-field.less
@@ -1,5 +1,5 @@
 
-.siteorigin-widget-form .siteorigin-widget-field-size {
+.siteorigin-widget-form .siteorigin-widget-field-type-image-size {
 	
 	.custom-size-wrapper {
 		margin-top: 15px;

--- a/base/inc/fields/image-size.class.php
+++ b/base/inc/fields/image-size.class.php
@@ -57,14 +57,14 @@ class SiteOrigin_Widget_Field_Image_Size extends SiteOrigin_Widget_Field_Select 
 					<?php _e( 'Width', 'so-widgets-bundle' ); ?>
 					<input type="number" value="<?php echo esc_attr( $width ); ?>"
 						name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_width', $this->parent_container ) ); ?>"
-						class="custom-size-width siteorigin-widget-input" />
+						class="custom-image-size custom-image-size-width siteorigin-widget-input" />
 				</label>
 
 				<label>
 					<?php _e( 'Height', 'so-widgets-bundle' ); ?>
 					<input type="number" value="<?php echo esc_attr( $height ); ?>"
 						name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_height', $this->parent_container ) ); ?>"
-						class="custom-size-height siteorigin-widget-input" />
+						class="custom-image-size custom-image-size-height siteorigin-widget-input" />
 				</label>
 			</div>
 			<?php

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -514,7 +514,7 @@ var sowbForms = window.sowbForms || {};
 
 			$fields.filter('[data-state-emitter]').each(function () {
 				
-				var $input = $( this ).find( '.siteorigin-widget-input' );
+				var $input = $( this ).find( '.siteorigin-widget-input:not(.custom-image-size)' );
 				
 				// Listen for any change events on an emitter field
 				$input.on('keyup change', stateEmitterChangeHandler);


### PR DESCRIPTION
This PR fixes the selector was previously specific to a field called "size" rather than all image size fields. This resulted in the field being unstyled. Test this using https://github.com/siteorigin/so-widgets-bundle/pull/1371

![Screenshot 2021-07-20 at 01-55-51 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/126189920-8a3a2d9b-0790-4418-9bf4-a173c7a2b710.png)

This PR also adds spacing between the dimensions:

![Screenshot 2021-07-24 at 01-57-34 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/126809215-33afb61a-c89e-47ae-ae2c-bd4f13d03c1f.png)

This PR also excludes the custom image sizes dimension fields from state emitters to prevent a situation where they'll unintentionally result in state changes. You can test this using https://github.com/siteorigin/so-widgets-bundle/pull/1371.
