### PR TITLE
Carousel Responsive Navigation Setting

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -66,6 +66,12 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'tablet_portrait' => 2,
 					'mobile' => 1,
 				),
+				'navigation' => array(
+					'desktop' => true,
+					'tablet_landscape' => true,
+					'tablet_portrait' => true,
+					'mobile' => true,
+				),
 				'slides_to_scroll_text' => array(
 					'label' => __( 'Slides to scroll', 'so-widgets-bundle' ),
 					'description' => __( 'Set the number of slides to scroll per navigation click or swipe on %s', 'so-widgets-bundle' ),
@@ -97,21 +103,29 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 				$section['fields'][ $sub_field_key ] = $this->add_section_group( $sub_field, $value_type );
 			}
 		} else {
-			$section['fields']['slides_to_scroll'] =  array(
+			if ( isset( $field['breakpoint'] ) ) {
+				$section['fields']['breakpoint'] = array(
+					'type' => 'number',
+					'label' => __( 'Breakpoint', 'so-widgets-bundle' ),
+					$value_type => $field['breakpoint'],
+				);
+			}
+
+			$section['fields']['slides_to_scroll'] = array(
 				'type' => 'number',
 				'label' => $carousel_settings['slides_to_scroll_text']['label'],
 				'description' => sprintf(
 					$carousel_settings['slides_to_scroll_text']['description'],
 					strtolower( $field['label'] )
 				),
-				$value_type => $field['value'],
+				$value_type => $field['slides_to_scroll'],
 			);
 
-			if ( isset( $field['breakpoint'] ) ) {
-				$section['fields']['breakpoint'] = array(
-					'type' => 'number',
-					'label' => __( 'Breakpoint', 'so-widgets-bundle' ),
-					$value_type => $field['breakpoint'],
+			if ( isset( $field['navigation'] ) ) {
+				$section['fields']['navigation'] = array(
+					'type' => 'checkbox',
+					'label' => __( 'Show navigation', 'so-widgets-bundle' ),
+					'default' => $field['navigation'],
 				);
 			}
 		}
@@ -129,7 +143,8 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 		$fields = array(
 			'desktop' => array(
 				'label' => __( 'Desktop', 'so-widgets-bundle' ),
-				'value' => $carousel_settings['slides_to_scroll']['desktop'],
+				'slides_to_scroll' => $carousel_settings['slides_to_scroll']['desktop'],
+				'navigation' => $carousel_settings['navigation']['desktop'],
 			),
 			'tablet' => array(
 				'label' => __( 'Tablet', 'so-widgets-bundle' ),
@@ -137,19 +152,22 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'landscape' => array(
 						'label' => __( 'Landscape', 'so-widgets-bundle' ),
 						'breakpoint' => $carousel_settings['breakpoints']['tablet_landscape'],
-						'value' => $carousel_settings['slides_to_scroll']['tablet_landscape'],
+						'slides_to_scroll' => $carousel_settings['slides_to_scroll']['tablet_landscape'],
+						'navigation' => $carousel_settings['navigation']['tablet_landscape'],
 					),
 					'portrait' => array(
 						'label' => __( 'Portrait', 'so-widgets-bundle' ),
 						'breakpoint' => $carousel_settings['breakpoints']['tablet_portrait'],
-						'value' => $carousel_settings['slides_to_scroll']['tablet_portrait'],
+						'slides_to_scroll' => $carousel_settings['slides_to_scroll']['tablet_portrait'],
+						'navigation' => $carousel_settings['navigation']['tablet_portrait'],
 					),
 				),
 			),
 			'mobile' => array(
 				'label' => __( 'Mobile', 'so-widgets-bundle' ),
 				'breakpoint' => $carousel_settings['breakpoints']['mobile'],
-				'value' => $carousel_settings['slides_to_scroll']['mobile'],
+				'slides_to_scroll' => $carousel_settings['slides_to_scroll']['mobile'],
+				'navigation' => $carousel_settings['navigation']['mobile'],
 			),
 		);
 
@@ -192,7 +210,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'label' => __( 'Autoplay', 'so-widgets-bundle' ),
 					'state_emitter' => array(
 						'callback' => 'conditional',
-						'args'     => array(
+						'args' => array(
 							'autoplay[show]: val',
 							'autoplay[hide]: ! val',
 						),
@@ -240,6 +258,22 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 		);
 
 		return $encode ? json_encode( $variables ) : $variables;
+	}
+
+	function responsive_less_variables( $less_vars, $instance ) {
+		$carousel_settings = $this->get_carousel_settings();
+		// Breakpoint
+		$less_vars['breakpoint_tablet_landscape'] = ( ! empty( $instance['responsive']['tablet_landscape']['breakpoint'] ) ? $instance['responsive']['tablet_landscape']['breakpoint'] : $carousel_settings['breakpoints']['tablet_landscape'] ) .'px';
+		$less_vars['breakpoint_tablet_portrait'] = ( ! empty( $instance['responsive']['tablet_portrait']['breakpoint'] ) ? $instance['responsive']['tablet_portrait']['breakpoint'] : $carousel_settings['breakpoints']['tablet_portrait'] ) .'px';
+		$less_vars['breakpoint_mobile'] = ( ! empty( $instance['responsive']['mobile']['breakpoint'] ) ? $instance['responsive']['mobile']['breakpoint'] : $carousel_settings['breakpoints']['mobile'] ) .'px';
+
+		// Navigation
+		$less_vars['navigation_desktop'] = isset( $instance['responsive']['desktop']['navigation'] ) ? ! empty( $instance['responsive']['desktop']['navigation'] ) : $carousel_settings['navigation']['desktop'];
+		$less_vars['navigation_tablet_landscape'] = isset( $instance['responsive']['tablet']['landscape']['navigation'] ) ? ! empty( $instance['responsive']['tablet']['landscape']['navigation'] ) : $carousel_settings['navigation']['tablet_landscape'];
+		$less_vars['navigation_tablet_portrait'] = isset( $instance['responsive']['tablet']['portrait']['navigation'] ) ? ! empty( $instance['responsive']['tablet']['portrait']['navigation'] ) : $carousel_settings['navigation']['tablet_portrait'];
+		$less_vars['navigation_mobile'] = isset( $instance['responsive']['mobile']['navigation'] ) ? ! empty( $instance['responsive']['mobile']['navigation'] ) : $carousel_settings['navigation']['mobile'];
+
+		return $less_vars;
 	}
 
 	function carousel_settings_template_variables( $settings, $encode = true ) {

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -248,6 +248,8 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 			$less_vars['item_font_weight'] = $item_font['weight_raw'];
 		}
 
+		$less_vars = $this->responsive_less_variables( $less_vars, $instance );
+
 		return $less_vars;
 	}
 

--- a/widgets/anything-carousel/styles/base.less
+++ b/widgets/anything-carousel/styles/base.less
@@ -21,6 +21,14 @@
 @navigation_dots_color: #bebebe;
 @navigation_dots_color_hover: #f14e4e;
 
+@breakpoint_tablet_landscape: default;
+@breakpoint_tablet_portrait: default;
+@breakpoint_mobile: default;
+@navigation_desktop: default;
+@navigation_tablet_landscape: default;
+@navigation_tablet_portrait: default;
+@navigation_mobile: default;
+
 .sow-carousel-container {
 	a.sow-carousel-next {
 		margin-left: @navigation_arrow_margin;
@@ -55,6 +63,31 @@
 		&:hover {
 			color: @navigation_arrow_color_hover;
 			border-color: @navigation_arrow_color_hover;
+		}
+
+
+		& when not ( isnumber( @navigation_desktop ) ) {
+			@media (min-width: @breakpoint_tablet_landscape) {
+				display: none;
+			}
+		}
+
+		& when not ( isnumber( @navigation_tablet_landscape ) ) {
+			@media (min-width: @breakpoint_tablet_portrait) and (max-width: @breakpoint_tablet_landscape) {
+				display: none;
+			}
+		}
+
+		& when not ( isnumber( @navigation_tablet_portrait ) ) {
+			@media (min-width: @breakpoint_mobile) and (max-width: @breakpoint_tablet_portrait) {
+				display: none;
+			}
+		}
+
+		& when not ( isnumber(  @navigation_mobile ) ) {
+			@media (max-width: @breakpoint_mobile) {
+				display: none;
+			}
 		}
 	}
 

--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -94,16 +94,6 @@
 			text-decoration: none;
 			text-transform: none;
 			width: 18px;
-
-			@media screen and (max-width: 600px) {
-				a.sow-carousel-previous {
-					display: none;
-				}
-
-				a.sow-carousel-next {
-					display: none;
-				}
-			}
 		}
 
 		a.sow-carousel-previous:before {

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -150,6 +150,12 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 				'tablet_portrait' => 2,
 				'mobile' => 1,
 			),
+			'navigation' => array(
+				'desktop' => true,
+				'tablet_landscape' => true,
+				'tablet_portrait' => true,
+				'mobile' => false,
+			),
 		);
 	}
 
@@ -263,8 +269,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 			$thumb_hover_width = $size['width'];
 			$thumb_hover_height = $size['height'];
 		}
-
-		return array(
+		$less_vars = array(
 			'thumbnail_width' => $thumb_width . 'px',
 			'thumbnail_height'=> $thumb_height . 'px',
 			'thumbnail_hover_width' => $thumb_hover_width . 'px',
@@ -276,6 +281,9 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 			'navigation_background' => ! empty ( $instance['design']['navigation_background'] ) ? $instance['design']['navigation_background'] : '',
 			'navigation_hover_background' => ! empty ( $instance['design']['navigation_hover_background'] ) ? $instance['design']['navigation_hover_background'] : '',
 		);
+		$less_vars = $this->responsive_less_variables( $less_vars, $instance );
+
+		return $less_vars;
 	}
 
 	public function get_template_variables( $instance, $args ) {

--- a/widgets/post-carousel/styles/default.less
+++ b/widgets/post-carousel/styles/default.less
@@ -11,6 +11,14 @@
 @navigation_background: #333;
 @navigation_hover_background: #444;
 
+@breakpoint_tablet_landscape: default;
+@breakpoint_tablet_portrait: default;
+@breakpoint_mobile: default;
+@navigation_desktop: default;
+@navigation_tablet_landscape: default;
+@navigation_tablet_portrait: default;
+@navigation_mobile: default;
+
 .sow-carousel-title {
 
   a.sow-carousel-next,
@@ -22,6 +30,30 @@
     &:hover {
       background: @navigation_hover_background;
       color: @navigation_color_hover;
+    }
+
+    & when not ( isnumber( @navigation_desktop ) ) {
+      @media (min-width: @breakpoint_tablet_landscape) {
+        display: none;
+      }
+    }
+
+    & when not ( isnumber( @navigation_tablet_landscape ) ) {
+      @media (min-width: @breakpoint_tablet_portrait) and (max-width: @breakpoint_tablet_landscape) {
+        display: none;
+      }
+    }
+
+    & when not ( isnumber( @navigation_tablet_portrait ) ) {
+      @media (min-width: @breakpoint_mobile) and (max-width: @breakpoint_tablet_portrait) {
+        display: none;
+      }
+    }
+
+    & when not ( isnumber(  @navigation_mobile ) ) {
+      @media (max-width: @breakpoint_mobile) {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
This PR allows you to control on what devices the navigation will appear on. It affects both the Anything Carousel and Post Carousel. By default, the navigation is enabled for everything but the Post Carousel on Mobile - this is due to legacy reasons.

This PR also moves the Breakpoint setting above the Slides to Scroll setting.