### PR TITLE
Carousel: Remove Navigation Arrows/Dots From Carousel Settings

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -243,7 +243,8 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 	}
 
 	function carousel_settings_form_fields() {
-		return array(
+		$carousel_settings = $this->get_carousel_settings();
+		$fields = array(
 			'type' => 'section',
 			'label' => __( 'Settings', 'so-widgets-bundle' ),
 			'hide' => true,
@@ -323,6 +324,16 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 				),
 			),
 		);
+
+		if ( ! isset( $carousel_settings['navigation'] ) || empty( $carousel_settings['navigation_label'] ) ) {
+			unset( $fields['fields']['arrows'] );
+		}
+
+		if ( ! isset( $carousel_settings['navigation_dots'] )  || empty( $carousel_settings['navigation_dots_label'] ) ) {
+			unset( $fields['fields']['dots'] );
+		}
+
+		return $fields;
 	}
 
 


### PR DESCRIPTION
This will ensure the Post Carousel widget doesn't have a Navigation Dots setting in the Carousel settings group when the Overlay theme isn't active.