### PR TITLE
Layout/Hero: Inline Height To Prevent Potential Jump

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -364,9 +364,9 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		return $instance;
 	}
 
-	function render_template( $controls, $frames ){
+	function render_template( $controls, $frames, $layout = array() ){
 		$this->render_template_part('before_slider', $controls, $frames);
-		$this->render_template_part('before_slides', $controls, $frames);
+		$this->render_template_part( 'before_slides', $controls, $frames, $layout );
 
 		foreach( $frames as $i => $frame ) {
 			$this->render_frame( $i, $frame, $controls );
@@ -377,7 +377,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		$this->render_template_part('after_slider', $controls, $frames);
 	}
 
-	function render_template_part( $part, $controls, $frames ) {
+	function render_template_part( $part, $controls, $frames, $layout = array() ) {
 		switch( $part ) {
 			case 'before_slider':
 				?><div class="sow-slider-base" style="display: none"><?php
@@ -392,7 +392,17 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				if ( $settings['swipe'] ) {
 					wp_enqueue_script( 'sow-slider-slider-cycle2-swipe' );
 				}
-				?><ul class="sow-slider-images" data-settings="<?php echo esc_attr( json_encode($settings) ) ?>"><?php
+
+				if ( ! empty( $layout['desktop'] ) && ! empty( $layout['desktop']['height'] ) ) {
+					$height = $instance['layout']['desktop']['height'];
+				}
+
+				$instance['layout']['desktop']['height']
+				?><ul
+					class="sow-slider-images"
+					data-settings="<?php echo esc_attr( json_encode($settings) ) ?>"
+					<?php echo ! empty( $layout['desktop'] ) && ! empty( $layout['desktop']['height'] ) ? 'style="min-height: ' . esc_attr( $layout['desktop']['height'] ) . '"' : ''; ?>
+				><?php
 				break;
 			case 'after_slides':
 				?></ul><?php

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -51,6 +51,7 @@
 .sow-slider-base {
 
 	ul.sow-slider-images {
+		min-height: 0 !important;
 
 		.sow-slider-image-wrapper {
 			padding: @slide_padding+@slide_padding_extra_top @slide_padding_sides @slide_padding @slide_padding_sides;

--- a/widgets/hero/tpl/default.php
+++ b/widgets/hero/tpl/default.php
@@ -1,3 +1,3 @@
 <?php
 
-$this->render_template($instance['controls'], $instance['frames']);
+$this->render_template( $instance['controls'], $instance['frames'], $instance['layout'] );

--- a/widgets/layout-slider/styles/default.less
+++ b/widgets/layout-slider/styles/default.less
@@ -41,6 +41,7 @@
 .sow-slider-base {
 
 	ul.sow-slider-images {
+		min-height: 0 !important;
 
 		.sow-slider-image-wrapper {
 			padding: @slide_padding+@slide_padding_extra_top @slide_padding_sides @slide_padding @slide_padding_sides;

--- a/widgets/layout-slider/tpl/default.php
+++ b/widgets/layout-slider/tpl/default.php
@@ -1,3 +1,3 @@
 <?php
 
-$this->render_template($instance['controls'], $instance['frames']);
+$this->render_template( $instance['controls'], $instance['frames'], $instance['layout'] );


### PR DESCRIPTION
This PR inlines the set desktop height for the slider. It then undersets it on load to prevent a situation where the mobile height could be smaller.