### PR TITLE
Widgets Block: Prevent Potential Undefined Error Outside of WP Admin

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -24,13 +24,13 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 	}
 
 	public function enqueue_widget_block_editor_assets() {
-		$current_screen = get_current_screen();
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
 		wp_enqueue_script(
 			'sowb-widget-block',
 			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.js', __FILE__ ),
 			array(
 				// The WP 5.8 Widget Area requires a specific editor script to be used.
-				$current_screen->base == 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
+				$current_screen->base == is_object( $current_screen ) && 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
 				'wp-blocks',
 				'wp-i18n',
 				'wp-element',


### PR DESCRIPTION
This PR will resolve the following Updraft Central error: I'm unsure when this error occurs as the logs don't provide further context but based on the context it's likely outside of WP Admin.

` The remote site has encountered a fatal error while executing the requested command. Remote response follows: PHP Fatal error (Error) has occurred during UpdraftCentral command execution. Error Message: Call to undefined function get_current_screen() (Code: 0, line 27 in /htdocs/wordpress/wp-content/plugins/so-widgets-bundle/compat/block-editor/widget-block.php) `