### PR TITLE
Hero: Allow Buttons to Contain $

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -376,14 +376,21 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 * @param $args
 	 * @param $instance
 	 */
-	public function sub_widget($class, $args, $instance){
+	public function sub_widget( $class, $args, $instance, $return = false ){
 		if(!class_exists($class)) return;
 		$widget = new $class;
 
 		$args['before_widget'] = '';
 		$args['after_widget'] = '';
+		if ( $return ) {
+			ob_start();
+		}
 
 		$widget->widget( $args, $instance );
+		
+		if ( $return ) {
+			return ob_get_clean();
+		}
 	}
 
 	/**

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -409,14 +409,16 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 
 		$content = wp_kses_post($content);
 		if ( strpos( $content, '[buttons]' ) !== false ) {
-			ob_start();
-			foreach( $frame['buttons'] as $button ) {
-				$this->sub_widget('SiteOrigin_Widget_Button_Widget', array(), $button['button']);
-			}
-			$button_code = ob_get_clean();
+			// Replace [buttons] with button wrapper.
+			$content = preg_replace('/(?:<(?:p|h\d|em|strong|li|blockquote) *([^>]*)> *)?\[ *buttons *\](:? *<\/(?:p|h\d|em|strong|li|blockquote)>)?/i', '<div class="sow-hero-buttons" $1>[SiteOriginHeroButton]</div>', $content );
 
-			// Add in the button code
-			$content = preg_replace('/(?:<(?:p|h\d|em|strong|li|blockquote) *([^>]*)> *)?\[ *buttons *\](:? *<\/(?:p|h\d|em|strong|li|blockquote)>)?/i', '<div class="sow-hero-buttons" $1>' . $button_code . '</div>', $content );
+			// Generate buttons.
+			foreach( $frame['buttons'] as $button ) {
+				$button_code .= $this->sub_widget('SiteOrigin_Widget_Button_Widget', array(), $button['button'], true);
+			}
+
+			// Add buttons to wrapper.
+			$content = str_replace( '[SiteOriginHeroButton]', $button_code, $content );
 		}
 		
 		// Process normal shortcodes


### PR DESCRIPTION
This PR allows for a button to the Hero widget to have a $. To test his PR set up a frame and add a button. Set the text to: `$25` and then save. How does that look?

(it's possible for certain other combinations to work, but using a price is the simplest way to removed it).