### PR TITLE
Widgets Block: Fix Logic Typo Resulting in Potential Notice

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -30,7 +30,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			plugins_url( 'widget-block' . SOW_BUNDLE_JS_SUFFIX . '.js', __FILE__ ),
 			array(
 				// The WP 5.8 Widget Area requires a specific editor script to be used.
-				$current_screen->base == is_object( $current_screen ) && 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
+				is_object( $current_screen ) && $current_screen->base == 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
 				'wp-blocks',
 				'wp-i18n',
 				'wp-element',


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/php-notices-on-wp-5-9/)

To test this please ensure no notice occurs when viewing a Block Editor powered page, or when using the new Widget Area.