### PR TITLE
Image Widgets: Use `wp_get_loading_attr_default`

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -21,7 +21,6 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			__('SiteOrigin Image Grid', 'so-widgets-bundle'),
 			array(
 				'description' => __('Display a grid of images. Also useful for displaying client logos.', 'so-widgets-bundle'),
-				'help' => 'https://siteorigin.com/widgets-bundle/image-grid/',
 			),
 			array(),
 			false,
@@ -174,6 +173,8 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	
 	function get_template_variables( $instance, $args ) {
 		$images = isset( $instance['images'] ) ? $instance['images'] : array();
+
+		// If WordPress 5.9 or higher is being used, let WordPress control if Lazy Load is enabled.
 		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'sow-image-grid' );
 
 		foreach ( $images as $id => &$image ) {
@@ -182,6 +183,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 				continue;
 			}
 
+			$loading_val = function_exists( 'wp_get_loading_attr_default' ) ? wp_get_loading_attr_default( 'the_content' ) : 'lazy';
 			$link_atts = empty( $image['link_attributes'] ) ? array() : $image['link_attributes'];
 			if ( ! empty( $image['new_window'] ) ) {
 				$link_atts['target'] = '_blank';
@@ -193,7 +195,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 
 			if ( empty( $image['image'] ) && ! empty( $image['image_fallback'] ) ) {
 				$alt = ! empty ( $image['alt'] ) ? $image['alt'] .'"' : '';
-				$image['image_html'] = '<img src="' . esc_url( $image['image_fallback'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" class="sow-image-grid-image_html" ' . ( $lazy ? 'loading="lazy"' : '' ) . '>';
+				$image['image_html'] = '<img src="' . esc_url( $image['image_fallback'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" class="sow-image-grid-image_html" ' . ( $lazy && $loading_val == 'lazy' ? 'loading="lazy"' : '' ) . '>';
 			} else {
 				if (
 					$instance['display']['attachment_size'] == 'custom_size' &&
@@ -214,7 +216,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title' => $title,
 					'alt'   => $image['alt'],
 					'class' => 'sow-image-grid-image_html',
-					'loading' => $lazy ? 'lazy' : '',
+					'loading' => $lazy && $loading_val == 'lazy' ? 'lazy' : '',
 				) );
 			}
 		}

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -22,6 +22,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			array(
 				'description' => __('Display a grid of images. Also useful for displaying client logos.', 'so-widgets-bundle'),
 			),
+			'help' => 'https://siteorigin.com/widgets-bundle/image-grid/',
 			array(),
 			false,
 			plugin_dir_path( __FILE__ )

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -185,7 +185,8 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 		$attr['rel'] = ! empty( $instance['rel'] ) ? $instance['rel'] : '';
 
 		if ( function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'sow-image' ) ) {
-			$attr['loading'] = 'lazy';
+			// If WordPress 5.9 or higher is being used, let WordPress control if Lazy Load is enabled.
+			$attr['loading'] = function_exists( 'wp_get_loading_attr_default' ) ? wp_get_loading_attr_default( 'the_content' ) : 'lazy';
 		}
 		
 		$link_atts = array();


### PR DESCRIPTION
This PR alters the Image and Image Grid widget to use [wp_get_loading_attr_default](https://developer.wordpress.org/reference/functions/wp_get_loading_attr_default/). This will prevent a situation where the image can cause a large contentful paint due to being set to lazy load above the fold. For users who would like to fine-tune how many images are excluded from lazy loading they can use the `wp_omit_loading_attr_threshold` filter to control that.

To test this, please add two valid SiteOrigin Image widgets. Check the markup of the first image and confirm no loading, and confirm it's present in the second one. Repeat this process for the Image grid widget. Please note that if a featured image is set, that'll be excluded from the lazy load isntead.