### PR TITLE
Anything Carousel Adjustments

### DIFF
--- a/widgets/anything-carousel/css/style.less
+++ b/widgets/anything-carousel/css/style.less
@@ -121,8 +121,14 @@
 						}
 					}
 
-					&.slick-active button:before {
-						opacity: 1;
+					&.slick-active button {
+						&:before {
+							opacity: 1;
+						}
+						
+						&:hover {
+							cursor: default;
+						}
 					}
 				}
 			}

--- a/widgets/anything-carousel/css/style.less
+++ b/widgets/anything-carousel/css/style.less
@@ -60,6 +60,7 @@
 			overflow: hidden;
 			position: relative;
 			right: 0;
+			width: 100%;
 
 			.sow-carousel-items {
 				.clearfix();

--- a/widgets/anything-carousel/styles/base.less
+++ b/widgets/anything-carousel/styles/base.less
@@ -43,7 +43,7 @@
 		align-items: center;
 		border-radius: 16px;
 		border: 1px solid @navigation_arrow_color;
-		color: @navigation_arrow_color;
+		color: @navigation_arrow_color !important;
 		display: flex;
 		font-size: 14px;
 		height: 32px;
@@ -53,7 +53,7 @@
 
 		&:focus,
 		&:hover {
-			color: @navigation_arrow_color_hover;
+			color: @navigation_arrow_color_hover !important;
 			border-color: @navigation_arrow_color_hover;
 		}
 	}


### PR DESCRIPTION
This PR includes a number of changes to the Anything Carousel Widget.

**Set Wrapper Full Width To Avoid Sizing Issue**
This PR resolves an issue where having fewer items than your slides to scroll setting will result in the carousel items that are present not being sized correctly. To test this, add a single carousel item with placeholder content and then preview the widget.

![2021-07-27_05-08-58-1543](https://user-images.githubusercontent.com/17275120/127044912-74309aa0-8e3e-41e3-b572-a9f2a3468324.jpg)

**Prevent Link Color From Overriding Nav Arrows**
The PB Link Color setting is overriding the Nav Arrow color. This PR prevents that by using by forcing the colors using `!important`. 

**![2021-07-27_04-56-30-1542](https://user-images.githubusercontent.com/17275120/127044705-ca49e89e-471e-408e-bd92-6a13aedf8b03.jpg)**

**Prevent Active Dot Pointer Cursor** 
This PR resets the cursor when hovering over the active navigation dot. This will prevent it from looking as though clicking the active item does anything.