### PR TITLE
Accordion: Hide Closed Panels Prior to Load

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -12,7 +12,6 @@ jQuery( function ( $ ) {
 			}
 
 			var $accordionPanels = $( element ).find( '> .sow-accordion-panel' );
-			$accordionPanels.not( '.sow-accordion-panel-open' ).children( '.sow-accordion-panel-content' ).hide();
 			var openPanels = $accordionPanels.filter( '.sow-accordion-panel-open' ).toArray();
 
 			var updateHash = function () {

--- a/widgets/accordion/tpl/default.php
+++ b/widgets/accordion/tpl/default.php
@@ -33,7 +33,13 @@ if( !empty( $instance['title'] ) ) {
 					</div>
 				</div>
 
-			<div class="sow-accordion-panel-content" role="region" aria-labelledby="accordion-label-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>" id="accordion-content-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>">
+			<div
+				class="sow-accordion-panel-content"
+				role="region"
+				aria-labelledby="accordion-label-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>"
+				id="accordion-content-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>"
+				<?php if ( $panel['initial_state'] == 'closed' ) echo 'style="display: none;"'; ?>
+			>
 				<div class="sow-accordion-panel-border" tabindex="0">
 					<?php $this->render_panel_content( $panel, $instance ); ?>
 				</div>


### PR DESCRIPTION
This PR will change how the Accordion hides closed panels so that they're automatically hidden before page load to load.