### PR TITLE
Button: Allow for apostrophe in onclick

### DIFF
--- a/widgets/button/tpl/default.php
+++ b/widgets/button/tpl/default.php
@@ -13,7 +13,7 @@
 ?>
 <div class="ow-button-base ow-button-align-<?php echo esc_attr( $align ) ?>">
 	<a href="<?php echo sow_esc_url( do_shortcode( $href ) ) ?>" <?php foreach( $button_attributes as $name => $val ) echo $name . '="' . esc_attr( $val ) . '" ' ?>
-		<?php if ( ! empty( $onclick ) ) echo 'onclick="' . esc_js( $onclick ) . '"'; ?>>
+		<?php if ( ! empty( $onclick ) ) echo 'onclick="' . wp_unslash( esc_js( $onclick ) ) . '"'; ?>>
 		<span>
 			<?php
 				if( ! empty( $icon_image_url ) ) {


### PR DESCRIPTION
This will allow for users to add JS using apostrophes without it being slashed in a manner that makes it unusable. I've run some additional tests with how certain JS is handled by this change and I don't notice any direct issues by making this change.

Test JS:

`console.log('This will not output anything to the console prior to this PR');`