### PR TITLE
Anything Carousel: Account For Situation Where Prev Nav Won't Work

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -170,6 +170,8 @@ jQuery( function ( $ ) {
 				} else if ( $( this ).hasClass( 'sow-carousel-previous' ) ) {
 					if ( $$.data( 'carousel_settings' ).loop && $items.slick( 'slickCurrentSlide' ) == 0 ) {
 						$items.slick( 'slickGoTo', lastPosition );
+					} else if ( ! $$.data( 'carousel_settings' ).loop && $items.slick( 'slickCurrentSlide' ) <= slidesToScroll ) {
+						$items.slick( 'slickGoTo', 1 );
 					} else {
 						$items.slick( 'slickPrev' );
 					}


### PR DESCRIPTION
This PR will resolve a situation that can result in the previous navigation from working. It's not clear what specifically causes this situation but it potentially appears to be that there are more slides than the `Slides to Scroll` setting and that results in Slick rejecting the navigation attempt.