### PR TITLE
Restore nav arrow margin

### DIFF
--- a/widgets/anything-carousel/styles/base.less
+++ b/widgets/anything-carousel/styles/base.less
@@ -52,7 +52,8 @@
 	}
 
 	.sow-carousel-navigation {
-		margin: 0;
+		margin-top: 0;
+		margin-bottom: 0;
 		min-width: 34px; // FF may ignore width due to the parent being a flexbox. It won't ignore min-width.
 		width: 34px;
 	}


### PR DESCRIPTION
* Restored nav arrow margin.
* Reset top and bottom margin to zero to override possible theme styling.