### PR TITLE
Contact: Allow Checkbox to be ticked by a default

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -203,6 +203,14 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 								'type'  => 'text',
 								'label' => __( 'Value', 'so-widgets-bundle' ),
 							),
+							'default' => array(
+								'type'  => 'checkbox',
+								'label' => __( 'Ticked by default', 'so-widgets-bundle' ),
+								'state_handler' => array(
+									'field_type_{$repeater}[checkboxes]' => array( 'show' ),
+									'_else[field_type_{$repeater}]'      => array( 'hide' ),
+								),
+							),
 						),
 
 						// These are only required for a few states

--- a/widgets/contact/fields/checkboxes.class.php
+++ b/widgets/contact/fields/checkboxes.class.php
@@ -10,8 +10,17 @@ class SiteOrigin_Widget_ContactForm_Field_Checkboxes extends SiteOrigin_Widget_C
 			?>
 			<ul>
 				<?php foreach ( $options['field']['options'] as $i => $option ): ?>
+					<?php
+					$is_checked = in_array( $option['value'], $options['value'] ) || ( isset( $option['default'] ) && $option['default'] );
+					?>
 					<li>
-						<input type="checkbox" value="<?php echo esc_attr( $option['value'] ) ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>[]" id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"<?php echo checked( in_array( $option['value'], $options['value'] ), true, false ) ?>/>
+						<input
+							type="checkbox"
+							value="<?php echo esc_attr( $option['value'] ) ?>"
+							name="<?php echo esc_attr( $options['field_name'] ) ?>[]"
+							id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"
+							<?php echo checked( $is_checked, true, false ) ?>
+						/>
 						<label for="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>">
 							<?php echo wp_kses_post( $option['value'] ); ?>
 						</label>


### PR DESCRIPTION
This PR will allow for checkboxes to be ticked by default. This is useful in situations where opt-out makes more sense than opt-in.
It's currently only enabled for the checkbox field but it could be extended to the radio field also.