### PR TITLE
get_video_oembed: Mute YouTube videos set to autoplay

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -75,7 +75,7 @@ class SiteOrigin_Video {
 					'remove_related_videos'
 				), $html );
 			}
-			
+
 			if ( ! empty( $html ) ) {
 				set_transient( 'sow-vid-embed[' . $hash . ']', $html, 30 * 86400 );
 			}
@@ -92,7 +92,17 @@ class SiteOrigin_Video {
 	 * @return mixed
 	 */
 	function autoplay_callback( $match ) {
-		return str_replace( $match[1], add_query_arg( 'autoplay', 1, $match[1] ), $match[0] );
+		return str_replace(
+			$match[1],
+			add_query_arg(
+				array(
+					'autoplay' => 1,
+					'mute' => 1,
+				),
+				$match[1]
+			),
+			$match[0]
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR will ensure that videos added using `get_video_oembed` (ie. SiteOrigin Slider Background Video) are automatically muted when autoplay is enabled. This is required for the video to autoplay in Chrome.