### PR TITLE
Social Media Buttons: Add Google Network

### DIFF
--- a/widgets/social-media-buttons/data/networks.php
+++ b/widgets/social-media-buttons/data/networks.php
@@ -184,6 +184,12 @@ return array(
 		'icon_color' => '#372213',
 		'button_color' => '#e2e0d1'
 	),
+	'google' => array(
+		'label'    => __( 'Google', 'so-widgets-bundle' ),
+		'base_url' => 'https://google.com/',
+		'icon_color' => '#4285F4',
+		'button_color' => '#FFFFFF'
+	),
 	'hacker-news'   => array(
 		'label'    => __( 'Hacker News', 'so-widgets-bundle' ),
 		'base_url' => 'https://news.ycombinator.com/',

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -192,6 +192,12 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 				if ( $network['name'] == 'envelope' ) {
 					$network['name'] = 'email';
 				}
+
+				// If user has a legacy Google Plus network selected, convert it to a standard Google icon.
+				if ( $network['name'] == 'google-plus' ) {
+					 $network['name'] = 'google';
+				}
+
 				$network['icon_name'] = 'fontawesome-' . ( $network['name'] == 'email' ? 'envelope' : $network['name'] );
 				$instance['networks'][$name] = $network;
 			}


### PR DESCRIPTION
This PR is a follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1399. That PR assumes all users were solely using that network for _just_ Google Plus, but there are reasons why a user may have used that icon without it being directly connected to Google Plus - such as Google Business reviews.

This PR adds a Google network option and adds migration code for any instances that were previously using the Google Plus network.