### PR TITLE
Slider Setting Migration: Check If Subsection Value Exists Before Migration

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -348,7 +348,9 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			foreach ( $migrate_layout_settings as $setting => $sub_section ) {
 				if ( is_array( $sub_section ) ) {
 					foreach ( $sub_section as $responsive_setting ) {
-						$instance['layout'][ $setting ][ $responsive_setting ] = $instance['design'][ $responsive_setting ];
+						if ( ! empty( $instance['design'][ $responsive_setting ] ) ) {
+							$instance['layout'][ $setting ][ $responsive_setting ] = $instance['design'][ $responsive_setting ];
+						}
 					}
 				} elseif ( ! empty( $instance['design'][ $setting ] ) ) {
 					$instance['layout'][ $setting ] = $instance['design'][ $setting ];


### PR DESCRIPTION
This PR resolves the following error:

`[05-Dec-2021 09:57:03 UTC] PHP Notice:  Undefined index: height_responsive_unit in /***/public_html/wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php on line 351`