### PR TITLE
Widgets Block: Add Anchor Support

### DIFF
--- a/base/inc/routes/siteorigin-widgets-resource.class.php
+++ b/base/inc/routes/siteorigin-widgets-resource.class.php
@@ -4,6 +4,7 @@
  */
 
 class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
+	var $widgetAnchor;
 
 	public function register_routes() {
 		$version = '1';
@@ -127,6 +128,10 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 		return true;
 	}
 
+	function add_widget_id( $id, $instance, $widget ) {
+		return $this->widgetAnchor;
+	}
+
 	/**
 	 * Get the collection of widgets.
 	 *
@@ -154,11 +159,20 @@ class SiteOrigin_Widgets_Resource extends WP_REST_Controller {
 
 		if ( $valid_widget_class && ! empty( $widget_data ) ) {
 			ob_start();
+			// Add anchor to widget wrapper.
+			if ( ! empty( $request['anchor'] ) ) {
+				$this->widgetAnchor = $request['anchor'];
+				add_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10, 3 );
+			}
 			/* @var $widget SiteOrigin_Widget */
 			$instance = $widget->update( $widget_data, $widget_data );
 			$widget->widget( array(), $instance );
 			$rendered_widget = array();
 			$rendered_widget['html'] = ob_get_clean();
+
+			if ( ! empty( $request['anchor'] ) ) {
+				remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
+			}
 
 			// Check if this widget loaded any icons, and if it has, store them.
 			$styles = wp_styles();

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -235,12 +235,17 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$this
 		);
 		$wrapper_classes = array_map( 'sanitize_html_class', $wrapper_classes );
+		$wrapper_id = apply_filters( 'siteorigin_widgets_wrapper_id_' . $this->id_base, '', $instance, $this );
 
 		$wrapper_data_string = $this->get_wrapper_data( $instance );
 
 		do_action( 'siteorigin_widgets_before_widget_' . $this->id_base, $instance, $this );
 		echo $args['before_widget'];
-		echo '<div class="' . esc_attr( implode( ' ', $wrapper_classes ) ) . '"' . $wrapper_data_string . '>';
+		echo '<div
+			' . ( ! empty( $wrapper_id ) ? 'id="' . esc_attr( $wrapper_id ) . '"' : '' ) . '
+			class="' . esc_attr( implode( ' ', $wrapper_classes ) ) . '"
+			' . $wrapper_data_string . '
+		>';
 		echo $template_html;
 		echo '</div>';
 		echo $args['after_widget'];

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -46,10 +46,14 @@
 
 		supports: {
 			html: false,
+			anchor: true,
 		},
 
 		attributes: {
 			widgetClass: {
+				type: 'string',
+			},
+			anchor: {
 				type: 'string',
 			},
 			widgetData: {
@@ -97,6 +101,7 @@
 						xhr.setRequestHeader( 'X-WP-Nonce', sowbBlockEditorAdmin.nonce );
 					},
 					data: {
+						anchor: props.attributes.anchor,
 						widgetClass: props.attributes.widgetClass,
 						widgetData: widgetData ? widgetData : props.attributes.widgetData || {}
 					}

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -1,6 +1,7 @@
 <?php
 
 class SiteOrigin_Widgets_Bundle_Widget_Block {
+	var $widgetAnchor;
 	/**
 	 * Get the singleton instance
 	 *
@@ -58,7 +59,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				$widget_class = end( $classes );
 				// For SiteOrigin widgets, just display the widget's name. For third party widgets, display the Author
 				// to try avoid confusion when the widgets have the same name.
-				if ( ! empty( $widget['Author'] ) && $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
+				if ( $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
 					$widget_name = sprintf( __( '%s by %s', 'so-widgets-bundle' ), $widget['Name'], $widget['Author'] );
 				} else {
 					$widget_name = $widget['Name'];
@@ -127,6 +128,10 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		$so_widgets_bundle->enqueue_registered_widgets_scripts();
 	}
 
+	function add_widget_id( $id, $instance, $widget ) {
+		return $this->widgetAnchor;
+	}
+
 	public function render_widget_block( $attributes ) {
 		if ( empty( $attributes['widgetClass'] ) ) {
 			return '<div>'.
@@ -134,8 +139,8 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				   '</div>';
 		}
 
-		$widget_class = $attributes['widgetClass'];
 
+		$widget_class = $attributes['widgetClass'];
 		global $wp_widget_factory;
 
 		$widget = ! empty( $wp_widget_factory->widgets[ $widget_class ] ) ? $wp_widget_factory->widgets[ $widget_class ] : false;
@@ -156,8 +161,9 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			$GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] = true;
 			$instance = $attributes['widgetData'];
 			add_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
-			ob_start();
 
+
+			ob_start();
 			// If we have pre-generated widgetHTML or there's a valid $_POST, generate the widget.
 			// We don't show the pre-generated widget when there's a valid $_POST
 			// as widgets will likely change when that happens.
@@ -182,6 +188,11 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 					)
 				)
 			) {
+				// Add anchor to widget wrapper.
+				if ( ! empty( $attributes['anchor'] ) ) {
+					$this->widgetAnchor = $attributes['anchor'];
+					add_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10, 3 );
+				}
 				/* @var $widget SiteOrigin_Widget */
 				$instance = $widget->update( $instance, $instance );
 				$widget->widget( array(
@@ -190,6 +201,10 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 					'before_title' => '<h3 class="widget-title">',
 					'after_title' => '</h3>',
 				), $instance );
+
+				if ( ! empty( $attributes['anchor'] ) ) {
+					remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
+				}
 			} else {
 				$widget->generate_and_enqueue_instance_styles( $instance );
 				$widget->enqueue_frontend_scripts( $instance );


### PR DESCRIPTION
Resolves https://github.com/siteorigin/so-widgets-bundle/issues/1489

This PR adds Anchor support to the SiteOrigin Widgets Block. It does this by adding the `siteorigin_widgets_wrapper_id_BASE_ID` (replace `base_id` with the widget id) filter. (I'll add WB docs for that filter shortly)

Please note that a build will be required for this PR to work as expected.

![2022-05-04_00-54-28-1650](https://user-images.githubusercontent.com/17275120/166478188-1cc6a91c-c2f6-49df-b7f9-de2be312e5b6.jpg)

