### PR TITLE
CSS Cache Compat: Hummingbird, Breeze, and potential `$Id` detection issue

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -70,9 +70,9 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 	public function clear_page_cache( $name, $instance = array() ) {
 		$id = explode( '-', $name );
 		$id = end( $id );
+		$id = explode( '.', $id )[0];
 
 		if ( is_numeric( $id ) ) {
-
 			if ( function_exists( 'w3tc_flush_post' ) ) {
 				w3tc_flush_post( $id );
 			}

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -80,6 +80,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			if ( class_exists( 'Swift_Performance_Cache' ) ) {
 				Swift_Performance_Cache::clear_post_cache( $id );
 			}
+
+			if ( class_exists( '\Hummingbird\\WP_Hummingbird' ) ) {
+				do_action( 'wphb_clear_page_cache', $id );
+			}
 		}
 	}
 
@@ -93,6 +97,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 
 		if ( class_exists( 'Swift_Performance_Cache' ) ) {
 			Swift_Performance_Cache::clear_all_cache();
+		}
+
+		if ( class_exists( '\Hummingbird\\WP_Hummingbird' ) ) {
+			do_action( 'wphb_clear_page_cache' );
 		}
 	}
 

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -84,6 +84,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			if ( class_exists( '\Hummingbird\\WP_Hummingbird' ) ) {
 				do_action( 'wphb_clear_page_cache', $id );
 			}
+
+			if ( function_exists( 'breeze_varnish_purge_cache' ) ) {
+				breeze_varnish_purge_cache( get_the_permalink( $id ) );
+			}
 		}
 	}
 
@@ -101,6 +105,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 
 		if ( class_exists( '\Hummingbird\\WP_Hummingbird' ) ) {
 			do_action( 'wphb_clear_page_cache' );
+		}
+
+		if ( class_exists( 'Breeze_PurgeCache' ) ) {
+			Breeze_PurgeCache::breeze_cache_flush();
 		}
 	}
 


### PR DESCRIPTION
This PR adds auto clearing cache support for:
- [Hummingbird](https://wordpress.org/plugins/hummingbird-performance/)
- [Breeze](https://wordpress.org/plugins/breeze/)

For testing instructions, please refer to [the initial PR](https://github.com/siteorigin/so-widgets-bundle/pull/1258) for this functionality,

This PR also prevents a situation where the file extension is included in the `$id` detection which will prevent the  CSS Cache from clearing correctly.