### PR TITLE
Multiple Media: box-sizing Adjustments

### DIFF
--- a/base/inc/fields/css/multiple-media-field.less
+++ b/base/inc/fields/css/multiple-media-field.less
@@ -4,7 +4,11 @@ div.siteorigin-widget-form .siteorigin-widget-field-type-multiple_media {
 
 	.multiple-media-field-wrapper {
 
-		* {
+		.button {
+			box-sizing: border-box;
+		}
+
+		.multiple-media-field-items {
 			box-sizing: content-box;
 		}
 


### PR DESCRIPTION
- The Add Media button requires `box-sizing: border-box;` to ensure the sizing is correct.
- `box-sizing: content-box;` only needs to be applied to the items.

Before:
![2021-11-01_04-06-31-1600](https://user-images.githubusercontent.com/17275120/139596235-49d03954-c23b-4359-92f9-4656c86f11f7.jpg)

After:
![2021-11-01_04-12-22-1601](https://user-images.githubusercontent.com/17275120/139596431-313e99e5-7a04-4206-b8c3-bd9812e15718.jpg)