### PR TITLE
Carousel Responsive Fix

### DIFF
--- a/js/lib/slick.js
+++ b/js/lib/slick.js
@@ -1861,7 +1861,7 @@
         var _ = this, breakpoint, currentBreakpoint, l,
             responsiveSettings = _.options.responsive || null;
 
-        if ( typeof responsiveSettings === 'array' && responsiveSettings.length ) {
+        if ( responsiveSettings.length ) {
 
             _.respondTo = _.options.respondTo || 'window';
 


### PR DESCRIPTION
This PR implements https://github.com/siteorigin/slick/pull/1/commits/db32990c3cec28cf701d148be874e60dcd55e0e3 to resolve an issue with the carousel widgets not being responsive. 