### PR TITLE
Post Carousel: Add Autoplay Continuous Scroll

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -254,6 +254,13 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 					'label' => __( 'Loop Items', 'so-widgets-bundle' ),
 					'description' => __( 'Automatically return to the first item after the last item.', 'so-widgets-bundle' ),
 					'default' => true,
+					'state_emitter' => array(
+						'callback' => 'conditional',
+						'args' => array(
+							'loop_posts[show]: val',
+							'loop_posts[hide]: ! val',
+						),
+					),
 				),
 				'dots' => array(
 					'type' => 'checkbox',
@@ -265,7 +272,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 							'nav_dots[show]: val',
 							'nav_dots[hide]: ! val',
 						),
-					)
+					),
 				),
 				'arrows' => array(
 					'type' => 'checkbox',
@@ -277,7 +284,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 							'nav_arrows[show]: val',
 							'nav_arrows[hide]: ! val',
 						),
-					)
+					),
 				),
 				'animation' => array(
 					'type' => 'select',

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -42,6 +42,7 @@ jQuery( function ( $ ) {
 						! $$.data( 'ajax-url' ) ||
 						(
 							$$.data( 'ajax-url' ) &&
+							carouselSettings.autoplay_continuous_scroll &&
 							carouselSettings.autoplay
 						)
 					),

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -37,7 +37,7 @@ jQuery( function ( $ ) {
 				rtl: $$.data( 'dir' ) == 'rtl',
 				touchThreshold: 20,
 				infinite:
-					$$.data( 'carousel_settings' ).loop &&
+					carouselSettings.loop &&
 					(
 						! $$.data( 'ajax-url' ) ||
 						(

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -247,8 +247,8 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 					'type' => 'checkbox',
 					'label' => __( 'Autoplay continuous scroll', 'so-widgets-bundle' ),
 					'state_handler' => array(
-						'autoplay[show]' => array( 'show' ),
-						'autoplay[hide]' => array( 'hide' ),
+						'loop_posts[show]' => array( 'show' ),
+						'loop_posts[hide]' => array( 'hide' ),
 					),
 				),
 			)

--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -239,6 +239,21 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 		$carousel_settings['fields']['loop']['description'] = __( 'Automatically return to the first post after the last post.', 'so-widgets-bundle' );
 		unset( $carousel_settings['fields']['animation'] );
 
+		siteorigin_widgets_array_insert(
+			$carousel_settings['fields'],
+			'autoplay_pause_hover',
+			array(
+				'autoplay_continuous_scroll' => array(
+					'type' => 'checkbox',
+					'label' => __( 'Autoplay continuous scroll', 'so-widgets-bundle' ),
+					'state_handler' => array(
+						'autoplay[show]' => array( 'show' ),
+						'autoplay[hide]' => array( 'hide' ),
+					),
+				),
+			)
+		);
+
 		return array(
 			'title' => array(
 				'type' => 'text',
@@ -377,6 +392,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 		$posts = new WP_Query( $query );
 
 		$carousel_settings = $this->carousel_settings_template_variables( $instance['carousel_settings'], false );
+		$carousel_settings['autoplay_continuous_scroll'] = ! empty( $instance['carousel_settings']['autoplay_continuous_scroll'] ) ? $instance['carousel_settings']['autoplay_continuous_scroll'] : false;
 		// The base theme doesn't support dot noviation so let's remove it.
 		if ( $theme == 'base' ) {
 			unset( $carousel_settings['dots'] );


### PR DESCRIPTION
This PR is a follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1462. It changes how the looping of the post carousel is handled when you reach the end of the post. Instead of transitioning back to the first item it "scrolls" to the first items in a more continuous fashion. Due to how visually different this is compared to the base method, it's behind a setting to prevent an unexpected change.

You can enable continuous scroll for the Post Carousel widget by enabling looping, autoplay, and the **Autoplay Continuous Scroll** setting.