### PR TITLE
Google Maps: Change How Maps Are Setup To Allow Greater Flexibility

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -476,9 +476,26 @@ jQuery(function ($) {
 			sowb.loadGoogleMapsAPI( forceLoad );
 			// Ensure Google Maps is loaded before using it.
 			sowb.googleMapsData.timer = setInterval( function () {
-				if ( typeof window.google !== 'undefined' && typeof window.google.maps !== 'undefined' ) {
-					clearInterval( sowb.googleMapsData.timer );
+				var clearTimer = false;
+				// Check if there been an error.
+				sowb.googleMapsData.ApiError = true;
+				if (
+					typeof sowb.googleMapsData.ApiError !== 'undefined' &&
+					sowb.googleMapsData.ApiError
+				) {
+					clearTimer = true;
+				}
+				if (
+					! clearTimer &&
+					typeof window.google !== 'undefined' &&
+					typeof window.google.maps !== 'undefined'
+				) {
+					clearTimer = true;
 					soGoogleMapInitialize();
+				}
+
+				if ( clearTimer ) {
+					clearInterval( sowb.googleMapsData.timer );
 				}
 			}, 250 );
 		}


### PR DESCRIPTION
This PR changes how Google Maps are set up to allow to avoid situations where a Google Map won't display correctly if invisible on load, or if the parent is invisible. It'll also allow developers to manually reinitialize the map if they wish to by using `sowb.setupGoogleMaps( false, true );` This PR will also more aggressively prevent itself from loading multiple instances of the Google Maps API script.

Please test:
- SiteOrigin Google Maps widget
- SiteOrigin Contact Form Location Field
- Google Maps inside of Accordion/tab widget
- Please test with a combination of only, and all as there could be a situation where the map will only display as expected if other maps are also present.