### PR TITLE
Block Editor: Fix Google Maps Unexpected content error when previewing

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -508,7 +508,7 @@ jQuery(function ($) {
 		if (
 			$( '#sow-google-maps-js' ).length &&
 			(
-				forceLoad 
+				forceLoad ||
 				(
 					typeof sowb.googleMapsData.ApiError !== 'undefined' &&
 					sowb.googleMapsData.ApiError


### PR DESCRIPTION
This PR resolves a preview SO Google Maps widget preview issue that occurs in the SiteOrigin Layout Block and SiteOrigin Widgets Block. The below error will occur when the Block is previewed and prevent any further edits of that block. You'll need to reload the editor (or disable the default preview state) to be able to continue to edit it. This issue does not affect the front end.

`Uncaught TypeError: forceLoad is not a function`

To test this PR, please add a SiteOrign Block and set it up to display a SiteOrigin Maps widget, save, and then preview the Block. Once previewed, the Block will break. Reload the editor to confirm the issue remains, and then switch to this PR to confirm that it resolves this issue.
