### PR TITLE
Widgets Block: Exclude Contact Form From Caching

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -162,6 +162,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				empty( $attributes['widgetHtml'] ) ||
 				! empty( $_POST ) ||
 				$attributes['widgetClass'] == 'SiteOrigin_Widget_PostCarousel_Widget' ||
+				$attributes['widgetClass'] == 'SiteOrigin_Widgets_ContactForm_Widget' ||
 				// Is WPML active? If so, is there a translation for this page?
 				(
 					defined( 'ICL_LANGUAGE_CODE' ) &&


### PR DESCRIPTION
This PR will exclude the Contact Form widget from the SO Widget Blocks HTML cache. This is required due to a nonce check. No other widgets rely on nonces so no other widgets need to be excluded for the same reason.

- You can test this build by adding a SIteOrigin Widgets Block with a contact form set. Save.
- View the page in a different browser and submit the form and it'll be rejected.
- Apply this PR and open a new tab with the page with the contact form.
- Submit it again and it should submit as the first time without issue.