### PR TITLE
Video: Remove Related Video setting and general support

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -28,11 +28,11 @@ class SiteOrigin_Video {
 	 *
 	 * @param string $src The URL of the video.
 	 * @param bool $autoplay Whether to start playing the video automatically once loaded. ( YouTube only )
-	 * @param bool $related_videos Whether to show related videos after the video has finished playing. ( YouTube only )
+	 * @param bool $related_videos Deprecated.
 	 *
 	 * @return false|mixed|null|string|string[]
 	 */
-	function get_video_oembed( $src, $autoplay = false, $related_videos = true, $loop = false ) {
+	function get_video_oembed( $src, $autoplay = false, $related_videos = false, $loop = false ) {
 		if ( empty( $src ) ) {
 			return '';
 		}
@@ -66,13 +66,6 @@ class SiteOrigin_Video {
 				$html = preg_replace_callback( '/src=["\'](http[^"\']*)["\']/', array(
 					$this,
 					'loop_callback'
-				), $html );
-			}
-
-			if ( empty( $related_videos ) ) {
-				$html = preg_replace_callback( '/src=["\'](http[^"\']*)["\']/', array(
-					$this,
-					'remove_related_videos'
 				), $html );
 			}
 
@@ -125,16 +118,5 @@ class SiteOrigin_Video {
 			$match[1]
 		);						
 		return str_replace( $match[1], $new_url, $match[0] );
-	}
-
-	/**
-	 * The preg_replace callback that adds the rel param for YouTube videos.
-	 *
-	 * @param $match
-	 *
-	 * @return mixed
-	 */
-	function remove_related_videos( $match ) {
-		return str_replace( $match[1], add_query_arg( 'rel', 0, $match[1] ), $match[0] );
 	}
 }

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -4,7 +4,6 @@
  * @var $args
  * @var $player_id
  * @var $autoplay
- * @var $related_videos
  * @var $skin_class
  * @var $is_skinnable_video_host
  * @var $sources
@@ -61,7 +60,7 @@ do_action( 'siteorigin_widgets_sow-video_before_video', $instance );
 			<?php endforeach; ?>
 		</video>
 	<?php else : ?>
-		<?php echo $so_video->get_video_oembed( $src, $autoplay, $related_videos, $loop ); ?>
+		<?php echo $so_video->get_video_oembed( $src, $autoplay, false, $loop ); ?>
 	<?php endif; ?>
 </div>
 <?php do_action( 'siteorigin_widgets_sow-video_after_video', $instance ); ?>

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -121,16 +121,6 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 							'video_type[self]'     => array( 'hide' ),
 						)
 					),
-					'related_videos' => array(
-						'type'          => 'checkbox',
-						'default'       => true,
-						'label'         => __( 'Show related videos.', 'so-widgets-bundle' ),
-						'description'   => __( 'If the external host supports it.', 'so-widgets-bundle' ),
-						'state_handler' => array(
-							'video_type[external]' => array( 'show' ),
-							'video_type[self]'     => array( 'hide' ),
-						)
-					),
 				),
 			),
 		);
@@ -235,7 +225,6 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'poster'                  => $poster,
 			'autoplay'                => ! empty( $instance['playback']['autoplay'] ),
 			'loop'                    => ! empty( $instance['playback']['loop'] ),
-			'related_videos'          => ! empty( $instance['playback']['related_videos'] ),
 			'skin_class'              => 'default',
 			'fitvids'                 => ! empty( $instance['playback']['fitvids'] ),
 		);


### PR DESCRIPTION
YouTube has heavily reworked the [related video parameter](https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018) to the point that it doesn't work in a very desirable (and reliable) manner.
There's now no way to completely disable related videos.

YouTube says they'll only show videos from the same channel but that's not true. It'll typically show 1 - 2 from other channels. As a result of these changes, we've decided to completely drop support for this setting.
