### PR TITLE
Widgets Block: Ensure Widget Has Author

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -58,7 +58,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				$widget_class = end( $classes );
 				// For SiteOrigin widgets, just display the widget's name. For third party widgets, display the Author
 				// to try avoid confusion when the widgets have the same name.
-				if ( $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
+				if ( ! empty( $widget['Author'] ) && $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
 					$widget_name = sprintf( __( '%s by %s', 'so-widgets-bundle' ), $widget['Name'], $widget['Author'] );
 				} else {
 					$widget_name = $widget['Name'];


### PR DESCRIPTION
This PR will resolve the following notice:

`Warning: strpos(): Empty needle in /home/****/public_html/wp-content/plugins/so-widgets-bundle/compat/block-editor/widget-block.php on line 61`

This notice only occurs if there's a third party widget that doesn't have an author set.