### PR TITLE
Sliders: Handle Video Loop Setting on a Frame by Frame Basis

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -250,7 +250,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				foreach ( $instance['frames'] as $k => $frame ) {
 					if ( $is_slider_widget ) {
 						$instance['frames'][ $k ]['loop_background_videos'] = 'on';
-					} else{
+					} else {
 						$instance['frames'][ $k ]['background']['loop_background_videos'] = 'on';
 					}
 				}

--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -143,12 +143,6 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				'label' => __( 'Show slide background videos on mobile', 'so-widgets-bundle' ),
 				'description' => __( 'Allow slide background videos to appear on mobile devices that support autoplay.', 'so-widgets-bundle' ),
 			),
-
-			'loop_background_videos' => array(
-				'type' => 'checkbox',
-				'label' => __( 'Loop slide background videos', 'so-widgets-bundle' ),
-				'default' => false,
-			),
 		);
 	}
 
@@ -210,6 +204,60 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			'nav_always_show_mobile'   => ! empty( $controls['nav_always_show_mobile'] ) ? true : '',
 			'breakpoint'               => ! empty( $controls['breakpoint'] ) ? $controls['breakpoint'] : '780px',
 		);
+	}
+
+	function widget_form( $form_options ) {
+		if ( isset( $form_options ) && isset( $form_options['frames'] ) ) {
+			$loop_setting = array(
+				'type' => 'checkbox',
+				'label' => __( 'Loop slide background videos', 'so-widgets-bundle' ),
+				'default' => false,
+			);
+			if ( isset( $form_options['frames']['fields']['background_videos'] ) ) {
+				// Add setting to SiteOrigin Slider widget.
+				siteorigin_widgets_array_insert(
+					$form_options['frames']['fields'],
+					'background_image',
+					array(
+						'loop_background_videos' => $loop_setting,
+					)
+				);
+			} elseif ( isset( $form_options['frames']['fields']['background'] ) ) {
+				// Add setting to all other slider widgets.
+				$form_options['frames']['fields']['background']['fields']['loop_background_videos'] = $loop_setting;
+			}
+		}
+		return $form_options;
+	}
+
+	/**
+	 * Migrate Slider settings.
+	 *
+	 * @param $instance
+	 *
+	 * @return mixed
+	 */
+	function modify_instance( $instance ){
+		if ( empty( $instance ) ) {
+			return array();
+		}
+
+		// Migrate global slider loop_background_videos setting to frame specific setting.
+		if ( ! empty( $instance['controls']['loop_background_videos'] ) ) {
+			unset( $instance['controls']['loop_background_videos'] );
+			if ( ! empty( $instance['frames'] ) ) {
+				$is_slider_widget = $this->widget_class == 'SiteOrigin_Widget_Slider_Widget';
+				foreach ( $instance['frames'] as $k => $frame ) {
+					if ( $is_slider_widget ) {
+						$instance['frames'][ $k ]['loop_background_videos'] = 'on';
+					} else{
+						$instance['frames'][ $k ]['background']['loop_background_videos'] = 'on';
+					}
+				}
+			}
+		}
+
+		return $instance;
 	}
 
 	function render_template( $controls, $frames ){
@@ -344,6 +392,14 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 					$classes[] = 'sow-mobile-video_enabled';
 				}
 
+				// If loop_background_videos is enabled, pass it to the video embed as a control.
+				if ( ! empty( $frame['loop_background_videos'] ) ) {
+					// SiteOrigin Slider Widget.
+					$controls['loop_background_videos'] = $frame['loop_background_videos'];
+				} elseif ( ! empty( $frame['background']['loop_background_videos'] ) ) {
+					// All other slider widgets.
+					$controls['loop_background_videos'] = $frame['background']['loop_background_videos'];
+				}
 				$this->video_code( $background['videos'], $classes, $controls );
 			}
 

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -44,7 +44,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	function get_widget_form(){
-		return array(
+		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
 				'label' => __('Hero frames', 'so-widgets-bundle'),
@@ -311,7 +311,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 
 				)
 			),
-		);
+		) );
 	}
 	
 	function filter_button_widget_form( $form_fields ) {

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -32,7 +32,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 
 	function get_widget_form(){
 		$show_heading_fields = apply_filters( 'sow_layout_slider_show_heading_fields', false );
-		return array(
+		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
 				'label' => __('Slider frames', 'so-widgets-bundle'),
@@ -230,7 +230,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 
 				)
 			),
-		);
+		) );
 	}
 
 	function form( $instance, $form_type = 'widget' ) {

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -28,7 +28,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	function get_widget_form(){
-		return array(
+		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
 				'label' => __('Slider frames', 'so-widgets-bundle'),
@@ -149,7 +149,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				),
 			),
 
-		);
+		) );
 	}
 
 	function get_frame_background( $i, $frame ){
@@ -339,7 +339,7 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 
 		}
 
-		return $instance;
+		return parent::modify_instance( $instance );
 	}
 
 	function get_form_teaser(){


### PR DESCRIPTION
This moves the `Loop slide background videos` in the Slider Controls setting group to frames - after the Background Videos repeater in the Slider widget, and at the very end of the Background section for the rest of the Slider widgets. If the user previously had this setting enabled, the frame by frame setting will be automatically enabled.

To test this PR:

- Add two of each slider to the page and set up 2 or so slides with videos set.
- Tick the Loop slide background videos in one instance of a slider widget and leave the other one unticked.
- Save. Export the layout (just to be safe),
- Switch to this branch.
- Confirm that the frame specific `Loop slide background videos` setting is correctly ticked when it should be, and confirm the videos loop.
- Once confirmed the migration worked without issue, disable the looping for certain frames and then confirm those videos are no longer looping while the other slides still are.