### PR TITLE
Google Map: Improved Init, global Google Maps Var usage, and SO Widgets Block Dispaly Issue Fix

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -118,7 +118,7 @@ sowb.SiteOriginGoogleMap = function($) {
 					}
 				}.bind( this ) );
 
-				window.google.maps.event.addDomListener( autocompleteElement, 'keypress', function ( event ) {
+				window.google.maps.event.addDomListener( autocompleteElement, 'keypress', function( event ) {
 					var key = event.keyCode || event.which;
 					if ( key === '13' ) {
 						event.preventDefault();
@@ -292,7 +292,7 @@ sowb.SiteOriginGoogleMap = function($) {
 						optimizeWaypoints: directions.optimizeWaypoints,
 					},
 					function(result, status) {
-						if (status === window.google.maps.DirectionsStatus.OK) {
+						if ( status === window.google.maps.DirectionsStatus.OK ) {
 							directionsRenderer.setOptions( { preserveViewport: directions.preserveViewport } );
 							directionsRenderer.setDirections(result);
 						}
@@ -437,7 +437,7 @@ sowb.SiteOriginGoogleMap = function($) {
 
 // Called by Google Maps API when it has loaded.
 function soGoogleMapInitialize() {
-	new sowb.SiteOriginGoogleMap(jQuery).initMaps();
+	jQuery( window.sowb ).trigger( 'sow-google-map-loaded' );
 }
 
 jQuery(function ($) {

--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -440,6 +440,11 @@ function soGoogleMapInitialize() {
 	jQuery( window.sowb ).trigger( 'sow-google-map-loaded' );
 }
 
+jQuery( window.sowb ).on( 'sow-google-map-loaded', function() {
+	new sowb.SiteOriginGoogleMap(jQuery).initMaps();
+} );
+
+
 jQuery(function ($) {
 	sowb.googleMapsData = [];
 	sowb.googleMapsData.libraries = [];
@@ -482,7 +487,9 @@ jQuery(function ($) {
 			// If this is an admin preview, and the API has already been setup,
 			// skip any further API checks to confirm it's working and set it up.
 			if ( $( 'body.wp-admin' ).length && $( '#sow-google-maps-js' ).length ) {
-				soGoogleMapInitialize();
+				setTimeout( function() {
+					soGoogleMapInitialize();
+				}, 250 );
 			} else {
 				sowb.loadGoogleMapsAPI( forceLoad );
 				// Ensure Google Maps is loaded before using it.

--- a/widgets/google-map/fields/js/location-field.js
+++ b/widgets/google-map/fields/js/location-field.js
@@ -7,6 +7,7 @@ sowbForms.LocationField = function () {
 	return {
 		init: function ( element ) {
 			
+			if ( typeof window.google.maps.places === 'undefined' ) {
 				console.error( 'SiteOrigin Google Maps Widget: Failed to load the places library.' );
 				return;
 			}
@@ -168,10 +169,15 @@ sowbForms.setupLocationFields = function () {
 
 // Called by Google Maps API when it has loaded.
 function sowbAdminGoogleMapInit() {
+	jQuery( window.sowb ).trigger( 'sow-google-map-loaded' );
+}
+
+jQuery( window.sowb ).on( 'sow-google-map-loaded', function() {
 	sowbForms.mapsInitializing = false;
 	sowbForms.mapsInitialized = true;
 	sowbForms.setupLocationFields();
-}
+} );
+
 
 window.addEventListener('DOMContentLoaded', function () {
 
@@ -274,7 +280,7 @@ window.addEventListener('DOMContentLoaded', function () {
 			var apiUrl = 'https://maps.googleapis.com/maps/api/js?key=' + apiKey + '&libraries=places&callback=sowbAdminGoogleMapInit';
 			$( 'body' ).append( '<script async type="text/javascript" id="sow-google-maps-js" src="' + apiUrl + '">' );
 		} else {
-			sowbAdminGoogleMapInit();
+			jQuery( window.sowb ).trigger( 'sow-google-map-loaded' );
 		}
 	} );
 

--- a/widgets/google-map/fields/js/location-field.js
+++ b/widgets/google-map/fields/js/location-field.js
@@ -1,19 +1,19 @@
 /* global jQuery, sowbForms, soLocationField */
 
 window.sowbForms = window.sowbForms || {};
+window.sowb = window.sowb || {};
 
 sowbForms.LocationField = function () {
 	return {
 		init: function ( element ) {
 			
-			if ( typeof google.maps.places === 'undefined' ) {
 				console.error( 'SiteOrigin Google Maps Widget: Failed to load the places library.' );
 				return;
 			}
 			
 			var inputField = element.querySelector( '.siteorigin-widget-location-input' );
 			var valueField = element.querySelector( '.siteorigin-widget-input' );
-			var autocomplete = new google.maps.places.Autocomplete( inputField );
+			var autocomplete = new window.google.maps.places.Autocomplete( inputField );
 			
 			var getSimplePlace = function ( place ) {
 				return new Promise(function (resolve, reject) {
@@ -24,9 +24,9 @@ sowbForms.LocationField = function () {
 						resolve(simplePlace);
 					} else {
 						var addr = {address: place.hasOwnProperty('formatted_address') ? place.formatted_address : place.name};
-						new google.maps.Geocoder().geocode(addr,
+						new window.google.maps.Geocoder().geocode(addr,
 							function (results, status) {
-								if (status === google.maps.GeocoderStatus.OK) {
+								if (status === window.google.maps.GeocoderStatus.OK) {
 									simplePlace.location = results[0].geometry.location.toString();
 									resolve(simplePlace);
 								} else {
@@ -117,7 +117,7 @@ sowbForms.LocationField = function () {
 							}
 						} )
 						.catch( function ( status ) {
-							if ( status === google.maps.GeocoderStatus.OVER_QUERY_LIMIT ) {
+							if ( status === window.google.maps.GeocoderStatus.OVER_QUERY_LIMIT ) {
 								if ( ! sowbForms.hasOwnProperty( 'overQueryLimitCount' ) ) {
 									sowbForms.overQueryLimitCount = 1;
 								} else {


### PR DESCRIPTION
This PR resolves an issue that results in the SiteOrigin Widget Block not working if the Google Map widget is set up. It also switches to an event-based init to allow for the location field and map override each other - this could also help with third-party plugins.

`sow.google-map.js?ver=dev:567 TypeError: Cannot read properties of undefined (reading 'Geocoder')`

To test this PR,
- Check that you're able to set up a Google Map on a Classic Editor powered page.
- Set up a SiteOrigin Widget Block with a Google Map able to display.
- Set up a SiteOrigin Layouts Block with a SiteOrigin Google Maps widget setup and previewing (ideally at the same time as the SiteOrigin Widgets Block version).