### PR TITLE
Social Media Buttons: Hover Adjustments

### DIFF
--- a/widgets/social-media-buttons/styles/atom.less
+++ b/widgets/social-media-buttons/styles/atom.less
@@ -19,6 +19,7 @@
 			border-color: lighten(@border_color, 2%) @border_color darken(@border_color, 3%) @border_color;
 			.gradient(@button_color, darken(@button_color, 10%), @button_color);
 
+			&.ow-button-hover:focus,
 			&.ow-button-hover:hover {
 				@border_color_hover: darken( @button_color_hover, 15% );
 				.gradient( lighten( @button_color_hover, 2% ), lighten( darken( @button_color_hover, 10% ), 2% ), lighten( @button_color_hover, 2% ) );
@@ -28,15 +29,13 @@
 
 		& when( iscolor( @icon_color ) ) {
 			color: @icon_color !important;
-			&:visited,
 			&:active,
 			&:hover {
 				color: @icon_color !important;
 			}
 
 			&.ow-button-hover {
-				&:visited,
-				&:active,
+				&:focus,
 				&:hover {
 					& when not( iscolor( @icon_color_hover ) ) {
 						color: lighten( @icon_color, 2% ) !important;

--- a/widgets/social-media-buttons/styles/atom.less
+++ b/widgets/social-media-buttons/styles/atom.less
@@ -29,11 +29,6 @@
 
 		& when( iscolor( @icon_color ) ) {
 			color: @icon_color !important;
-			&:active,
-			&:hover {
-				color: @icon_color !important;
-			}
-
 			&.ow-button-hover {
 				&:focus,
 				&:hover {

--- a/widgets/social-media-buttons/styles/flat.less
+++ b/widgets/social-media-buttons/styles/flat.less
@@ -14,9 +14,8 @@
 		& when( iscolor( @icon_color ) ) {
 			color: @icon_color !important;
 
-			&:visited,
-			&:active,
-			&:hover {
+			&.ow-button-hover:focus,
+			&.ow-button-hover:hover {
 				& when not( iscolor( @icon_color_hover ) ) {
 					color: @icon_color !important;
 				}
@@ -24,10 +23,6 @@
 				& when( iscolor( @icon_color_hover ) ) {
 					color: @icon_color_hover !important;
 				}
-			}
-
-			&.ow-button-hover:hover {
-				color: lighten(@icon_color, 4%);
 			}
 		}
 

--- a/widgets/social-media-buttons/styles/wire.less
+++ b/widgets/social-media-buttons/styles/wire.less
@@ -18,20 +18,15 @@
 			border: 2px solid @button_color;
 			color: @button_color !important;
 
-			&:visited,
-			&:active,
-			&:hover{
+			&.ow-button-hover:focus,
+			&.ow-button-hover:hover {
 				& when not( iscolor( @button_color_hover ) ) {
 					color: @button_color !important;
 				}
 
 				& when( iscolor( @button_color_hover ) ) {
-					color: @button_color !important;
+					background: @button_color_hover;
 				}
-			}
-
-			&.ow-button-hover:hover {
-				background: @button_color;
 			}
 		}
 


### PR DESCRIPTION
- Clean up selectors to prevent CSS output that's never used.
- Flat: Correctly override Icon color hover.
- Remove :visited and :active in favour of :hover and :focus
- Ensure hover styling isn't output when hover styles are disabled.