### PR TITLE
Carousel: Override Slick Autoplay & Add Continuous scroll to Post Carousel

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -86,7 +86,7 @@ jQuery( function ( $ ) {
 				$$.parent().parent().find( '.sow-carousel-' + ( direction == 'left' ? 'next' : 'prev' ) ).trigger( 'touchend' );
 			} );
 
-			// Set up Autoplay. We use a custom autoplay rather than the SLick
+			// Set up Autoplay. We use a custom autoplay rather than the Slick
 			// autoplay to account for the (sometimes) non-standard nature of our
 			// navigation that Slick has trouble accounting for.
 			if ( carouselSettings.autoplay ) {

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -41,9 +41,6 @@ jQuery( function ( $ ) {
 				accessibility: false,
 				cssEase: carouselSettings.animation,
 				speed: carouselSettings.animation_speed,
-				autoplay: carouselSettings.autoplay,
-				autoplaySpeed: carouselSettings.autoplaySpeed,
-				pauseOnHover: carouselSettings.pauseOnHover,
 				slidesToScroll: responsiveSettings.desktop_slides_to_scroll,
 				slidesToShow: typeof responsiveSettings.desktop_slides_to_show == 'undefined'
 					? responsiveSettings.desktop_slides_to_scroll
@@ -80,6 +77,28 @@ jQuery( function ( $ ) {
 			$items.on( 'swipe', function( e, slick, direction ) {
 				$$.parent().parent().find( '.sow-carousel-' + ( direction == 'left' ? 'next' : 'prev' ) ).trigger( 'touchend' );
 			} );
+
+			// Set up Autoplay. We use a custom autoplay rather than the SLick
+			// autoplay to account for the (sometimes) non-standard nature of our
+			// navigation that Slick has trouble accounting for.
+			if ( carouselSettings.autoplay ) {
+				var interrupted = false;
+				var autoplayNav = $$.parent().parent().find( '.sow-carousel-' + ( $$.data( 'dir' ) == 'ltr' ? 'next' : 'prev' ) );
+				setInterval( function() {
+					if ( ! interrupted ) {
+						autoplayNav.trigger( 'click' );
+					}
+				}, carouselSettings.autoplaySpeed );
+
+				if ( carouselSettings.pauseOnHover ) {
+					$items.on('mouseenter.slick', function() {
+						 interrupted = true;
+					} );
+					$items.on( 'mouseleave.slick', function() {
+						 interrupted = false;
+					} );
+				}
+			}
 
 			// click is used rather than Slick's beforeChange or afterChange
 			// due to the inability to stop a slide from changing from those events

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -36,7 +36,15 @@ jQuery( function ( $ ) {
 				rows: 0,
 				rtl: $$.data( 'dir' ) == 'rtl',
 				touchThreshold: 20,
-				infinite: ! $$.data( 'ajax-url' )&&  $$.data( 'carousel_settings' ).loop,
+				infinite:
+					$$.data( 'carousel_settings' ).loop &&
+					(
+						! $$.data( 'ajax-url' ) ||
+						(
+							$$.data( 'ajax-url' ) &&
+							carouselSettings.autoplay
+						)
+					),
 				variableWidth: $$.data( 'variable_width' ),
 				accessibility: false,
 				cssEase: carouselSettings.animation,


### PR DESCRIPTION
This PR will replace the Slick autoplay with our own method of handling it. This will allow the autoplay to account for the non-standard method of handling navigation in the Post Carousel widget.

Please test this PR with both the Post Carousel and Anything Carousel widgets. Try a few different timeouts and confirm the **Autoplay pause on hover** setting setting works as expected.

You can enable continuous scroll for the Post Carousel widget by enabling looping and autoplay.