### PR TITLE
CSS Cache Compat: LiteSpeed Cache

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -73,7 +73,6 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		}
 	}
 
-
 	/**
 	 * Tell cache plugins that they need to regenerate a page cache.
 	 *
@@ -102,6 +101,13 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			if ( function_exists( 'breeze_varnish_purge_cache' ) ) {
 				breeze_varnish_purge_cache( get_the_permalink( $id ) );
 			}
+
+			if ( function_exists( 'run_litespeed_cache' ) ) {
+				$url = parse_url( get_the_permalink( $id ) );
+				if ( ! empty( $url ) ) {
+					header( 'x-litespeed-purge: ' . $url['path'] );
+				}
+			}
 		}
 	}
 
@@ -123,6 +129,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 
 		if ( class_exists( 'Breeze_PurgeCache' ) ) {
 			Breeze_PurgeCache::breeze_cache_flush();
+		}
+
+		if ( function_exists( 'run_litespeed_cache' ) ) {
+			header( 'x-litespeed-purge: *' );
 		}
 	}
 


### PR DESCRIPTION
This PR adds auto clearing cache support for:
- [LiteSpeed Cache](https://wordpress.org/plugins/litespeed-cache/)

For testing instructions, please refer to [the initial PR](https://github.com/siteorigin/so-widgets-bundle/pull/1258) for this functionality.