### PR TITLE
Measurement: Increase Spacing After Input

### DIFF
--- a/base/inc/fields/css/measurement-field.less
+++ b/base/inc/fields/css/measurement-field.less
@@ -2,7 +2,7 @@ div.siteorigin-widget-form div.siteorigin-widget-field.siteorigin-widget-field {
 	input[type="text"].siteorigin-widget-input-measurement {
 		float: left;
 		max-width: 58px;
-		margin-right: 1px;
+		margin-right: 5px;
 		min-height: 30px;
 		vertical-align: middle;
 		padding: 0 8px;


### PR DESCRIPTION
This PR increases the spacing after the measurement field input. It's now in line with the multi-measurement field spacing.

![2021-07-21_03-26-56-1537](https://user-images.githubusercontent.com/17275120/126368831-f34402a4-6ba1-4a8f-87ac-3de154316404.jpg)
