### PR TITLE
Block Editor: Resolve Google Map Widget Errors

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -464,40 +464,45 @@ jQuery(function ($) {
 			}
 			$this.data( 'apiInitialized', true );
 		});
+
 		if ( typeof window.google === 'undefined' ) {
 			window.google = {};
 		}
 
 		if (
 			forceLoad ||
-			typeof window.google === 'undefined' ||
 			typeof window.google.maps === 'undefined'
 		) {
-			sowb.loadGoogleMapsAPI( forceLoad );
-			// Ensure Google Maps is loaded before using it.
-			sowb.googleMapsData.timer = setInterval( function () {
-				var clearTimer = false;
-				// Check if there been an error.
-				sowb.googleMapsData.ApiError = true;
-				if (
-					typeof sowb.googleMapsData.ApiError !== 'undefined' &&
-					sowb.googleMapsData.ApiError
-				) {
-					clearTimer = true;
-				}
-				if (
-					! clearTimer &&
-					typeof window.google !== 'undefined' &&
-					typeof window.google.maps !== 'undefined'
-				) {
-					clearTimer = true;
-					soGoogleMapInitialize();
-				}
+			// If this is an admin preview, and the API has already been setup,
+			// skip any further API checks to confirm it's working and set it up.
+			if ( $( 'body.wp-admin' ).length && $( '#sow-google-maps-js' ).length ) {
+				soGoogleMapInitialize();
+			} else {
+				sowb.loadGoogleMapsAPI( forceLoad );
+				// Ensure Google Maps is loaded before using it.
+				sowb.googleMapsData.timer = setInterval( function () {
+					var clearTimer = false;
+					// Check if there been an error.
+					sowb.googleMapsData.ApiError = true;
+					if (
+						typeof sowb.googleMapsData.ApiError !== 'undefined' &&
+						sowb.googleMapsData.ApiError
+					) {
+						clearTimer = true;
+					}
+					if (
+						! clearTimer &&
+						typeof window.google.maps !== 'undefined'
+					) {
+						clearTimer = true;
+						soGoogleMapInitialize();
+					}
 
-				if ( clearTimer ) {
-					clearInterval( sowb.googleMapsData.timer );
-				}
-			}, 250 );
+					if ( clearTimer ) {
+						clearInterval( sowb.googleMapsData.timer );
+					}
+				}, 250 );
+			}
 		}
 	};
 

--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -448,6 +448,12 @@ jQuery(function ($) {
 		if ( ! $mapCanvas.length ) {
 			return;
 		}
+
+		// Account for situation where widget preview is loaded before the location field.
+		if ( $( 'body.wp-admin' ).length ) {
+			sowb.googleMapsData.libraries.push( 'places' );
+		}
+
 		$mapCanvas.each(function(index, element) {
 			var $this = $(element);
 			if ( $this.data( 'apiInitialized' ) ) {

--- a/widgets/google-map/fields/js/location-field.js
+++ b/widgets/google-map/fields/js/location-field.js
@@ -268,10 +268,14 @@ window.addEventListener('DOMContentLoaded', function () {
 			
 			window.console.error = sowbForms.checkMapsApiInvalidKeyError;
 		}
-		
-		// Try to load even if API key is missing to allow Google Maps API to provide it's own warnings/errors about missing API key.
-		var apiUrl = 'https://maps.googleapis.com/maps/api/js?key=' + apiKey + '&libraries=places&callback=sowbAdminGoogleMapInit';
-		$( 'body' ).append( '<script async type="text/javascript" src="' + apiUrl + '">' );
+
+		if ( $( '#sow-google-maps-js' ).length ) {
+			// Try to load even if API key is missing to allow Google Maps API to provide it's own warnings/errors about missing API key.
+			var apiUrl = 'https://maps.googleapis.com/maps/api/js?key=' + apiKey + '&libraries=places&callback=sowbAdminGoogleMapInit';
+			$( 'body' ).append( '<script async type="text/javascript" id="sow-google-maps-js" src="' + apiUrl + '">' );
+		} else {
+			sowbAdminGoogleMapInit();
+		}
 	} );
 
 });

--- a/widgets/google-map/fields/js/location-field.js
+++ b/widgets/google-map/fields/js/location-field.js
@@ -155,7 +155,7 @@ sowbForms.LocationField = function () {
 };
 
 sowbForms.setupLocationFields = function () {
-	if ( google && google.maps && google.maps.places ) {
+	if ( window.google && window.google.maps && window.google.maps.places ) {
 		document.querySelectorAll( '.siteorigin-widget-field-type-location' ).forEach( function ( element ) {
 			var elementVisible = !!( element.offsetWidth !== 0 && element.offsetHeight !== 0 );
 			if ( elementVisible && element.getAttribute( 'data-initialized' ) !== 'true' ) {


### PR DESCRIPTION
This PR resolves a few JS related errors and notices that can result in SiteOrigin Google Maps widget not working as expected or other widgets/blocks being negatively affected.

To test this PR:

- Please confirm no console errors occur when previewing the map (outside of generic WordPress errors).
- You're able to use the Location field after viewing the Block Preview first.
- You're able to preview the map after using the Location field first.