### PR TITLE
Resole Slider PHP 8 notices

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -396,8 +396,6 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				if ( ! empty( $layout['desktop'] ) && ! empty( $layout['desktop']['height'] ) ) {
 					$height = $instance['layout']['desktop']['height'];
 				}
-
-				$instance['layout']['desktop']['height']
 				?><ul
 					class="sow-slider-images"
 					data-settings="<?php echo esc_attr( json_encode($settings) ) ?>"


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/php-errors-siteorigin-widget-bundle/)

This PR resolves the following notices that occur while using PHP 8.

```
Undefined variable $instance (count1)
wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php:400 – Plugin: so-widgets-bundle

Trying to access array offset on value of type null (count3)
wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php:400 – Plugin: so-widgets-bundle
```