### PR TITLE
Button: Ensure $instance isn't empty before modifying it

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -405,6 +405,10 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 	 * @return mixed
 	 */
 	function modify_instance( $instance ) {
+		if ( empty( $instance ) ) {
+			return array();
+		}
+
 		$migrate_props = array(
 			'button_icon' => array(
 				'icon_selected',


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/so-widgets-bundle-generating-an-error/)

Resolves the following error:

> Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /home/qwerty/public_html/wp-content/plugins/so-widgets-bundle/widgets/button/button.php:433

This isn't simple to test as the error requires a very specific setup so just confirm the Button widget displays as expected.