### PR TITLE
Hero/Layout Slider: Move Layout Settings to dedicated section, and add Padding Responsive Settings

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -212,6 +212,62 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		);
 	}
 
+	/**
+	 * Migrate Slider settings.
+	 *
+	 * @param $instance
+	 *
+	 * @return mixed
+	 */
+	function modify_instance( $instance ){
+		if ( empty( $instance ) ) {
+			return array();
+		}
+
+		// Migrate Hero and Layout Slider Layouts and Design settings to separate section.
+		if (
+			(
+				$this->widget_class == 'SiteOrigin_Widget_Hero_Widget' ||
+				$this->widget_class == 'SiteOrigin_Widget_LayoutSlider_Widget'
+			) &&
+			empty( $instance['layout'] )
+		) {
+			$migrate_layout_settings = array(
+				'vertically_align' => true,
+				'desktop' => array(
+					'height',
+					'height_unit',
+					'padding',
+					'padding_unit',
+					'extra_top_padding',
+					'extra_top_padding_unit',
+					'padding_sides',
+					'padding_sides_unit',
+					'width',
+					'width_unit',
+				),
+				'mobile' => array(
+					'height_responsive',
+					'height_responsive_unit',
+				),
+			);
+
+			foreach ( $migrate_layout_settings as $setting => $sub_section ) {
+				if ( is_array( $sub_section ) ) {
+					foreach ( $sub_section as $responsive_setting ) {
+						$instance['layout']['responsive'][ $setting ][ $responsive_setting ] = $instance['design'][ $responsive_setting ];
+					}
+				} elseif ( ! empty( $instance['design'][ $setting ] ) ) {
+					$instance['layout'][ $setting ] = $instance['design'][ $setting ];
+
+					unset( $instance['design'][ $setting ] );
+				}
+			}
+		}
+
+		return $instance;
+	}
+
 	function render_template( $controls, $frames ){
 		$this->render_template_part('before_slider', $controls, $frames);
 		$this->render_template_part('before_slides', $controls, $frames);

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -174,54 +174,75 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				'fields' => $this->control_form_fields()
 			),
 
-			'design' => array(
+			'layout' => array(
 				'type' => 'section',
-				'label' => __('Design and Layout', 'so-widgets-bundle'),
+				'label' => __( 'Layout', 'so-widgets-bundle' ),
 				'fields' => array(
-
-					'height' => array(
-						'type' => 'measurement',
-						'label' => __( 'Height', 'so-widgets-bundle' ),
-						'default' => 'default',
-					),
-
-					'height_responsive' => array(
-						'type' => 'measurement',
-						'label' => __( 'Responsive Height', 'so-widgets-bundle' ),
-						'default' => 'default',
-					),
-
 					'vertically_align' => array(
 						'type' => 'checkbox',
 						'label' => __( 'Vertically center align slide contents', 'so-widgets-bundle' ),
 						'description' => __( 'For perfect centering, consider setting the Extra top padding setting to 0 when enabling this setting.', 'so-widgets-bundle' ),
 					),
+					'responsive' => array(
+						'type' => 'section',
+						'label' => __( 'Responsive', 'so-widgets-bundle' ),
+						'fields' => array(
+							'desktop' => array(
+								'type' => 'section',
+								'label' => __( 'Layout', 'so-widgets-bundle' ),
+								'fields' => array(
+									'height' => array(
+										'type' => 'measurement',
+										'label' => __( 'Height', 'so-widgets-bundle' ),
+									),
 
-					'padding' => array(
-						'type' => 'measurement',
-						'label' => __('Top and bottom padding', 'so-widgets-bundle'),
-						'default' => '50px',
+									'padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Top and bottom padding', 'so-widgets-bundle' ),
+										'default' => '50px',
+									),
+
+									'extra_top_padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
+										'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
+										'default' => '0px',
+									),
+
+									'padding_sides' => array(
+										'type' => 'measurement',
+										'label' => __( 'Side padding', 'so-widgets-bundle' ),
+										'default' => '20px',
+									),
+
+									'width' => array(
+										'type' => 'measurement',
+										'label' => __( 'Maximum container width', 'so-widgets-bundle' ),
+										'default' => '1280px',
+									),
+
+								),
+							),
+							'mobile' => array(
+								'type' => 'section',
+								'label' => __( 'Mobile', 'so-widgets-bundle' ),
+								'fields' => array(
+									'height_responsive' => array(
+										'type' => 'measurement',
+										'label' => __( 'Height', 'so-widgets-bundle' ),
+									),
+								),
+							),
+						),
 					),
 
-					'extra_top_padding' => array(
-						'type' => 'measurement',
-						'label' => __('Extra top padding', 'so-widgets-bundle'),
-						'description' => __('Additional padding added to the top of the slider', 'so-widgets-bundle'),
-						'default' => '0px',
-					),
+				),
+			),
 
-					'padding_sides' => array(
-						'type' => 'measurement',
-						'label' => __('Side padding', 'so-widgets-bundle'),
-						'default' => '20px',
-					),
-
-					'width' => array(
-						'type' => 'measurement',
-						'label' => __('Maximum container width', 'so-widgets-bundle'),
-						'default' => '1280px',
-					),
-
+			'design' => array(
+				'type' => 'section',
+				'label' => __( 'Design', 'so-widgets-bundle' ),
+				'fields' => array(
 					'heading_font' => array(
 						'type' => 'font',
 						'label' => __('Heading font', 'so-widgets-bundle'),
@@ -413,20 +434,29 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		$less['nav_color_hex'] = $instance['controls']['nav_color_hex'];
 		$less['nav_size'] = $instance['controls']['nav_size'];
 
-		// Hero specific design
 		// Measurement field type options
 		$meas_options = array();
-		$meas_options['slide_padding'] = $instance['design']['padding'];
-		$meas_options['slide_padding_extra_top'] = $instance['design']['extra_top_padding'];
-		$meas_options['slide_padding_sides'] = $instance['design']['padding_sides'];
-		$meas_options['slide_width'] = $instance['design']['width'];
-		$meas_options['slide_height'] = $instance['design']['height'];
-		if ( ! empty( $instance['design']['height_responsive'] ) ) {
-			$meas_options['slide_height_responsive'] = $instance['design']['height_responsive'];
+
+		// Layouts settings.
+		if ( ! empty( $instance['layout'] ) && ! empty( $instance['layout']['responsive'] ) ) {
+			if ( ! empty( $instance['layout']['responsive']['desktop'] ) ) {
+				$desktop_settings = $instance['layout']['responsive']['desktop'];
+				$meas_options['slide_height'] = ! empty( $desktop_settings['height'] ) ? $desktop_settings['height'] : '';
+				$meas_options['slide_padding'] = ! empty( $desktop_settings['slide_padding'] ) ? $desktop_settings['slide_padding'] : '';
+				$meas_options['slide_padding_extra_top'] = ! empty( $desktop_settings['extra_top_padding'] ) ? $desktop_settings['extra_top_padding'] : '';
+				$meas_options['slide_padding_sides'] = ! empty( $desktop_settings['slide_padding_sides'] ) ? $desktop_settings['slide_padding_sides'] : '';
+				$meas_options['slide_width'] = ! empty( $desktop_settings['slide_width'] ) ? $desktop_settings['slide_width'] : '';
+			}
+
+			if ( ! empty( $instance['layout']['responsive']['mobile'] ) ) {
+				$mobile_settings = $instance['layout']['responsive']['mobile'];
+
+				$meas_options['slide_height_responsive'] = ! empty( $mobile_settings['height_responsive'] ) ? $mobile_settings['height_responsive'] : '';
+			}
 		}
+
 		$meas_options['heading_size'] = $instance['design']['heading_size'];
 		$meas_options['text_size'] = $instance['design']['text_size'];
-
 		foreach ( $meas_options as $key => $val ) {
 			$less[ $key ] = $this->add_default_measurement_unit( $val );
 		}

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -231,6 +231,23 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 										'type' => 'measurement',
 										'label' => __( 'Height', 'so-widgets-bundle' ),
 									),
+
+									'padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Top and bottom padding', 'so-widgets-bundle' ),
+									),
+
+									'extra_top_padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
+										'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
+									),
+
+									'padding_sides' => array(
+										'type' => 'measurement',
+										'label' => __( 'Side padding', 'so-widgets-bundle' ),
+									),
+
 								),
 							),
 						),
@@ -452,6 +469,13 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				$mobile_settings = $instance['layout']['responsive']['mobile'];
 
 				$meas_options['slide_height_responsive'] = ! empty( $mobile_settings['height_responsive'] ) ? $mobile_settings['height_responsive'] : '';
+				$meas_options['slide_padding_responsive'] = ! empty( $mobile_settings['padding'] ) ? $mobile_settings['padding'] : '';
+				$meas_options['slide_padding_sides_responsive'] = ! empty( $mobile_settings['padding_sides'] ) ? $mobile_settings['padding_sides'] : '';
+
+				if ( ! empty( $mobile_settings['extra_top_padding'] ) ) {
+					// Add extra padding to top padidng.
+					$meas_options['slide_padding_top_responsive'] = (int) $meas_options['slide_padding_responsive'] + (int) $mobile_settings['extra_top_padding'];
+				}
 			}
 		}
 

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -3,11 +3,23 @@
 @nav_color_hex: #FFFFFF;
 @nav_size: 25;
 
+// Layout.
+@vertically_align: false;
+// Layout Desktop.
+@slide_height: default;
 @slide_padding: 50px;
 @slide_padding_extra_top: 0px;
 @slide_padding_sides: 10px;
 @slide_width: 1280px;
-@slide_height: default;
+
+// Layout Mobile.
+@responsive_breakpoint: 780px;
+@slide_height_responsive: default;
+@slide_padding_responsive: default;
+@slide_padding_top_responsive: default;
+@slide_padding_sides_responsive: default;
+
+// Design.
 @heading_size: 38px;
 @text_size: 16px;
 @text_color: #F6F6F6;
@@ -15,34 +27,24 @@
 @text_font: default;
 @text_font_weight: 500;
 @text_font_style: default;
-
 @link_color: default;
 @link_color_hover: default;
-
 @heading_font: default;
 @heading_font_weight: 400;
 @heading_font_style: default;
 @heading_color: #FFFFFF;
 @heading_shadow: 50;
 
-@responsive_breakpoint: 780px;
-@slide_height_responsive: default;
-@vertically_align: false;
-
 // "Pre-fill" hero widget area if height is set
 & when ( isnumber( @slide_height ) ) {
 	@media (min-width: @responsive_breakpoint) {
-		& {
-			min-height: @slide_height;
-		}
+		min-height: @slide_height;
 	}
 }
 
 & when ( isnumber( @slide_height_responsive ) ) {
 	@media (max-width: @responsive_breakpoint) {
-		& {
-			min-height: @slide_height_responsive;
-		}
+		min-height: @slide_height_responsive;
 	}
 }
 
@@ -63,9 +65,21 @@
 			}
 
 			& when ( isnumber( @slide_height_responsive ) ) {
-				@media (max-width: @responsive_breakpoint) {
-					&{
+				@media (max-width: @responsive_breakpoint) {			
+					& when ( isnumber( @slide_height_responsive ) ) {
 						height: @slide_height_responsive;
+					}
+
+					& when ( isnumber( @slide_padding_top_responsive ) ) {
+						padding-top: @slide_padding_top_responsive;
+					}
+
+					& when ( isnumber( @slide_padding_sides_responsive ) ) {
+						padding-right: @slide_padding_sides_responsive;
+						padding-left: @slide_padding_sides_responsive;
+					}
+					& when ( isnumber( @slide_padding_responsive ) ) {
+						padding-bottom: @slide_padding_responsive;
 					}
 				}
 			}

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -142,90 +142,105 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 				'fields' => $this->control_form_fields()
 			),
 
-			'design' => array(
+			'layout' => array(
 				'type' => 'section',
-				'label' => __('Design and Layout', 'so-widgets-bundle'),
+				'label' => __( 'Layout', 'so-widgets-bundle' ),
 				'fields' => array(
-
-					'height' => array(
-						'type' => 'measurement',
-						'label' => __( 'Height', 'so-widgets-bundle' ),
-					),
-
-					'height_responsive' => array(
-						'type' => 'measurement',
-						'label' => __( 'Responsive Height', 'so-widgets-bundle' ),
-					),
-
 					'vertically_align' => array(
 						'type' => 'checkbox',
 						'label' => __( 'Vertically center align slide contents', 'so-widgets-bundle' ),
 						'description' => __( 'For perfect centering, consider setting the Extra top padding setting to 0 when enabling this setting.', 'so-widgets-bundle' ),
 					),
+					'responsive' => array(
+						'type' => 'section',
+						'label' => __( 'Responsive', 'so-widgets-bundle' ),
+						'fields' => array(
+							'desktop' => array(
+								'type' => 'section',
+								'label' => __( 'Layout', 'so-widgets-bundle' ),
+								'fields' => array(
+									'height' => array(
+										'type' => 'measurement',
+										'label' => __( 'Height', 'so-widgets-bundle' ),
+									),
 
-					'padding' => array(
-						'type' => 'measurement',
-						'label' => __('Top and bottom padding', 'so-widgets-bundle'),
-						'default' => '50px',
-					),
+									'padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Top and bottom padding', 'so-widgets-bundle' ),
+										'default' => '50px',
+									),
 
-					'extra_top_padding' => array(
-						'type' => 'measurement',
-						'label' => __('Extra top padding', 'so-widgets-bundle'),
-						'description' => __('Additional padding added to the top of the slider', 'so-widgets-bundle'),
-						'default' => '0px',
-					),
+									'extra_top_padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
+										'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
+										'default' => '0px',
+									),
 
-					'padding_sides' => array(
-						'type' => 'measurement',
-						'label' => __('Side padding', 'so-widgets-bundle'),
-						'default' => '20px',
-					),
+									'padding_sides' => array(
+										'type' => 'measurement',
+										'label' => __( 'Side padding', 'so-widgets-bundle' ),
+										'default' => '20px',
+									),
 
-					'width' => array(
-						'type' => 'measurement',
-						'label' => __('Maximum container width', 'so-widgets-bundle'),
-						'default' => '1280px',
-					),
+									'width' => array(
+										'type' => 'measurement',
+										'label' => __( 'Maximum container width', 'so-widgets-bundle' ),
+										'default' => '1280px',
+									),
 
-					'heading_color' => array(
-						'type' => 'color',
-						'label' => __('Heading color', 'so-widgets-bundle'),
-						'state_emitter' => array(
-							'callback' => 'conditional',
-							'args'     => array(
-								'meh[hide]: ' . ( $show_heading_fields ? 'false' : 'true' ),
+								),
+							),
+							'mobile' => array(
+								'type' => 'section',
+								'label' => __( 'Mobile', 'so-widgets-bundle' ),
+								'fields' => array(
+									'height_responsive' => array(
+										'type' => 'measurement',
+										'label' => __( 'Height', 'so-widgets-bundle' ),
+									),
+
+								),
 							),
 						),
-						'state_handler' => array(
-							'meh[hide]' => array( 'hide' ),
-						)
+					),
+
+				),
+			),
+
+			'design' => array(
+				'type' => 'section',
+				'label' => __( 'Design', 'so-widgets-bundle' ),
+				'state_emitter' => array(
+					'callback' => 'conditional',
+					'args'     => array(
+						'meh[hide]: ' . ( $show_heading_fields ? 'false' : 'true' ),
+					),
+				),
+				'state_handler' => array(
+					'meh[hide]' => array( 'hide' ),
+				),
+				'fields' => array(
+					'heading_color' => array(
+						'type' => 'color',
+						'label' => __( 'Heading color', 'so-widgets-bundle' ),
 					),
 
 					'heading_shadow' => array(
 						'type' => 'slider',
-						'label' => __('Heading shadow intensity', 'so-widgets-bundle'),
+						'label' => __( 'Heading shadow intensity', 'so-widgets-bundle' ),
 						'max' => 100,
 						'min' => 0,
-						'state_handler' => array(
-							'meh[hide]' => array( 'hide' ),
-						)
 					),
 
 					'text_size' => array(
 						'type' => 'measurement',
-						'label' => __('Text size', 'so-widgets-bundle'),
-						'state_handler' => array(
-							'meh[hide]' => array( 'hide' ),
-						)
+						'label' => __( 'Text size', 'so-widgets-bundle' ),
 					),
 
 					'text_color' => array(
 						'type' => 'color',
-						'label' => __('Text color', 'so-widgets-bundle'),
-						'state_handler' => array(
-							'meh[hide]' => array( 'hide' ),
-						)
+						'label' => __( 'Text color', 'so-widgets-bundle' ),
 					),
 
 				)
@@ -377,16 +392,25 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 		$less['nav_color_hex'] = $instance['controls']['nav_color_hex'];
 		$less['nav_size'] = $instance['controls']['nav_size'];
 
-		// Hero specific design
-		//Measurement field type options
+		// Measurement field type options
 		$meas_options = array();
-		$meas_options['slide_padding'] = $instance['design']['padding'];
-		$meas_options['slide_padding_extra_top'] = $instance['design']['extra_top_padding'];
-		$meas_options['slide_padding_sides'] = $instance['design']['padding_sides'];
-		$meas_options['slide_width'] = $instance['design']['width'];
-		$meas_options['slide_height'] = $instance['design']['height'];
-		if ( ! empty( $instance['design']['height_responsive'] ) ) {
-			$meas_options['slide_height_responsive'] = $instance['design']['height_responsive'];
+
+		// Layouts settings.
+		if ( ! empty( $instance['layout'] ) && ! empty( $instance['layout']['responsive'] ) ) {
+			if ( ! empty( $instance['layout']['responsive']['desktop'] ) ) {
+				$desktop_settings = $instance['layout']['responsive']['desktop'];
+				$meas_options['slide_height'] = ! empty( $desktop_settings['height'] ) ? $desktop_settings['height'] : '';
+				$meas_options['slide_padding'] = ! empty( $desktop_settings['slide_padding'] ) ? $desktop_settings['slide_padding'] : '';
+				$meas_options['slide_padding_extra_top'] = ! empty( $desktop_settings['extra_top_padding'] ) ? $desktop_settings['extra_top_padding'] : '';
+				$meas_options['slide_padding_sides'] = ! empty( $desktop_settings['slide_padding_sides'] ) ? $desktop_settings['slide_padding_sides'] : '';
+				$meas_options['slide_width'] = ! empty( $desktop_settings['slide_width'] ) ? $desktop_settings['slide_width'] : '';
+			}
+
+			if ( ! empty( $instance['layout']['responsive']['mobile'] ) ) {
+				$mobile_settings = $instance['layout']['responsive']['mobile'];
+
+				$meas_options['slide_height_responsive'] = ! empty( $mobile_settings['height_responsive'] ) ? $mobile_settings['height_responsive'] : '';
+			}
 		}
 
 		if ( ! empty( $instance['design']['text_size'] ) ) {

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -200,6 +200,22 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 										'label' => __( 'Height', 'so-widgets-bundle' ),
 									),
 
+									'padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Top and bottom padding', 'so-widgets-bundle' ),
+									),
+
+									'extra_top_padding' => array(
+										'type' => 'measurement',
+										'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
+										'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
+									),
+
+									'padding_sides' => array(
+										'type' => 'measurement',
+										'label' => __( 'Side padding', 'so-widgets-bundle' ),
+									),
+
 								),
 							),
 						),
@@ -410,6 +426,13 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 				$mobile_settings = $instance['layout']['responsive']['mobile'];
 
 				$meas_options['slide_height_responsive'] = ! empty( $mobile_settings['height_responsive'] ) ? $mobile_settings['height_responsive'] : '';
+				$meas_options['slide_padding_responsive'] = ! empty( $mobile_settings['padding'] ) ? $mobile_settings['padding'] : '';
+				$meas_options['slide_padding_sides_responsive'] = ! empty( $mobile_settings['padding_sides'] ) ? $mobile_settings['padding_sides'] : '';
+
+				if ( ! empty( $mobile_settings['extra_top_padding'] ) ) {
+					// Add extra padding to top padidng.
+					$meas_options['slide_padding_top_responsive'] = (int) $meas_options['slide_padding_responsive'] + (int) $mobile_settings['extra_top_padding'];
+				}
 			}
 		}
 

--- a/widgets/layout-slider/styles/default.less
+++ b/widgets/layout-slider/styles/default.less
@@ -3,15 +3,23 @@
 @nav_color_hex: #FFFFFF;
 @nav_size: 25;
 
+// Layout.
+@vertically_align: false;
+// Layout Desktop.
+@slide_height: default;
 @slide_padding: 50px;
 @slide_padding_extra_top: 0px;
 @slide_padding_sides: 10px;
 @slide_width: 1280px;
-@slide_height: default;
+
+// Layout Mobile.
 @responsive_breakpoint: 780px;
 @slide_height_responsive: default;
-@vertically_align: false;
+@slide_padding_responsive: default;
+@slide_padding_top_responsive: default;
+@slide_padding_sides_responsive: default;
 
+// Design.
 @text_size: default;
 @text_color: default;
 @heading_shadow: default;
@@ -20,17 +28,13 @@
 // "Pre-fill" Layout Slider widget area if height is set
 & when ( isnumber( @slide_height ) ) {
 	@media (min-width: @responsive_breakpoint) {
-		& {
-			min-height: @slide_height;
-		}
+		min-height: @slide_height;
 	}
 }
 
 & when ( isnumber( @slide_height_responsive ) ) {
 	@media (max-width: @responsive_breakpoint) {
-		& {
-			min-height: @slide_height_responsive;
-		}
+		min-height: @slide_height_responsive;
 	}
 }
 
@@ -40,7 +44,6 @@
 
 		.sow-slider-image-wrapper {
 			padding: @slide_padding+@slide_padding_extra_top @slide_padding_sides @slide_padding @slide_padding_sides;
-
 			max-width: @slide_width;
 			height: @slide_height;
 			
@@ -56,9 +59,20 @@
 					height: auto;
 				}
 				
-				// If responsive height is set, use it
 				& when ( isnumber( @slide_height_responsive ) ) {
 					height: @slide_height_responsive;
+				}
+
+				& when ( isnumber( @slide_padding_top_responsive ) ) {
+					padding-top: @slide_padding_top_responsive;
+				}
+
+				& when ( isnumber( @slide_padding_sides_responsive ) ) {
+					padding-right: @slide_padding_sides_responsive;
+					padding-left: @slide_padding_sides_responsive;
+				}
+				& when ( isnumber( @slide_padding_responsive ) ) {
+					padding-bottom: @slide_padding_responsive;
 				}
 			}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/pull/1380

To test this PR, please import this [Test Layout](https://drive.google.com/uc?id=17Gs0mxwi-UG_7UtNuY40jHx0s5nNJquA) and then save. Switch to this branch and ensure the settings have migrated over as expected. [Here's a screenshot of the settings of this layout](https://i.imgur.com/u1jCFsg.jpeg).

Then test the new Responsive Padding settings.