### PR TITLE
Carousel: Change "Display navigation" label to "Display navigation arrows"

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -76,7 +76,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'tablet_portrait' => true,
 					'mobile' => true,
 				),
-				'navigation_label' => __( 'Show navigation', 'so-widgets-bundle' ),
+				'navigation_label' => __( 'Display navigation arrows', 'so-widgets-bundle' ),
 			)
 		);
 	}

--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -46,7 +46,6 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 				'label' => __( 'Slides to show ', 'so-widgets-bundle' ),
 				'description' => __( 'The number of slides to show on %s.', 'so-widgets-bundle' ),
 			),
-			'navigation_label' =>__( 'Display navigation arrows', 'so-widgets-bundle' ),
 		);
 	}
 


### PR DESCRIPTION
Also re-ordered slides_to_scroll_text to before slides_to_scroll to help with readability. This change affects both the Anything Carousel and Post Carousel.

