### PR TITLE
Widget Block Third Party Widget Changes

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -11,15 +11,14 @@
 	var Spinner  = components.Spinner;
 	var __ = i18n.__;
 
-	var ajaxErrorHandler = function( response ) {
+	var getAjaxErrorMsg = function( response ) {
 		var errorMessage = '';
 		if ( response.hasOwnProperty( 'responseJSON' ) ) {
 			errorMessage = response.responseJSON.message;
 		} else if ( response.hasOwnProperty( 'responseText' ) ) {
 			errorMessage = response.responseText;
 		}
-
-		props.setState( { widgetFormHtml: '<div>' + errorMessage + '</div>', } );
+		return errorMessage;
 	}
 
 	registerBlockType( 'sowb/widget-block', {
@@ -114,7 +113,9 @@
 					} );
 					wp.data.dispatch( 'core/editor' ).unlockPostSaving();
 				} )
-				.fail( ajaxErrorHandler );
+				.fail( function( response ) {
+					props.setState( { widgetFormHtml: '<div>' + getAjaxErrorMsg( response ) + '</div>', } );
+				} );
 			}
 
 			function switchToEditing() {
@@ -188,7 +189,9 @@
 					.done( function( widgetForm ) {
 						props.setState( { widgetFormHtml: widgetForm } );
 					} )
-					.fail( ajaxErrorHandler );
+					.fail( function( response ) {
+						props.setState( { widgetFormHtml: '<div>' + getAjaxErrorMsg( response ) + '</div>', } );
+					} );
 				}
 
 				var widgetForm = props.widgetFormHtml ? props.widgetFormHtml : '';

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -56,9 +56,16 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				// The last class will always be from the widget file we just loaded.
 				$classes = get_declared_classes();
 				$widget_class = end( $classes );
+				// For SiteOrigin widgets, just display the widget's name. For third party widgets, display the Author
+				// to try avoid confusion when the widgets have the same name.
+				if ( $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
+					$widget_name = sprintf( __( '%s by %s', 'so-widgets-bundle' ), $widget['Name'], $widget['Author'] );
+				} else {
+					$widget_name = $widget['Name'];
+				}
 
 				$so_widgets[] = array(
-					'name' => $widget['Name'],
+					'name' => $widget_name,
 					'class' => $widget_class,
 				);
 			}

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -72,8 +72,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				$author = '';
 				// Try to find a widget's author from its file metadata, by matching the filename to the ID (which is derived from the filename).
 				foreach ( $widgets_metadata_list as $widget_metadata ) {
-					$filename = $widgets_manager->get_widget_filename( $widget_obj->id_base );
-					if ( $widget_metadata['ID'] == $filename ) {
+					if ( $widgets_manager->get_class_from_path( wp_normalize_path( $widget_metadata['File'] ) ) == $class ) {
 						$author = $widget_metadata['Author'];
 						break;
 					}


### PR DESCRIPTION
This PR will:
- Fix an issue that prevented ajax errors from showing these were present when trying to use a deactivated third party widget. This error could occur even when the widget was active and that would make the widget unusable.
- Prevent a third party widget data unintentionally having the wrong author.
- List the author in widget names for all third party widgets. This was previously the case for only certain widgets. `Widget Name by Author`.

You can test this PR using the [Livemesh SiteOrgin Widgets](https://wordpress.org/plugins/livemesh-siteorigin-widgets/) plugin.