### PR TITLE
Button and Contact: Migrate `onclick` to `on_click` to avoid WF flag

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -265,7 +265,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 						'description' => __( 'Adds a title attribute to the button link.', 'so-widgets-bundle' ),
 					),
 
-					'onclick' => array(
+					'on_click' => array(
 						'type' => 'text',
 						'label' => __( 'Onclick', 'so-widgets-bundle' ),
 						'description' => __( 'Run this Javascript when the button is clicked. Ideal for tracking.', 'so-widgets-bundle' ),
@@ -349,7 +349,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 		return array(
 			'button_attributes' => $button_attributes,
 			'href' => ! empty( $instance['url'] ) ? $instance['url'] : '#',
-			'onclick' => ! empty( $attributes['onclick'] ) ? $attributes['onclick'] : '',
+			'on_click' => ! empty( $attributes['on_click'] ) ? $attributes['on_click'] : '',
 			'align' => $instance['design']['align'],
 			'icon_image_url' => $icon_image_url,
 			'icon' => $instance['button_icon']['icon_selected'],
@@ -442,6 +442,14 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 					}
 				}
 			}
+		}
+
+		// Migrate onclick setting to prevent Wordfence flag.
+		if (
+			! empty( $instance['attributes'] ) &&
+			! empty( $instance['attributes']['onclick'] )
+		) {
+			$instance['attributes']['on_click'] = $instance['attributes']['onclick'];
 		}
 
 		// If the mobile_align setting isn't set, set it to the same value as the align value.

--- a/widgets/button/tpl/default.php
+++ b/widgets/button/tpl/default.php
@@ -13,7 +13,7 @@
 ?>
 <div class="ow-button-base ow-button-align-<?php echo esc_attr( $align ) ?>">
 	<a href="<?php echo sow_esc_url( do_shortcode( $href ) ) ?>" <?php foreach( $button_attributes as $name => $val ) echo $name . '="' . esc_attr( $val ) . '" ' ?>
-		<?php if ( ! empty( $onclick ) ) echo 'onclick="' . wp_unslash( esc_js( $onclick ) ) . '"'; ?>>
+		<?php if ( ! empty( $on_click ) ) echo 'onclick="' . wp_unslash( esc_js( $on_click ) ) . '"'; ?>>
 		<span>
 			<?php
 				if( ! empty( $icon_image_url ) ) {

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -97,7 +97,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						'label' => __( 'Button ID', 'so-widgets-bundle' ),
 						'description' => __( 'An ID attribute allows you to target this button in JavaScript.', 'so-widgets-bundle' ),
 					),
-					'onclick' => array(
+					'on_click' => array(
 						'type'        => 'text',
 						'label'       => __( 'Onclick', 'so-widgets-bundle' ),
 						'description' => __( 'Run this JavaScript when the button is clicked. Ideal for tracking.', 'so-widgets-bundle' ),
@@ -761,6 +761,14 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			);
 		}
 
+		// Migrate onclick setting to prevent Wordfence flag.
+		if (
+			! empty( $instance['settings'] ) &&
+			! empty( $instance['settings']['onclick'] )
+		) {
+			$instance['settings']['on_click'] = $instance['settings']['onclick'];
+		}
+
 		return $instance;
 	}
 
@@ -782,7 +790,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		return array(
 			'instance_hash' => $instance_hash,
 			'submit_attributes' => $submit_attributes,
-			'onclick' => ! empty( $instance['settings']['onclick'] ) ? $instance['settings']['onclick'] : '',
+			'onclick' => ! empty( $instance['settings']['on_click'] ) ? $instance['settings']['on_click'] : '',
 		);
 	}
 


### PR DESCRIPTION
This PR will prevent the contact widget, and the Button widget (and any widget that includes it as a sub widget) from being flagged by Wordfence for having a setting called `onclick`.

To test this PR:

1. Set up a test page with a button widget and a contact form. Set the onclick in both widgets to anything (doesn't need to be valid JS, just needs to be set).
2. Install Wordfence and open the button widget to confirm the block. Do the same for the contact form.
3. Disable Wordfence.
4. Enable this PR, reload the test page and save it (this is to save the migrated `onclick` settings to the `on_click` structure.
5. Re-enable Wordfence. Check if widgets are blocks.

If you're having trouble causing the base block, it's possible you may have previously set Wordfence to bypass this block. You can confirm this by navigating to **Wordfence > Firewall**. Open **All Firewall Options** and then scroll to the very bottom of the page. Clear any `"allowlisted URLs" that reference `panels`.