### PR TITLE
SO Widgets Block: 5.8 Widgets Area Notice Fix

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -24,10 +24,19 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 	}
 
 	public function enqueue_widget_block_editor_assets() {
+		$current_screen = get_current_screen();
 		wp_enqueue_script(
 			'sowb-widget-block',
 			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.js', __FILE__ ),
-			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose' ),
+			array(
+				// The WP 5.8 Widget Area requires a speciic editor script to be used.
+				$current_screen->base == 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
+				'wp-blocks',
+				'wp-i18n',
+				'wp-element',
+				'wp-components',
+				'wp-compose'
+			),
 			SOW_BUNDLE_VERSION
 		);
 

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -29,7 +29,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			'sowb-widget-block',
 			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.js', __FILE__ ),
 			array(
-				// The WP 5.8 Widget Area requires a speciic editor script to be used.
+				// The WP 5.8 Widget Area requires a specific editor script to be used.
 				$current_screen->base == 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
 				'wp-blocks',
 				'wp-i18n',


### PR DESCRIPTION
To test this PR please open the 5.8 widget area while WP_DEBUG_LOG is enabled.

`( ! ) Notice: wp_enqueue_script() was called <strong>incorrectly</strong>. "wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets). Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.8.0.) in C:\Users\Alex\Documents\local-sites\wp-nightly\app\public\wp-includes\functions.php on line 5535`