### PR TITLE
Carousel: Add design_settings_form_fields & Post Carousel Design Field Adjustments

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -252,7 +252,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 						),
 						'size' => array(
 							'type' => 'measurement',
-							'label' => __( 'Size', 'so-widgets-bundle' ),
+							'label' => __( 'Font size', 'so-widgets-bundle' ),
 						),
 						'color' => array(
 							'type' => 'color',

--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -260,18 +260,6 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 						),
 					),
 				),
-				'item' => array(
-					'type' => 'section',
-					'label' => __( 'Item', 'so-widgets-bundle' ),
-					'hide' => true,
-					'fields' => array(),
-				),
-				'navigation' => array(
-					'type' => 'section',
-					'label' => __( 'Navigation', 'so-widgets-bundle' ),
-					'hide' => true,
-					'fields' => array(),
-				),
 			),
 		);
 

--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -220,6 +220,68 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 		);
 	}
 
+
+	function design_settings_form_fields( $settings = array() ) {
+		$fields = array(
+			'type' => 'section',
+			'label' => __( 'Design', 'so-widgets-bundle' ),
+			'hide' => true,
+			'fields' => array(
+				'item_title' => array(
+					'type' => 'section',
+					'label' => __( 'Item title', 'so-widgets-bundle' ),
+					'hide' => true,
+					'fields' => array(
+						'tag' => array(
+							'type' => 'select',
+							'label' => __( 'HTML Tag', 'so-widgets-bundle' ),
+							'default' => 'h4',
+							'options' => array(
+								'h1' => __( 'H1', 'so-widgets-bundle' ),
+								'h2' => __( 'H2', 'so-widgets-bundle' ),
+								'h3' => __( 'H3', 'so-widgets-bundle' ),
+								'h4' => __( 'H4', 'so-widgets-bundle' ),
+								'h5' => __( 'H5', 'so-widgets-bundle' ),
+								'h6' => __( 'H6', 'so-widgets-bundle' ),
+								'p' => __( 'Paragraph', 'so-widgets-bundle' ),
+							),
+						),
+						'font' => array(
+							'type' => 'font',
+							'label' => __( 'Font', 'so-widgets-bundle' ),
+						),
+						'size' => array(
+							'type' => 'measurement',
+							'label' => __( 'Size', 'so-widgets-bundle' ),
+						),
+						'color' => array(
+							'type' => 'color',
+							'label' => __( 'Color', 'so-widgets-bundle' ),
+						),
+					),
+				),
+				'item' => array(
+					'type' => 'section',
+					'label' => __( 'Item', 'so-widgets-bundle' ),
+					'hide' => true,
+					'fields' => array(),
+				),
+				'navigation' => array(
+					'type' => 'section',
+					'label' => __( 'Navigation', 'so-widgets-bundle' ),
+					'hide' => true,
+					'fields' => array(),
+				),
+			),
+		);
+
+		if ( ! empty( $settings ) ) {
+			$fields = array_merge_recursive( $fields, array( 'fields' => $settings ) );
+		}
+
+		return $fields;
+	}
+
 	function get_settings_form() {
 		return array(
 			'responsive' => $this->responsive_form_fields( 'global' ),

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -83,42 +83,10 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 				),
 			),
 			'carousel_settings' => $this->carousel_settings_form_fields(),
-			'design' => array(
-				'type' => 'section',
-				'label' => __( 'Design', 'so-widgets-bundle' ),
-				'hide' => true,
-				'fields' => array(
+			'design' => $this->design_settings_form_fields(
+				array(
 					'item_title' => array(
-						'type' => 'section',
-						'label' => __( 'Item title', 'so-widgets-bundle' ),
-						'hide' => true,
 						'fields' => array(
-							'tag' => array(
-								'type' => 'select',
-								'label' => __( 'HTML Tag', 'so-widgets-bundle' ),
-								'default' => 'h4',
-								'options' => array(
-									'h1' => __( 'H1', 'so-widgets-bundle' ),
-									'h2' => __( 'H2', 'so-widgets-bundle' ),
-									'h3' => __( 'H3', 'so-widgets-bundle' ),
-									'h4' => __( 'H4', 'so-widgets-bundle' ),
-									'h5' => __( 'H5', 'so-widgets-bundle' ),
-									'h6' => __( 'H6', 'so-widgets-bundle' ),
-									'p' => __( 'Paragraph', 'so-widgets-bundle' ),
-								),
-							),
-							'font' => array(
-								'type' => 'font',
-								'label' => __( 'Font', 'so-widgets-bundle' ),
-							),
-							'size' => array(
-								'type' => 'measurement',
-								'label' => __( 'Size', 'so-widgets-bundle' ),
-							),
-							'color' => array(
-								'type' => 'color',
-								'label' => __( 'Color', 'so-widgets-bundle' ),
-							),
 							'bottom_margin' => array(
 								'type' => 'measurement',
 								'label' => __( 'Bottom margin', 'so-widgets-bundle' ),
@@ -127,9 +95,6 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 						),
 					),
 					'item' => array(
-						'type' => 'section',
-						'label' => __( 'Item', 'so-widgets-bundle' ),
-						'hide' => true,
 						'fields' => array(
 							'font' => array(
 								'type' => 'font',
@@ -170,9 +135,6 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 						),
 					),
 					'navigation' => array(
-						'type' => 'section',
-						'label' => __( 'Navigation', 'so-widgets-bundle' ),
-						'hide' => true,
 						'fields' => array(
 							'arrow_color' => array(
 								'type' => 'color',
@@ -199,10 +161,9 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 								'label' => __( 'Dots selected and hover color', 'so-widgets-bundle' ),
 								'default' => '#f14e4e',
 							),
-
 						),
 					),
-				),
+				)
 			),
 			'responsive' => $this->responsive_form_fields(),
 		);

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -95,6 +95,9 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 						),
 					),
 					'item' => array(
+						'type' => 'section',
+						'label' => __( 'Item', 'so-widgets-bundle' ),
+						'hide' => true,
 						'fields' => array(
 							'font' => array(
 								'type' => 'font',
@@ -135,6 +138,9 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 						),
 					),
 					'navigation' => array(
+						'type' => 'section',
+						'label' => __( 'Navigation', 'so-widgets-bundle' ),
+						'hide' => true,
 						'fields' => array(
 							'arrow_color' => array(
 								'type' => 'color',

--- a/widgets/post-carousel/css/style.less
+++ b/widgets/post-carousel/css/style.less
@@ -159,19 +159,6 @@
 					display: block;
 					.gradient(#E8E8E8, #E0E0E0, #E8E8E8)
 				}
-
-				h3 {
-					font-size: 15px;
-					text-align: center;
-					font-weight: 500;
-					color: #474747;
-					margin: 10px 0 0 0;
-
-					a {
-						text-decoration: none;
-						color: inherit;
-					}
-				}
 			}
 
 			.sow-carousel-loading {

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -182,7 +182,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 						),
 					),
 				),
-			),
+			)
 		);
 
 		// Overide defaults.

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -276,7 +276,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 			isset( $instance['design'] ) &&
 			isset( $instance['design']['thumbnail_overlay_hover_color'] )
 		) {
-			$instance['design']['item'] = array(
+			$instance['design']['thumbnail'] = array(
 				'thumbnail_overlay_hover_color' => $instance['design']['thumbnail_overlay_hover_color'],
 				'thumbnail_overlay_hover_opacity' => $instance['design']['thumbnail_overlay_hover_opacity'],
 			);

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -154,6 +154,54 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 	}
 
 	function get_widget_form() {
+		$design_settings = $this->design_settings_form_fields(
+			array(
+				'item' => array(
+					'fields' => array(
+						'thumbnail_overlay_hover_color' => array(
+							'type' => 'color',
+							'label' => __( 'Thumbnail overlay hover color', 'so-widgets-bundle' ),
+							'default' => '#3279BB',
+						),
+						'thumbnail_overlay_hover_opacity' => array(
+							'type' => 'slider',
+							'label' => __( 'Thumbnail overlay hover opacity', 'so-widgets-bundle' ),
+							'default' => '0.5',
+							'min' => 0,
+							'max' => 1,
+							'step' => 0.1,
+						),
+					),
+				),
+				'navigation' => array(
+					'fields' => array(
+						'navigation_color' => array(
+							'type' => 'color',
+							'label' => __( 'Navigation arrow color', 'so-widgets-bundle' ),
+							'default' => '#fff',
+						),
+						'navigation_color_hover' => array(
+							'type' => 'color',
+							'label' => __( 'Navigation arrow hover color', 'so-widgets-bundle' ),
+						),
+						'navigation_background' => array(
+							'type' => 'color',
+							'label' => __( 'Navigation background', 'so-widgets-bundle' ),
+							'default' => '#333',
+						),
+						'navigation_hover_background' => array(
+							'type' => 'color',
+							'label' => __( 'Navigation hover background', 'so-widgets-bundle' ),
+							'default' => '#444',
+						),
+					),
+				),
+			),
+		);
+
+		// Alter Item Title Tag default.
+		$design_settings['fields']['item_title']['fields']['tag']['default'] = 'h3';
+var_dump( $design_settings['fields']['item_title']['fields']['tag']['default'] );
 		return array(
 			'title' => array(
 				'type' => 'text',
@@ -202,48 +250,38 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 					),
 				),
 			),
-
-			'design' => array(
-				'type' => 'section',
-				'label' => __( 'Design', 'so-widgets-bundle' ),
-				'hide' => true,
-				'fields' => array(
-					'thumbnail_overlay_hover_color' => array(
-						'type' => 'color',
-						'label' => __( 'Thumbnail overlay hover color', 'so-widgets-bundle' ),
-						'default' => '#3279BB',
-					),
-					'thumbnail_overlay_hover_opacity' => array(
-						'type' => 'slider',
-						'label' => __( 'Thumbnail overlay hover opacity', 'so-widgets-bundle' ),
-						'default' => '0.5',
-						'min' => 0,
-						'max' => 1,
-						'step' => 0.1,
-					),
-					'navigation_color' => array(
-						'type' => 'color',
-						'label' => __( 'Navigation arrow color', 'so-widgets-bundle' ),
-						'default' => '#fff',
-					),
-					'navigation_color_hover' => array(
-						'type' => 'color',
-						'label' => __( 'Navigation arrow hover color', 'so-widgets-bundle' ),
-					),
-					'navigation_background' => array(
-						'type' => 'color',
-						'label' => __( 'Navigation background', 'so-widgets-bundle' ),
-						'default' => '#333',
-					),
-					'navigation_hover_background' => array(
-						'type' => 'color',
-						'label' => __( 'Navigation hover background', 'so-widgets-bundle' ),
-						'default' => '#444',
-					),
-				),
-			),
+			'design' => $design_settings,
 			'responsive' => $this->responsive_form_fields(),
 		);
+	}
+
+	function modify_instance( $instance ) {
+		// Migrate old Design settings to new settings structure.
+		if (
+			is_array( $instance ) &&
+			isset( $instance['design'] ) &&
+			isset( $instance['design']['thumbnail_overlay_hover_color'] )
+		) {
+			$instance['design']['item'] = array(
+				'thumbnail_overlay_hover_color' => $instance['design']['thumbnail_overlay_hover_color'],
+				'thumbnail_overlay_hover_opacity' => $instance['design']['thumbnail_overlay_hover_opacity'],
+			);
+			$instance['design']['navigation'] = array(
+				'navigation_color' => $instance['design']['navigation_color'],
+				'navigation_color_hover' => $instance['design']['navigation_color_hover'],
+				'navigation_background' => $instance['design']['navigation_background'],
+				'navigation_hover_background' => $instance['design']['navigation_hover_background'],
+			);
+
+			unset( $instance['design']['thumbnail_overlay_hover_color'] );
+			unset( $instance['design']['thumbnail_overlay_hover_opacity'] );
+			unset( $instance['design']['navigation_color'] );
+			unset( $instance['design']['navigation_color_hover'] );
+			unset( $instance['design']['navigation_background'] );
+			unset( $instance['design']['navigation_hover_background'] );
+		}
+
+		return $instance;
 	}
 
 	function get_less_variables( $instance ) {
@@ -269,12 +307,15 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 			'thumbnail_height'=> $thumb_height . 'px',
 			'thumbnail_hover_width' => $thumb_hover_width . 'px',
 			'thumbnail_hover_height'=> $thumb_hover_height . 'px',
-			'thumbnail_overlay_hover_color' => ! empty ( $instance['design']['thumbnail_overlay_hover_color'] ) ? $instance['design']['thumbnail_overlay_hover_color'] : '',
-			'thumbnail_overlay_hover_opacity' => ! empty ( $instance['design']['thumbnail_overlay_hover_opacity'] ) ? $instance['design']['thumbnail_overlay_hover_opacity'] : 0.5,
-			'navigation_color' => ! empty ( $instance['design']['navigation_color'] ) ? $instance['design']['navigation_color'] : '',
-			'navigation_color_hover' => ! empty ( $instance['design']['navigation_color_hover'] ) ? $instance['design']['navigation_color_hover'] : '',
-			'navigation_background' => ! empty ( $instance['design']['navigation_background'] ) ? $instance['design']['navigation_background'] : '',
-			'navigation_hover_background' => ! empty ( $instance['design']['navigation_hover_background'] ) ? $instance['design']['navigation_hover_background'] : '',
+			'thumbnail_overlay_hover_color' => ! empty ( $instance['design']['item']['thumbnail_overlay_hover_color'] ) ? $instance['design']['item']['thumbnail_overlay_hover_color'] : '',
+			'thumbnail_overlay_hover_opacity' => ! empty ( $instance['design']['item']['thumbnail_overlay_hover_opacity'] ) ? $instance['design']['item']['thumbnail_overlay_hover_opacity'] : 0.5,
+			'navigation_color' => ! empty ( $instance['design']['navigation']['navigation_color'] ) ? $instance['design']['navigation']['navigation_color'] : '',
+			'navigation_color_hover' => ! empty ( $instance['design']['navigation']['navigation_color_hover'] ) ? $instance['design']['navigation']['navigation_color_hover'] : '',
+			'navigation_background' => ! empty ( $instance['design']['navigation']['navigation_background'] ) ? $instance['design']['navigation']['navigation_background'] : '',
+			'navigation_hover_background' => ! empty ( $instance['design']['navigation']['navigation_hover_background'] ) ? $instance['design']['navigation']['navigation_hover_background'] : '',
+			'item_title_tag' => $instance['design']['item_title']['tag'],
+			'item_title_font_size' => ! empty( $instance['design']['item_title']['size'] ) ? $instance['design']['item_title']['size'] : '',
+			'item_title_color' => ! empty( $instance['design']['item_title']['color'] ) ? $instance['design']['item_title']['color'] : '',
 		);
 	}
 
@@ -301,6 +342,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 				'link_target' => ! empty( $instance['link_target'] ) ? $instance['link_target'] : 'same',
 				'item_template' => plugin_dir_path( __FILE__ ) . 'tpl/item.php',
 				'navigation' => 'title',
+				'item_title_tag' => ! empty( $instance['design']['item_title']['tag'] ) ? $instance['design']['item_title']['tag'] : 'h3',
 				'attributes' => array(
 					'widget' => 'post',
 					'fetching' => 'false',

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -201,7 +201,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 
 		// Alter Item Title Tag default.
 		$design_settings['fields']['item_title']['fields']['tag']['default'] = 'h3';
-var_dump( $design_settings['fields']['item_title']['fields']['tag']['default'] );
+
 		return array(
 			'title' => array(
 				'type' => 'text',

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -156,24 +156,10 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 	function get_widget_form() {
 		$design_settings = $this->design_settings_form_fields(
 			array(
-				'item' => array(
-					'fields' => array(
-						'thumbnail_overlay_hover_color' => array(
-							'type' => 'color',
-							'label' => __( 'Thumbnail overlay hover color', 'so-widgets-bundle' ),
-							'default' => '#3279BB',
-						),
-						'thumbnail_overlay_hover_opacity' => array(
-							'type' => 'slider',
-							'label' => __( 'Thumbnail overlay hover opacity', 'so-widgets-bundle' ),
-							'default' => '0.5',
-							'min' => 0,
-							'max' => 1,
-							'step' => 0.1,
-						),
-					),
-				),
 				'navigation' => array(
+					'type' => 'section',
+					'label' => __( 'Navigation', 'so-widgets-bundle' ),
+					'hide' => true,
 					'fields' => array(
 						'navigation_color' => array(
 							'type' => 'color',
@@ -199,8 +185,36 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 			),
 		);
 
-		// Alter Item Title Tag default.
+		// Overide defaults.
+		$design_settings['fields']['item_title']['label'] = __( 'Post title', 'so-widgets-bundle' );
 		$design_settings['fields']['item_title']['fields']['tag']['default'] = 'h3';
+
+		// Reposition thumbnail settings.
+		$design_settings['fields'] = array_merge(
+			array(
+				'thumbnail' => array(
+					'type' => 'section',
+					'label' => __( 'Post thumbnail', 'so-widgets-bundle' ),
+					'hide' => true,
+					'fields' => array(
+						'thumbnail_overlay_hover_color' => array(
+							'type' => 'color',
+							'label' => __( 'Thumbnail overlay hover color', 'so-widgets-bundle' ),
+							'default' => '#3279BB',
+						),
+						'thumbnail_overlay_hover_opacity' => array(
+							'type' => 'slider',
+							'label' => __( 'Thumbnail overlay hover opacity', 'so-widgets-bundle' ),
+							'default' => '0.5',
+							'min' => 0,
+							'max' => 1,
+							'step' => 0.1,
+						),
+					),
+				),
+			),
+			$design_settings['fields']
+		);
 
 		return array(
 			'title' => array(

--- a/widgets/post-carousel/styles/default.less
+++ b/widgets/post-carousel/styles/default.less
@@ -12,8 +12,8 @@
 @navigation_hover_background: #444;
 
 @item_title_tag: default;
-@item_title_font_size: default;
-@item_title_color: default;
+@item_title_font_size: 15px;
+@item_title_color: #474747;
 
 .sow-carousel-title {
 
@@ -52,14 +52,12 @@
         }
       }
 
-      @{item_title_tag}.sow-carousel-item-title a {
-        font-size: @item_title_font_size;
+      @{item_title_tag}.sow-carousel-item-title {
         color: @item_title_color;
-        font-size: 15px;
-        text-align: center;
+        font-size: @item_title_font_size;
         font-weight: 500;
-        color: #474747;
         margin: 10px 0 0 0;
+        text-align: center;
 
         a {
           text-decoration: none;

--- a/widgets/post-carousel/styles/default.less
+++ b/widgets/post-carousel/styles/default.less
@@ -11,6 +11,10 @@
 @navigation_background: #333;
 @navigation_hover_background: #444;
 
+@item_title_tag: default;
+@item_title_font_size: default;
+@item_title_color: default;
+
 .sow-carousel-title {
 
   a.sow-carousel-next,
@@ -46,6 +50,11 @@
         span.overlay {
           background: @thumbnail_overlay_hover_color;
         }
+      }
+
+      @{item_title_tag}.sow-carousel-item-title a {
+        font-size: @item_title_font_size;
+        color: @item_title_color;
       }
 
       &:focus,

--- a/widgets/post-carousel/styles/default.less
+++ b/widgets/post-carousel/styles/default.less
@@ -55,6 +55,16 @@
       @{item_title_tag}.sow-carousel-item-title a {
         font-size: @item_title_font_size;
         color: @item_title_color;
+        font-size: 15px;
+        text-align: center;
+        font-weight: 500;
+        color: #474747;
+        margin: 10px 0 0 0;
+
+        a {
+          text-decoration: none;
+          color: inherit;
+        }
       }
 
       &:focus,

--- a/widgets/post-carousel/tpl/item.php
+++ b/widgets/post-carousel/tpl/item.php
@@ -30,16 +30,17 @@ while( $settings['posts']->have_posts() ) :
 				</a>
 			<?php endif; ?>
 		</div>
-		<h3>
+		<<?php echo esc_attr( $settings['item_title_tag'] ); ?> class="sow-carousel-item-title">
 			<a
 				href="<?php the_permalink(); ?>"
 				id="sow-carousel-id-<?php echo the_ID(); ?>"
 				<?php echo $settings['link_target'] == 'new' ? 'target="_blank" rel="noopener noreferrer"': ''; ?>
 				tabindex="-1"
 			>
-			<?php the_title(); ?>
+
+				<?php echo esc_html( get_the_title() ); ?>
 			</a>
-		</h3>
+		</<?php echo esc_attr( $settings['item_title_tag'] ); ?>>
 	</div>
 <?php
 endwhile;


### PR DESCRIPTION
This PR adds a new method for carousels called `design_settings_form_fields`. This will allow for more centrally structured design settings. This PR then modifies both carousel widgets to use this new method. For the post carousel specifically, it:

- Migrate settings to correct design sub-sections.
- Adds support new title settings.

Please test that pre-existing Post Carousel and Anything Carousel widgets work as expected (specifically, the post carousel design settings migrate over correctly) after switching to this PR.
