### PR TITLE
Sliders: Add Background Video Opacity Setting

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -251,7 +251,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		return $slider_settings;
 	}
 
-	function modify_form( $form_options ) {
+	function widget_form( $form_options ) {
 		if ( isset( $form_options ) && isset( $form_options['frames'] ) ) {
 			$loop_setting = array(
 				'type' => 'checkbox',


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1408

This setting introduces the Background Video Opacity setting for all sliders. It's below the Loop Slide Background videos setting.
The Hero and Layout Sliders share exact same structure while the Slider widget doesn't so extra attention should be paid to the Slider widget during testing.