### PR TITLE
Remove WB form min-width

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -50,12 +50,6 @@ div.siteorigin-widget-form {
 	display: block !important;
 	margin: 15px 0;
 
-	@media (min-width: 680px) {
-		&.siteorigin-widget-form-main {
-			min-width: 600px;
-		}
-	}
-
 	div.siteorigin-widget-field {
 		margin: 1em 0;
 


### PR DESCRIPTION
This is a follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1088. That PR attempted to get around the potential situation where fields would be larger than 600px but it doesn't work if something makes the widget area smaller - this is what happens when you open the search field in the 5.8 widget area but it's not specific to that interface.

![2021-07-21_03-44-51-1538](https://user-images.githubusercontent.com/17275120/126371016-be6750ea-abf7-47ce-9c92-7b7ab596edb5.jpg)

I found no negative results by completely removing the min-width. It's possible there could be some so please test any situation you can think of.