### PR TITLE
Carousel: Hide Container Arrows If Disabled

### DIFF
--- a/base/inc/widgets/tpl/carousel.php
+++ b/base/inc/widgets/tpl/carousel.php
@@ -36,7 +36,7 @@
 			<?php include $settings['item_template']; ?>
 		</div>
 		<?php if ( $settings['navigation'] == 'container' ) : ?>
-			<div class="sow-carousel-nav <?php echo ! $settings['navigation_arrows'] ? 'sow-carousel-navigation-hidden' : ''; ?>">
+			<div class="sow-carousel-nav" <?php echo ! $settings['navigation_arrows'] ? 'style="display: none;"' : ''; ?>>
 				<div class="sow-carousel-nav-arrows">
 					<?php $this->render_navigation( 'both' ); ?>
 				</div>


### PR DESCRIPTION
Related to https://github.com/siteorigin/so-widgets-bundle/pull/1476

This PR will prevent the Post Carousel Overlay Carousel from appearing when the navigation arrows are disabled.