### PR TITLE
Presets: Trigger Init and Improved Automated Section Hiding

### DIFF
--- a/base/inc/fields/js/presets-field.js
+++ b/base/inc/fields/js/presets-field.js
@@ -11,6 +11,7 @@
 		var $undoLink = $presetSelect.find( '+ .sowb-presets-field-undo' );
 		$undoLink.hide();
 
+		var onLoadTrigger = false;
 		var addingDefault = false;
 		var presets = $presetSelect.data( 'presets' );
 		$presetSelect.on( 'change', function() {
@@ -18,9 +19,9 @@
 			if ( selectedPreset && presets.hasOwnProperty( selectedPreset ) ) {
 				var presetValues = presets[ selectedPreset ].values;
 				var $formContainer = $presetSelect.closest( '.siteorigin-widget-form-main' );
-				
+
 				// If we're adding defaults, don't show undo.
-				if ( ! addingDefault) {
+				if ( ! addingDefault && ! onLoadTrigger) {
 					var previousValues = $presetSelect.data( 'previousValues' );
 					if ( ! previousValues ) {
 						var presetClone = JSON.parse( JSON.stringify( presetValues ) );
@@ -57,9 +58,9 @@
 							$presetSelect.val( '' );
 						} );
 					}
+					sowbForms.setWidgetFormValues( $formContainer, presetValues, true );
 				}
-			
-				sowbForms.setWidgetFormValues( $formContainer, presetValues, true );
+				onLoadTrigger = false;
 			}
 		} );
 
@@ -72,6 +73,7 @@
 				$presetSelect.val( $presetSelect.data( 'default-preset' ) );
 			}
 		}
+		onLoadTrigger = true;
 		$presetSelect.trigger( 'change' );
 
 		$presetSelect.data( 'initialized', true );

--- a/base/inc/fields/js/presets-field.js
+++ b/base/inc/fields/js/presets-field.js
@@ -70,9 +70,9 @@
 			if ( $presetSelect.val() == 'default' ) {
 				addingDefault = true;
 				$presetSelect.val( $presetSelect.data( 'default-preset' ) );
-				$presetSelect.trigger( 'change' );
 			}
 		}
+		$presetSelect.trigger( 'change' );
 
 		$presetSelect.data( 'initialized', true );
 	} );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1436,6 +1436,8 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				continue;
 			}
 
+			$used_by = null;
+
 			// If this is a section field, we need to apply the state handlers for sub fields.
 			if ( $fields[ $field ]['type'] == 'section' ) {
 				$fields[ $field ]['fields'] = $this->dynamic_preset_add_state_handler(
@@ -1444,12 +1446,14 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 					$fields[ $field ]['fields']
 				);
 
-				$used_by = implode( ',', $field_value['key'] );
+				if ( isset( $field_value['key'] ) ) {
+					$used_by = implode( ',', $field_value['key'] );
+				}
 			} else {
 				$used_by = implode( ',', $field_value ); 
 			}
 
-			if ( ! $exclude_section ) {
+			if ( ! $exclude_section && ! empty( $used_by ) ) {
 				$fields[ $field ]['state_handler'] = array(
 					$state_name . '[' . $used_by . ']' => array( 'show' ),
 						'_else[' . $state_name . ']' => array( 'hide' ),

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -1369,7 +1369,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 *
 	 * @return array $fields with any state_handler's applied.
 	 */
-	protected function dynamic_preset_state_handler( $state_name, $preset_data, $fields ) {
+	public function dynamic_preset_state_handler( $state_name, $preset_data, $fields ) {
 		// Build an array of all the adjusted fields by the preset data, and note which presets adjust them.
 		$adjusted_fields = array();
 		foreach ( $preset_data as $preset_id => $preset ) {
@@ -1386,7 +1386,8 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		return $this->dynamic_preset_add_state_handler(
 			$state_name,
 			$adjusted_fields,
-			$fields
+			$fields,
+			true
 		);
 	}
 
@@ -1406,6 +1407,8 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				$extracted_fields[ $field_key ] = $this->dynamic_preset_extract_fields( $field, $preset_id );
 			} else {
 				$extracted_fields[ $field_key ][] = $preset_id;
+				// Add a key that contains all of the presets that adjust this section.
+				$extracted_fields['key'][ $preset_id ] = $preset_id;
 			}
 		}
 
@@ -1419,10 +1422,11 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 * @param string $state_name
 	 * @param array $preset_adjusted_fields
 	 * @param array $fields The fields to apply state handlers too.
+	 * @param array false $exclude_section Whether to add state emitter to the current section.
 	 *
 	 * @return array $fields with any state_handler's applied.
 	 */
-	private function dynamic_preset_add_state_handler( $state_name, $adjusted_fields, $fields ) {
+	private function dynamic_preset_add_state_handler( $state_name, $adjusted_fields, $fields, $exclude_section = false ) {
 		foreach ( $adjusted_fields as $field => $field_value ) {
 			// Skip field if it's not adjusted by of the presets, or if the field has a state_handler already.
 			if (
@@ -1439,8 +1443,13 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 					$field_value,
 					$fields[ $field ]['fields']
 				);
+
+				$used_by = implode( ',', $field_value['key'] );
 			} else {
 				$used_by = implode( ',', $field_value ); 
+			}
+
+			if ( ! $exclude_section ) {
 				$fields[ $field ]['state_handler'] = array(
 					$state_name . '[' . $used_by . ']' => array( 'show' ),
 						'_else[' . $state_name . ']' => array( 'hide' ),


### PR DESCRIPTION
This PR ensures that state emitters are correctly triggered when opening a widget that uses a presets field for state emitter. It also adds a key that contains all of the presets that adjust sections to allow for more automatic section hiding.

Please test this PR using https://github.com/siteorigin/siteorigin-premium/pull/587
Prior to this PR **Design > Category** settings group will appear while using the Default theme. If you save with the Overlay theme selected the Default sections will appear when re-opening the widget.