### PR TITLE
CTA: Remove `Use default background colors` setting

### DIFF
--- a/widgets/cta/cta.php
+++ b/widgets/cta/cta.php
@@ -75,16 +75,13 @@ class SiteOrigin_Widget_Cta_Widget extends SiteOrigin_Widget {
 				'fields' => array(
 					'background_color' => array(
 						'type' => 'color',
-						'label' => __('Background color', 'so-widgets-bundle'),
+						'label' => __( 'Background color', 'so-widgets-bundle' ),
+						'default' => '#F8F8F8'
 					),
 					'border_color' => array(
 						'type' => 'color',
-						'label' => __('Border color', 'so-widgets-bundle'),
-					),
-					'use_default_background' => array(
-						'type' => 'checkbox',
-						'label' => __( 'Use default background colors', 'so-widgets-bundle' ),
-						'default' => true,
+						'label' => __( 'Border color', 'so-widgets-bundle' ),
+						'default' => '#E3E3E3',
 					),
 					'title_color' => array(
 						'type' => 'color',
@@ -132,23 +129,6 @@ class SiteOrigin_Widget_Cta_Widget extends SiteOrigin_Widget {
 	function modify_child_widget_form($child_widget_form, $child_widget) {
 		unset( $child_widget_form['design']['fields']['align'] );
 		return $child_widget_form;
-	}
-	
-	function modify_instance( $instance ) {
-		if ( ! isset( $instance['design']['use_default_background'] ) ) {
-			$instance['design']['use_default_background'] = true;
-		}
-		
-		if ( ! empty( $instance['design']['use_default_background'] ) ) {
-			if ( empty( $instance['design']['background_color'] ) ) {
-				$instance['design']['background_color'] = '#F8F8F8';
-			}
-			if ( empty( $instance['design']['border_color'] ) ) {
-				$instance['design']['border_color'] = '#E3E3E3';
-			}
-		}
-		
-		return $instance;
 	}
 
 	function get_form_teaser(){


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1446

It's been long enough where the **Use default background colors** isn't required anymore. The chance of someone upgrading from a version prior to that setting and having cleared the background and border color settings is _very_ low.