### PR TITLE
5.8 Widgets: Widget Preview Button Text

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -868,6 +868,7 @@ div.siteorigin-widget-form {
 		}
 
 
+		a.siteorigin-widget-preview-button.button-secondary,
 		a.siteorigin-widget-help-link,
 		div.siteorigin-widget-form .siteorigin-widget-form-notification a,
 		div.siteorigin-widget-form a {


### PR DESCRIPTION
This PR corrects the font of the widget preview button in the 5.8 Widget Area.

![2021-07-21_02-37-11-1535](https://user-images.githubusercontent.com/17275120/126362663-5d882443-4275-4557-b0e0-341130504327.jpg)
