### PR TITLE
Anything Carousel: Animation Setting

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -223,6 +223,15 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'type' => 'checkbox',
 					'label' => __( 'Navigation dots', 'so-widgets-bundle' ),
 				),
+				'animation' => array(
+					'type' => 'select',
+					'label' => __( 'Animation', 'so-widgets-bundle' ),
+					'default' => 'Ease',
+					'options' => array(
+						'ease' => __( 'Ease', 'so-widgets-bundle' ),
+						'linear' => __( 'Linear', 'so-widgets-bundle' ),
+					),
+				),
 				'animation_speed' => array(
 					'type' => 'number',
 					'label' => __( 'Animation speed', 'so-widgets-bundle' ),
@@ -360,6 +369,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 		$variables = array(
 			'loop' => isset( $settings['loop'] ) ? $settings['loop'] : true,
 			'dots' => isset( $settings['dots'] ) ? $settings['dots'] : true,
+			'animation' => isset( $settings['animation'] ) ? $settings['animation'] : 'ease',
 			'animation_speed' => ! empty( $settings['animation_speed'] ) ? $settings['animation_speed'] : 800,
 			'autoplay' => isset( $settings['autoplay'] ) ? $settings['autoplay'] : false,
 			'pauseOnHover' => isset( $settings['autoplay_pause_hover'] ) ? $settings['autoplay_pause_hover'] : false,

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -34,6 +34,7 @@ jQuery( function ( $ ) {
 				infinite: ! $$.data( 'ajax-url' )&&  $$.data( 'carousel_settings' ).loop,
 				variableWidth: $$.data( 'variable_width' ),
 				accessibility: false,
+				cssEase: carouselSettings.animation,
 				speed: carouselSettings.animation_speed,
 				autoplay: carouselSettings.autoplay,
 				autoplaySpeed: carouselSettings.autoplaySpeed,


### PR DESCRIPTION
This PR adds an Animation setting to the Anything Carousel widget. This allows you to set the Anything Carousel up to continuously scroll rather.

To test this PR:
- Please add a Siterigin Anything Carousel and add enough items to allow for a number of scrolls.
- Open the settings and set `Animation` to `Linear`.
- Set Timeout to 1 for the best overall results.
- Consider reducing the `Slides to Scroll` setting to `1` and setting the Animation to a lower amount to speed up the scroll - try `2500`.