### PR TITLE
Social Media Buttons: Icon Color Hover fix

### DIFF
--- a/widgets/social-media-buttons/styles/atom.less
+++ b/widgets/social-media-buttons/styles/atom.less
@@ -34,13 +34,17 @@
 				color: @icon_color !important;
 			}
 
-			&.ow-button-hover:hover {
-				& when not( iscolor( @icon_color_hover ) ) {
-					color: lighten( @icon_color, 2% );
-				}
+			&.ow-button-hover {
+				&:visited,
+				&:active,
+				&:hover {
+					& when not( iscolor( @icon_color_hover ) ) {
+						color: lighten( @icon_color, 2% ) !important;
+					}
 
-				& when( iscolor( @icon_color_hover ) ) {
-					color: @icon_color_hover;
+					& when( iscolor( @icon_color_hover ) ) {
+						color: @icon_color_hover !important;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Previously, the icon_cover override didn't override in a reliable manner.