### PR TITLE
Video Player External Video: Resolve MeidaElements issue

### DIFF
--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -225,6 +225,14 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			$video_host          = $this->get_host_from_url( $instance['video']['external_video'] );
 			$external_video_type = 'video/' . $video_host;
 			$external_src        = ! empty( $instance['video']['external_video'] ) ? $instance['video']['external_video'] : '';
+
+			if ( ! $instance['playback']['oembed'] ) {
+				// Add video as self_source to allow MediaElements to pick up on it.
+				$self_sources[] = array(
+					'src' => $external_src,
+					'type' => 'mp4',
+				);
+			}
 		}
 
 		$return = array(
@@ -243,8 +251,8 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'fitvids'                 => ! empty( $instance['playback']['fitvids'] ),
 		);
 
-		// Force oEmbed for this video
 		if ( $instance['host_type'] == 'external' && $instance['playback']['oembed'] ) {
+			// Force oEmbed for this video if oEmbed is enabled.
 			$return['is_skinnable_video_host'] = false;
 		}
 


### PR DESCRIPTION
Previously, External Videos set to not Use oEmbed wouldn't play. This PR fixes that by passing the source as a valid `video source`. 