### PR TITLE
New Widget Area: Preview line-height fix

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -877,5 +877,9 @@ div.siteorigin-widget-form {
 				color: #0a4b78;
 			}
 		}
+
+		a.siteorigin-widget-preview-button.button-secondary {
+			line-height: 2.15384615;
+		}
 	}
 }


### PR DESCRIPTION
This PR will correct the Preview Button line-height.
<img width="1425" alt="widget-area-btn-preview" src="https://user-images.githubusercontent.com/17275120/129481982-92e77a25-5e4f-4984-9041-4428536a33ad.png">
