### PR TITLE
Carousel Dots: Resolve Miscalculation When Multiple Carousels Are Present

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -178,7 +178,7 @@ jQuery( function ( $ ) {
 				// Post Carousel update dot navigation active item.
 				if ( carouselSettings.dots && $$.data( 'widget' ) == 'post' ) {
 					$$.find( 'li.slick-active' ).removeClass( 'slick-active' );
-					$$.find( '.slick-dots li' ).eq( Math.ceil( $( '.sow-carousel-items' ).slick( 'slickCurrentSlide' ) / slidesToScroll ) ).addClass( 'slick-active' );
+					$$.find( '.slick-dots li' ).eq( Math.ceil( $$.find( '.sow-carousel-items' ).slick( 'slickCurrentSlide' ) / slidesToScroll ) ).addClass( 'slick-active' );
 				}
 			} );
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1481

[Please test this PR using this PR.](https://drive.google.com/uc?id=1x9B6UCnaVE9ZIT7oEyQhSXJmnQiQPF2N) Prior to this PR the Anything Carousel dot navigations won't work correctly and after enabling this PR they'll work as expected.