### PR TITLE
Base Slider: Merge Migration Code

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -302,21 +302,6 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			}
 		}
 
-		return $instance;
-	}
-
-	/**
-	 * Migrate Slider settings.
-	 *
-	 * @param $instance
-	 *
-	 * @return mixed
-	 */
-	function modify_instance( $instance ){
-		if ( empty( $instance ) ) {
-			return array();
-		}
-
 		// Migrate Hero and Layout Slider Layouts and Design settings to separate section.
 		if (
 			(


### PR DESCRIPTION
This PR will resolve the following error:

`Fatal error: Cannot redeclare SiteOrigin_Widget_Base_Slider::modify_instance() in /Users/amisplon/Sites/siteorigin/wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php on line 315`