### PR TITLE
Anything Carousel Anchor Setup

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -141,6 +141,8 @@ jQuery( function ( $ ) {
 			}
 		} );
 
+		$( sowb ).trigger( 'carousel_setup' );
+
 		// Keyboard Navigation of carousel navigation.
 		$( document ).on( 'keydown', '.sow-carousel-navigation a', function( e ) {
 			if ( e.keyCode != 13 && e.keyCode != 32 ) {

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -265,7 +265,6 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 					'loop' => ! empty( $instance['loop_posts'] ),
 					'carousel_settings' => $this->carousel_settings_template_variables( $instance['carousel_settings'] ),
 					'responsive' => $this->responsive_template_variables( $instance['responsive'] ),
-					'anchor' => ! empty( $instance['carousel_settings']['use_anchor_tags'] ) && ! empty( $instance['title'] ) ? sanitize_title_with_dashes( $instance['title'] ) : '',
 				),
 			),
 		);

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -265,6 +265,7 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 					'loop' => ! empty( $instance['loop_posts'] ),
 					'carousel_settings' => $this->carousel_settings_template_variables( $instance['carousel_settings'] ),
 					'responsive' => $this->responsive_template_variables( $instance['responsive'] ),
+					'anchor' => ! empty( $instance['carousel_settings']['use_anchor_tags'] ) && ! empty( $instance['title'] ) ? sanitize_title_with_dashes( $instance['title'] ) : '',
 				),
 			),
 		);


### PR DESCRIPTION
This PR will add an anchor tag to the Anything Carousel widget wrapper, and it also adds a new event for the carousel `carousel_setup` that is triggered after all carousels are set up.