### PR TITLE
Image Grid: Fix Loading Attribute

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -227,7 +227,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title' => $title,
 					'alt'   => $image['alt'],
 					'class' => 'sow-image-grid-image_html',
-					'loading' => $lazy_load_current,
+					'loading' => $lazy_load_current ? 'lazy' : '',
 				) );
 			}
 		}


### PR DESCRIPTION
This will prevent the loading tag from being set to `1` rather than `lazy`.