### PR TITLE
Anything Carousel: Prevent Shadow from Navigation Dot

### DIFF
--- a/widgets/anything-carousel/css/style.less
+++ b/widgets/anything-carousel/css/style.less
@@ -92,6 +92,7 @@
 					button {
 						background: transparent;
 						border: 0;
+						box-shadow: none;
 						color: transparent;
 						cursor: pointer;
 						display: block;


### PR DESCRIPTION
This PR will prevent themes from adding a shadow to the navigation dot buttons. To test this PR:

- Switch to Corp
- Add an Anything Carousel, add a few items to allow for navigation dots, and enable Navigation Dots.
- View Page

It can be hard to see the dots so you may need to zoom.
![2021-10-08_06-01-11-1585](https://user-images.githubusercontent.com/17275120/136454202-98a65caf-ae98-4934-ad62-693644757310.jpg)


