### PR TITLE
Widgets Block: Exclude Post Carousel From Caching

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -161,6 +161,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			if (
 				empty( $attributes['widgetHtml'] ) ||
 				! empty( $_POST ) ||
+				$attributes['widgetClass'] == 'SiteOrigin_Widget_PostCarousel_Widget' ||
 				// Is WPML active? If so, is there a translation for this page?
 				(
 					defined( 'ICL_LANGUAGE_CODE' ) &&


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/post-carousel-doesnt-update-automaticly/)

This PR will exclude the Post Carousel widget from the SO Widget Blocks html cache. This is done to ensure that the post carousel always shows the latest posts.