### PR TITLE
Slider: Disable `loading` override when AMP plugin is active

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -30,6 +30,20 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
 		add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
 		add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
+
+		if (
+			function_exists( 'amp_is_enabled' ) &&
+			amp_is_enabled()
+		) {
+			// AMP plugin is installed and enabled. Remove Slider Lazy Loading.ss
+			add_filter( 'siteorigin_widgets_slider_attr', function( $attr ) {
+				if ( ! empty( $attr['class'] ) ) {
+					$attr['class'] = str_replace( ' skip-lazy', '', $attr['class'] );
+				}
+				unset( $attr['loading'] );
+				return $attr;
+			} );
+		}
 	}
 
 	function get_active_builder() {

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -35,7 +35,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			function_exists( 'amp_is_enabled' ) &&
 			amp_is_enabled()
 		) {
-			// AMP plugin is installed and enabled. Remove Slider Lazy Loading.ss
+			// AMP plugin is installed and enabled. Remove Slider Lazy Loading.
 			add_filter( 'siteorigin_widgets_slider_attr', function( $attr ) {
 				if ( ! empty( $attr['class'] ) ) {
 					$attr['class'] = str_replace( ' skip-lazy', '', $attr['class'] );

--- a/compat/compat.php
+++ b/compat/compat.php
@@ -40,7 +40,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 				if ( ! empty( $attr['class'] ) ) {
 					$attr['class'] = str_replace( ' skip-lazy', '', $attr['class'] );
 				}
-				unset( $attr['loading'] );
+				$attr['loading'] = false;
 				return $attr;
 			} );
 		}

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -216,10 +216,12 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 							$frame['foreground_image'],
 							'full',
 							! empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-							array(
-								'class' => 'sow-slider-foreground-image skip-lazy',
-								'loading' => 'eager',
-								'style' => ! empty( $foreground_style_attr ) ? $foreground_style_attr : '',
+							apply_filters( 'siteorigin_widgets_slider_attr',
+								array(
+									'class' => 'sow-slider-foreground-image skip-lazy',
+									'loading' => apply_filters( 'siteorigin_widgets_slider_loading_attr', 'eager' ),
+									'style' => ! empty( $foreground_style_attr ) ? $foreground_style_attr : '',
+								)
 							)
 						);
 						?>
@@ -248,9 +250,11 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 				$frame['background_image'],
 				'full',
 				! empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : '',
-				array(
-					'class' => 'sow-slider-background-image skip-lazy',
-					'loading' => 'eager',
+				apply_filters( 'siteorigin_widgets_slider_attr',
+					array(
+						'class' => 'sow-slider-background-image skip-lazy',
+						'loading' => 'eager',
+					)
 				)
 			);
 


### PR DESCRIPTION
This PR resolves an AMP compatibility issue with the `loading` attribute `eager` value. If the [AMP plugin](https://wordpress.org/plugins/amp/) is active and enabled, this PR will prevent the Slider widgets `loading` attribute override for images. 

`siteorigin_widgets_slider_attr` filter to do this. This was done in response to [this thread](https://wordpress.org/support/topic/disallowed-attribute-value/) and you can test this issue by checking the attribute of the SiteOrigin Slider Foreground and Background Image to ensure it's set to loading and `skip-lazy` isn't a set class for the image.