### PR TITLE
Add `siteorigin_widgets_accordion_scrollto_offset` filter

### DIFF
--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -59,6 +59,7 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 			'sowAccordion',
 			array(
 				'scrollto_after_change' => ! empty( $global_settings['scrollto_after_change'] ),
+				'scrollto_offset' => (int) apply_filters( 'siteorigin_widgets_accordion_scrollto_offset', 80 ),
 			)
 		);
 	}

--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -19,7 +19,8 @@ jQuery( function ( $ ) {
 			};
 			
 			var scrollToPanel = function ( $panel, smooth ) {
-				var navOffset = 90;// Add some magic number offset to make space for possible nav menus etc.
+				// Add some magic number offset to make space for possible nav menus etc.
+				var navOffset = sowAccordion.scrollto_offset ? sowAccordion.scrollto_offset : 80;
 				var scrollTop = $panel.offset().top - navOffset;
 				if ( smooth ) {
 					$( 'body,html' ).animate( {


### PR DESCRIPTION
This PR will allow users to change the offset used by the scroll to functionality when opening Accordion items.
You can test this PR by adding the following PHP to your website:

```
add_filter( 'siteorigin_widgets_accordion_scrollto_offset', function( $offset ) {
	return 150;
} );
```