### PR TITLE
Add `siteorigin_widgets_WIDGET_NAME_lazy_load` filter

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -194,9 +194,19 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 
 			$title = $this->get_image_title($image);
 
+			// Allow other plugins to override whether this image is lazy loaded or not.
+			$lazy_load_current = apply_filters(
+				'siteorigin_widgets_image_grid_lazy_load',
+				// If WordPress 5.9 or higher is being used, let WordPress control if Lazy Load is enabled.
+				$lazy && $loading_val == 'lazy',
+				$instance,
+				$this
+			);
 			if ( empty( $image['image'] ) && ! empty( $image['image_fallback'] ) ) {
 				$alt = ! empty ( $image['alt'] ) ? $image['alt'] .'"' : '';
-				$image['image_html'] = '<img src="' . esc_url( $image['image_fallback'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" class="sow-image-grid-image_html" ' . ( $lazy && $loading_val == 'lazy' ? 'loading="lazy"' : '' ) . '>';
+
+				// lazy_load_current
+				$image['image_html'] = '<img src="' . esc_url( $image['image_fallback'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" class="sow-image-grid-image_html" ' . ( $lazy_load_current ? 'loading="lazy"' : '' ) . '>';
 			} else {
 				if (
 					$instance['display']['attachment_size'] == 'custom_size' &&
@@ -217,7 +227,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title' => $title,
 					'alt'   => $image['alt'],
 					'class' => 'sow-image-grid-image_html',
-					'loading' => $lazy && $loading_val == 'lazy' ? 'lazy' : '',
+					'loading' => $lazy_load_current,
 				) );
 			}
 		}

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -185,8 +185,14 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 		$attr['rel'] = ! empty( $instance['rel'] ) ? $instance['rel'] : '';
 
 		if ( function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'sow-image' ) ) {
-			// If WordPress 5.9 or higher is being used, let WordPress control if Lazy Load is enabled.
-			$attr['loading'] = function_exists( 'wp_get_loading_attr_default' ) ? wp_get_loading_attr_default( 'the_content' ) : 'lazy';
+			// Allow other plugins to override whether this widget is lazy loaded or not.
+			$attr['loading'] = apply_filters(
+				'siteorigin_widgets_image_lazy_load',
+				// If WordPress 5.9 or higher is being used, let WordPress control if Lazy Load is enabled.
+				function_exists( 'wp_get_loading_attr_default' ) ? wp_get_loading_attr_default( 'the_content' ) : 'lazy',
+				$instance,
+				$this
+			);
 		}
 		
 		$link_atts = array();


### PR DESCRIPTION
Follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1492.

`wp_get_loading_attr_default` doesn't work in widget areas so if a SiteOrigin Image widget is added to prior to the content it'll always be lazy loaded. It also doesn't work for versions of WordPress 5.9 (which is expected). This PR adds the `siteorigin_widgets_WIDGET_NAME_lazy_load` filter to the Image and Image Grid widgets. This will allow for the developer to programmatically exclude an image using PHP. For example, the following PHP will prevent the image with id 6119 from being lazy loaded:

```
add_filter( 'siteorigin_widgets_image_lazy_load', function( $lazy, $instance, $widget ) {
	return $instance['image'] !== 6119 ? $lazy : '';
}, 10, 3 );
```

Filter for image grid is: `siteorigin_widgets_image_grid_lazy_load`