### PR TITLE
5.8 Widgets: Fix Alignment of Links Button

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -867,6 +867,9 @@ div.siteorigin-widget-form {
 			}
 		}
 
+		div.siteorigin-widget-field.siteorigin-widget-field-type-link .select-content-button {
+			line-height: 28px;
+		}
 
 		a.siteorigin-widget-help-link,
 		div.siteorigin-widget-form .siteorigin-widget-form-notification a,


### PR DESCRIPTION
This PR fixes the alignment of the "select content" button in the Links field.

![2021-07-21_02-12-55-1534](https://user-images.githubusercontent.com/17275120/126359519-6b538c0d-bb92-47b0-bc2f-fa5bb88dcbc6.jpg)
