### PR TITLE
Multiple Media: Repeater Support

### DIFF
--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -5,10 +5,17 @@
 	$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-multiple_media', function( e ) {
 		var $field = $( this ),
 			$data = $field.find( '.siteorigin-widget-input' ),
-			selectedMedia = $data.val().split( ',' );
+			selectedMedia = $data.val().split( ',' ),
+			repeater = $data.data( 'repeater' )
 
 		if ( $field.data( 'initialized' ) ) {
 			return;
+		}
+
+		if ( repeater ) {
+			// This field is used to bulk add repeater items.
+			repeater.field = $field.siblings( '.siteorigin-widget-field-' + repeater.field ).find( ' > .siteorigin-widget-field-repeater' );
+			repeater.addBtn = repeater.field.find( '> .siteorigin-widget-field-repeater-add' );
 		}
 
 		// Handle the media uploader
@@ -40,16 +47,18 @@
 				}
 			} );
 
-			// If there's a selected image, highlight it. 
-			frame.on( 'open', function() {
-				if ( selectedMedia.length ) {
-					var selection = frame.state().get( 'selection' );
+			// If there's images selected, highlight them.
+			if ( ! repeater ) {
+				frame.on( 'open', function() {
+					if ( selectedMedia.length ) {
+						var selection = frame.state().get( 'selection' );
 
-					$.each( selectedMedia, function() {
-					    selection.add( wp.media.attachment( this ) );
-					} );
-				}
-			} );
+						$.each( selectedMedia, function() {
+						    selection.add( wp.media.attachment( this ) );
+						} );
+					}
+				} );
+			}
 
 			// Store the frame
 			$$.data( 'frame', frame );
@@ -60,35 +69,52 @@
 					attachment,
 					attachmentUrl,
 					$currentItem,
-					$thumbnail;
+					$thumbnail,
+					$inputField;
 
 				$.each( frame.state().get( 'selection' ).models, function() {
 					attachment = this.attributes;
+					if ( repeater ) {
+						// Add new item
+						repeater.addBtn.trigger( 'click' );
+						// Find image setting and set it.
+						$currentItem = repeater.field.find( '> .siteorigin-widget-field-repeater-items > .siteorigin-widget-field-repeater-item:last-of-type > .siteorigin-widget-field-repeater-item-form > .siteorigin-widget-field-' + repeater.setting );
+						$inputField = $currentItem.find( '.siteorigin-widget-input' ).not( '.media-fallback-external' );
+						$inputField.val( attachment.id );
 
-					// Don't process images that already exist.
-					if ( selectedMedia.indexOf( attachment.id.toString() ) == -1 ) {
-						$field.find( '.multiple-media-field-template .multiple-media-field-item' ).clone().appendTo( $field.find( '.multiple-media-field-items' ) );
-						$currentItem = $field.find( '.multiple-media-field-items .multiple-media-field-item' ).last();
-
-						$thumbnail = $currentItem.find( '.thumbnail' );
-						$thumbnail.attr( 'title', attachment.title );
-						$currentItem.find( '.title' ).text( attachment.title );
-
-						$currentItem.attr( 'data-id', attachment.id );
-
-						if ( typeof attachment.sizes !== 'undefined' ) {
-							if ( typeof attachment.sizes.thumbnail !== 'undefined' ) {
-								attachmentUrl = attachment.sizes.thumbnail.url;
-							} else {
-								attachmentUrl = attachment.sizes.full.url;
-							}
-						} else{
-							attachmentUrl = attachment.icon;
+						// We need to manually set the thumbnail to show as the field won't.
+						$currentItem.find( '.thumbnail' ).show();
+					} else {
+						attachmentIds.push( attachment.id );
+						// Don't process images that already exist.
+						if ( selectedMedia.indexOf( attachment.id.toString() ) == -1 ) {
+							$field.find( '.multiple-media-field-template .multiple-media-field-item' ).clone().appendTo( $field.find( '.multiple-media-field-items' ) );
+							$currentItem = $field.find( '.multiple-media-field-items .multiple-media-field-item' ).last();
+							$currentItem.attr( 'data-id', attachment.id );
+						} else {
+							return;
 						}
-						$thumbnail.attr( 'src', attachmentUrl );
 					}
 
-					attachmentIds.push( attachment.id );
+					// Display thumbnail.
+					$thumbnail = $currentItem.find( '.thumbnail' );
+					$thumbnail.attr( 'title', attachment.title );
+					$currentItem.find( '.title' ).html( attachment.title );
+					if ( typeof attachment.sizes !== 'undefined' ) {
+						if ( typeof attachment.sizes.thumbnail !== 'undefined' ) {
+							attachmentUrl = attachment.sizes.thumbnail.url;
+						} else {
+							attachmentUrl = attachment.sizes.full.url;
+						}
+					} else{
+						attachmentUrl = attachment.icon;
+					}
+					$thumbnail.attr( 'src', attachmentUrl );
+
+					if ( repeater ) {
+						// This is required to ensure state emitter titles are updated.
+						$inputField.trigger( 'change', { silent: true } );
+					}
 				} );
 
 				// Remove any no longer selected images
@@ -114,15 +140,17 @@
 			frame.open();
 		});
 
-		$( document ).on( 'click','.siteorigin-widget-field-type-multiple_media a.media-remove-button', function( e ) {
-			e.preventDefault();
-			var $currentItem = $( this ).parent();
+		if ( ! repeater ) {
+			$( document ).on( 'click','.siteorigin-widget-field-type-multiple_media a.media-remove-button', function( e ) {
+				e.preventDefault();
+				var $currentItem = $( this ).parent();
 
-			selectedMedia.splice( selectedMedia.indexOf( $currentItem.data( 'id' ) ) );
-			$data.val( selectedMedia.join( ',' ) );
+				selectedMedia.splice( selectedMedia.indexOf( $currentItem.data( 'id' ) ) );
+				$data.val( selectedMedia.join( ',' ) );
 
-			$currentItem.remove();
-		} );
+				$currentItem.remove();
+			} );
+		}
 
 		$field.data( 'initialized', true );
 	} );

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -47,6 +47,15 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 	 */
 	protected $thumbnail_dimensions;
 
+	/**
+	 * An optional array containing information about a repeater field. This will
+	 * allow for the multiple media field to add items to the repeater.
+	 *
+	 * @access protected
+	 * @var array
+	 */
+	protected $repeater;
+
 	static $default_thumbnail_dimensions = array( 64, 64 ); 
 
 	protected function get_default_options() {
@@ -88,50 +97,60 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 				<?php echo esc_html( $this->choose ); ?>
 			</a>
 
-
-			<div class="multiple-media-field-items">
-				<?php
-				if ( is_array( $attachments ) ) {
-					foreach ( $attachments as $attachment ) {
-						$item_title = get_the_title( $attachment );
-						$src = wp_get_attachment_image_src( $attachment, 'thumbnail' );
-
-						if ( empty( $src ) ) {
-							// If item doesn't have an image src, use the WP icon for its media type.
-							$src = wp_mime_type_icon( $attachment );
-						} else {
-							$src = $src[0];
-						}
-						?>
-						<div class="multiple-media-field-item" data-id="<?php echo esc_attr( $attachment ); ?>">
-							<?php if ( ! empty( $src ) ) : ?>
-								<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $item_title ); ?>" width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
-							<?php endif; ?>
-							<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
-							<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>">
-								<?php
-								if ( ! empty( $item_title ) ) {
-									echo esc_attr( $item_title );
-								}
-								?>		
-							</div>
-						</div>
+			<?php if ( empty( $this->repeater ) ) : ?>
+				<div class="multiple-media-field-items">
 					<?php
+					if ( is_array( $attachments ) ) {
+						foreach ( $attachments as $attachment ) {
+							$item_title = get_the_title( $attachment );
+							$src = wp_get_attachment_image_src( $attachment, 'thumbnail' );
+
+							if ( empty( $src ) ) {
+								// If item doesn't have an image src, use the WP icon for its media type.
+								$src = wp_mime_type_icon( $attachment );
+							} else {
+								$src = $src[0];
+							}
+							?>
+							<div class="multiple-media-field-item current" data-id="<?php echo esc_attr( $attachment ); ?>">
+								<?php if ( ! empty( $src ) ) : ?>
+									<img src="<?php echo sow_esc_url( $src ); ?>" class="thumbnail" title="<?php echo esc_attr( $item_title ); ?>" width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
+								<?php endif; ?>
+								<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
+								<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>">
+									<?php
+									if ( ! empty( $item_title ) ) {
+										echo esc_attr( $item_title );
+									}
+									?>		
+								</div>
+							</div>
+						<?php
+						}
 					}
-				}
-				?>
-			</div>
-			
-			<div class="multiple-media-field-template" style="display:none">
-				<div class="multiple-media-field-item">
-					<img class="thumbnail"  width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
-					<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
-					<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>"></div>
+					?>
 				</div>
+				
+				<div class="multiple-media-field-template" style="display:none">
+					<div class="multiple-media-field-item current">
+						<img class="thumbnail"  width="<?php echo $this->thumbnail_dimensions[0]; ?>" height="<?php echo $this->thumbnail_dimensions[1]; ?>"/>
+						<a href="#" class="media-remove-button"><?php esc_html_e( 'Remove', 'so-widgets-bundle' ); ?></a>
+						<div class="title <?php echo (bool) $this->title ? 'title-enabled" style="width: ' . $this->thumbnail_dimensions[0] . 'px' : ''; ?>"></div>
+					</div>
 
-			</div>
+				</div>
+			<?php endif; ?>
 
-			<input type="hidden" value="<?php echo is_array( $attachments ) ? esc_attr( implode( ',', $attachments ) ) : ''; ?>" data-element="<?php echo esc_attr( $this->element_name ); ?>" name="<?php echo esc_attr( $this->element_name ); ?>" class="siteorigin-widget-input" />
+			<input
+				type="hidden"
+				value="<?php echo is_array( $attachments ) ? esc_attr( implode( ',', $attachments ) ) : ''; ?>"
+				data-element="<?php echo esc_attr( $this->element_name ); ?>"
+				name="<?php echo esc_attr( $this->element_name ); ?>"
+				<?php if ( ! empty( $this->repeater ) ) : ?>
+					data-repeater="<?php echo esc_attr( json_encode( $this->repeater ) ); ?>"
+				<?php endif; ?>
+				class="siteorigin-widget-input"
+			/>
 		</div>
 
 		<?php


### PR DESCRIPTION
This PR allows for the multiple media field to be directly connected to a repeater field and used as a method of adding bulk adding images.  This is done by setting the repeater parameter and listing the field and setting add the image data to. This looks like this:

```

'bulk_add' => array(
	'type' => 'multiple_media',
	'library' => 'all',
	'label' => __( 'Multiple Media Repeater', 'so-widgets-test' ),
	'repeater' => array(
		'field' => $field, // repeater name
		'setting' => $setting, // The name of the media field inside of the repeater
	),
),
```

[Here's a test plugin](url). Once installed, navigate to **Plugins > SiteOrigin Widgets** and activate **SiteOrigin Multiple Media Repeater**.