### PR TITLE
Accordion/Tabs: Remove `border-radius` dependency on `border-width`

### DIFF
--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -32,16 +32,17 @@
 .sow-accordion {
 	.sow-accordion-panel {
 		.sow-accordion-panel-header {
-			position: relative;
-			cursor: pointer;
-			padding: @heading_padding;
 			background-color: @heading_background_color;
+			border-radius: @heading_border_radius;
 			color: @title_color;
-			font-family: @heading_title_font_family;
-			font-weight: @heading_title_font_weight;
-			font-size: @heading_title_font_size;
-			text-transform: @heading_title_text_transform;
+			cursor: pointer;
 			display: flex;
+			font-family: @heading_title_font_family;
+			font-size: @heading_title_font_size;
+			font-weight: @heading_title_font_weight;
+			padding: @heading_padding;
+			position: relative;
+			text-transform: @heading_title_text_transform;
 			& when ( @open_close_location = right ) {
 				flex-direction: row;
 			}
@@ -54,7 +55,6 @@
 				border-style: solid;
 				border-width: @heading_border_width;
 			}
-			border-radius: @heading_border_radius;
 
 			&:hover {
 				background-color: @heading_background_hover_color;
@@ -119,17 +119,18 @@
 		.sow-accordion-panel-content {
 			.sow-accordion-panel-border {
 				background-color: @panels_background_color;
+				border-radius: @panels_border_radius;
 				& when ( @has_panels_border_width = true ) {
 					border-color: @panels_border_color;
 					border-style: solid;
 					border-width: @panels_border_width;
 				}
-				border-radius: @panels_border_radius;
-				padding: @panels_padding;
 				color: @panels_font_color;
 				font-family: @panels_font_family;
 				font-size: @panels_font_size;
 				overflow: auto;
+				padding: @panels_padding;
+
 				&:focus {
 					outline: 1px dotted #666;
 					outline: auto 5px -webkit-focus-ring-color;

--- a/widgets/accordion/styles/default.less
+++ b/widgets/accordion/styles/default.less
@@ -50,11 +50,11 @@
 			}
 
 			& when( @has_heading_border_width = true ) {
-				border-style: solid;
 				border-color: @heading_border_color;
+				border-style: solid;
 				border-width: @heading_border_width;
-				border-radius: @heading_border_radius;
 			}
+			border-radius: @heading_border_radius;
 
 			&:hover {
 				background-color: @heading_background_hover_color;
@@ -120,11 +120,11 @@
 			.sow-accordion-panel-border {
 				background-color: @panels_background_color;
 				& when ( @has_panels_border_width = true ) {
-					border-style: solid;
 					border-color: @panels_border_color;
+					border-style: solid;
 					border-width: @panels_border_width;
-					border-radius: @panels_border_radius;
 				}
+				border-radius: @panels_border_radius;
 				padding: @panels_padding;
 				color: @panels_font_color;
 				font-family: @panels_font_family;

--- a/widgets/tabs/styles/default.less
+++ b/widgets/tabs/styles/default.less
@@ -65,11 +65,11 @@
 
 		//noinspection CssOptimizeSimilarProperties
 		& when ( @has_tabs_container_border_width = true ) {
-			border-style: solid;
 			border-color: @tabs_container_border_color;
+			border-style: solid;
 			border-width: @tabs_container_border_width;
-			border-radius: @tabs_container_border_radius;
 		}
+		border-radius: @tabs_container_border_radius;
 
 		.sow-tabs-tab {
 			display: inline-block;
@@ -85,11 +85,11 @@
 
 			//noinspection CssOptimizeSimilarProperties
 			& when ( @has_tabs_border_width = true ) {
-				border-style: solid;
 				border-color: @tabs_border_color;
+				border-style: solid;
 				border-width: @tabs_border_width;
-				border-radius: @tabs_border_radius;
 			}
+			border-radius: @tabs_border_radius;
 
 			&.sow-tabs-tab-selected, &:hover {
 				background-color: @tabs_background_hover_color;
@@ -97,11 +97,11 @@
 
 				//noinspection CssOptimizeSimilarProperties
 				& when ( @has_tabs_border_hover_width = true ) {
-					border-style: solid;
 					border-color: @tabs_border_hover_color;
+					border-style: solid;
 					border-width: @tabs_border_hover_width;
-					border-radius: @tabs_border_radius;
 				}
+				border-radius: @tabs_border_radius;
 			}
 
 			.sow-tabs-title {
@@ -134,11 +134,11 @@
 
 		//noinspection CssOptimizeSimilarProperties
 		& when( @has_panels_border_width = true ) {
+			border-color: @panels_border_color;
 			border-style: solid;
 			border-width: @panels_border_width;
-			border-color: @panels_border_color;
-			border-radius: @panels_border_radius;
 		}
+		border-radius: @panels_border_radius;
 
 		.sow-tabs-panel {
 			padding: @panels_padding;

--- a/widgets/tabs/styles/default.less
+++ b/widgets/tabs/styles/default.less
@@ -40,8 +40,9 @@
 .sow-tabs {
 	.sow-tabs-tab-container {
 		background-color: @tabs_container_background_color;
-		padding: @tabs_container_padding;
+		border-radius: @tabs_container_border_radius;
 		display: flex;
+		padding: @tabs_container_padding;
 
 		& when ( @tabs_container_tabs_position = top ), ( @tabs_container_tabs_position = bottom ) {
 			flex-wrap: wrap;
@@ -69,18 +70,18 @@
 			border-style: solid;
 			border-width: @tabs_container_border_width;
 		}
-		border-radius: @tabs_container_border_radius;
 
 		.sow-tabs-tab {
-			display: inline-block;
-			cursor: pointer;
 			background-color: @tabs_background_color;
-			padding: @tabs_padding;
-			margin: @tabs_margin;
+			border-radius: @tabs_border_radius;
 			color: @tabs_title_color;
+			cursor: pointer;
+			display: inline-block;
 			font-family: @tabs_font_family;
-			font-weight: @tabs_font_weight;
 			font-size: @tabs_font_size;
+			font-weight: @tabs_font_weight;
+			margin: @tabs_margin;
+			padding: @tabs_padding;
 			transition: all 0.3s;
 
 			//noinspection CssOptimizeSimilarProperties
@@ -89,10 +90,10 @@
 				border-style: solid;
 				border-width: @tabs_border_width;
 			}
-			border-radius: @tabs_border_radius;
 
 			&.sow-tabs-tab-selected, &:hover {
 				background-color: @tabs_background_hover_color;
+				border-radius: @tabs_border_radius;
 				color: @tabs_title_hover_color;
 
 				//noinspection CssOptimizeSimilarProperties
@@ -101,7 +102,6 @@
 					border-style: solid;
 					border-width: @tabs_border_hover_width;
 				}
-				border-radius: @tabs_border_radius;
 			}
 
 			.sow-tabs-title {
@@ -128,9 +128,10 @@
 	}
 
 	.sow-tabs-panel-container {
-		position: relative;
+		border-radius: @panels_border_radius;
 		background-color: @panels_background_color;
 		color: @panels_font_color;
+		position: relative;
 
 		//noinspection CssOptimizeSimilarProperties
 		& when( @has_panels_border_width = true ) {
@@ -138,7 +139,6 @@
 			border-style: solid;
 			border-width: @panels_border_width;
 		}
-		border-radius: @panels_border_radius;
 
 		.sow-tabs-panel {
 			padding: @panels_padding;


### PR DESCRIPTION
`border-radius` doesn't need an actual width so this PR removes the dependency on `border-width`.