### PR TITLE
Contact: reCAPTCHA v3

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -234,7 +234,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						'fields' => array(
 							'use_captcha' => array(
 								'type'    => 'radio',
-								'label'   => __( 'reCAPTCHA version', 'so-widgets-bundle' ),
+								'label'   => __( 'reCAPTCHA', 'so-widgets-bundle' ),
 								'default' => false,
 								'options' => array(
 									''   => __( 'Disabled', 'so-widgets' ),

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -253,18 +253,34 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 							),
 							'site_key'    => array(
 								'type'  => 'text',
-								'label' => __( 'reCAPTCHA Site Key', 'so-widgets-bundle' ),
+								'label' => __( 'reCAPTCHA v2 Site Key', 'so-widgets-bundle' ),
 								'state_handler' => array(
-									'recaptcha_version[v2,v3]' => array( 'slideDown' ),
-									'_else[recaptcha_version]' => array( 'slideUp' ),
+									'recaptcha_version[v2]' => array( 'show' ),
+									'_else[recaptcha_version]' => array( 'hide' ),
 								),
 							),
 							'secret_key'  => array(
 								'type'  => 'text',
-								'label' => __( 'reCAPTCHA Secret Key', 'so-widgets-bundle' ),
+								'label' => __( 'reCAPTCHA v2 Secret Key', 'so-widgets-bundle' ),
 								'state_handler' => array(
-									'recaptcha_version[v2,v3]' => array( 'slideDown' ),
-									'_else[recaptcha_version]' => array( 'slideUp' ),
+									'recaptcha_version[v2]' => array( 'show' ),
+									'_else[recaptcha_version]' => array( 'hide' ),
+								),
+							),
+							'site_key_v3'    => array(
+								'type'  => 'text',
+								'label' => __( 'reCAPTCHA v3 Site Key', 'so-widgets-bundle' ),
+								'state_handler' => array(
+									'recaptcha_version[v3]' => array( 'show' ),
+									'_else[recaptcha_version]' => array( 'hide' ),
+								),
+							),
+							'secret_key_v3'  => array(
+								'type'  => 'text',
+								'label' => __( 'reCAPTCHA v3 Secret Key', 'so-widgets-bundle' ),
+								'state_handler' => array(
+									'recaptcha_version[v3]' => array( 'show' ),
+									'_else[recaptcha_version]' => array( 'hide' ),
 								),
 							),
 							'theme'       => array(
@@ -789,8 +805,19 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				! $use_v3 ||
 				$settings['use_captcha'] == 'v3'
 			) &&
-			! empty( $settings['site_key'] ) &&
-			! empty( $settings['secret_key'] );
+			(
+				// Check for v2
+				(
+					! $use_v3 &&
+					! empty( $settings['site_key'] ) &&
+					! empty( $settings['secret_key'] )
+				) ||
+				// Check for v3
+				(
+					! empty( $settings['site_key_v3'] ) &&
+					! empty( $settings['secret_key_v3'] )
+				)
+			);
 	}
 
 	function get_template_variables( $instance, $args ) {
@@ -814,12 +841,12 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 		$template_vars['recaptcha'] = self::is_recaptcha_enabled( $instance['spam']['recaptcha'] );
 		if ( $template_vars['recaptcha'] ) {
-			// reCAPTCHA v2
+			// reCAPTCHA v3
 			if ( self::is_recaptcha_enabled( $instance['spam']['recaptcha'], true ) ) {
-				$submit_attributes['data-sitekey'] = $instance['spam']['recaptcha']['site_key'];
+				$submit_attributes['data-sitekey'] = $instance['spam']['recaptcha']['site_key_v3'];
 				$submit_attributes['data-callback'] = 'soContactFormSubmit';
 				$submit_attributes['data-action'] = 'submit';
-			} else { // reCAPTCHA v3
+			} else { // reCAPTCHA v2
 				$template_vars['recaptcha_v2'] = array(
 					'sitekey' => $instance['spam']['recaptcha']['site_key'],
 					'theme'   => $instance['spam']['recaptcha']['theme'],
@@ -1282,7 +1309,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				'https://www.google.com/recaptcha/api/siteverify',
 				array(
 					'body' => array(
-						'secret'   => $instance['spam']['recaptcha']['secret_key'],
+						'secret'   => $instance['spam']['recaptcha']['use_captcha'] == 'v2' ? $instance['spam']['recaptcha']['secret_key'] : $instance['spam']['recaptcha']['secret_key_v3'],
 						'response' => $post_vars['g-recaptcha-response'],
 						'remoteip' => isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null,
 					)

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -83,10 +83,10 @@ function soContactFormSubmit( token, e ) {
 	sowb.SiteOriginContactFormV3.parent().parent().trigger( 'submit' );
 }
 
-jQuery( function ($) {
+jQuery( function ( $ ) {
 	var recaptcha = $( 'form.sow-contact-form .sow-recaptcha' );
 	// Check if reCAPTCHA is being used.
-	if ( recaptcha ) {
+	if ( recaptcha.length ) {
 		if (window.recaptcha) {
 			sowb.SiteOriginContactForm.init( $, recaptcha );
 		} else {

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -32,8 +32,9 @@ sowb.SiteOriginContactForm = {
 					return;
 				}
 			}
-			var $submitButton = $(this).find('.sow-submit-wrapper > input.sow-submit');
-			if (useRecaptcha) {
+			var $submitButton = $( this ).find( '.sow-submit-wrapper > .sow-submit' );
+
+			if ( useRecaptcha && sowb.SiteOriginContactFormV2 ) {
 				// Render recaptcha
 				var $recaptchaDiv = $el.find('.sow-recaptcha');
 				if ($recaptchaDiv.length) {
@@ -77,24 +78,34 @@ function soContactFormInitialize() {
 	sowb.SiteOriginContactForm.init(window.jQuery, true);
 }
 
-jQuery(function ($) {
+// reCAPTCHA v3 form submission.
+function soContactFormSubmit( token, e ) {
+	sowb.SiteOriginContactFormV3.parent().parent().trigger( 'submit' );
+}
 
-	var $contactForms = $('form.sow-contact-form');
-	// Check if there are any recaptcha placeholders.
-	var useRecaptcha = $contactForms.toArray().some(function (form) {
-		return $(form).find('div').hasClass('sow-recaptcha');
-	});
-
-	if (useRecaptcha) {
+jQuery( function ($) {
+	var recaptcha = $( 'form.sow-contact-form .sow-recaptcha' );
+	// Check if reCAPTCHA is being used.
+	if ( recaptcha ) {
 		if (window.recaptcha) {
-			sowb.SiteOriginContactForm.init($, useRecaptcha);
+			sowb.SiteOriginContactForm.init( $, recaptcha );
 		} else {
-			// Load the recaptcha API
-			var apiUrl = 'https://www.google.com/recaptcha/api.js?onload=soContactFormInitialize&render=explicit';
-			var script = $('<script type="text/javascript" src="' + apiUrl + '" async defer>');
-			$('body').append(script);
+			var apiUrl = 'https://www.google.com/recaptcha/api.js?onload=soContactFormInitialize';
+			// v2 requires a specific render type.
+			if ( recaptcha.first().data( 'config' ) != undefined ) {
+				sowb.SiteOriginContactFormV2 = true;
+				apiUrl += '&render=explicit';
+			} else {
+				// v3 requires a click event for submission.
+				$( 'button.sow-submit ' ).on( 'click', function( e ) {
+					e.preventDefault();
+					sowb.SiteOriginContactFormV3 = $( this );
+				} );
+			}
+			var script = $( '<script type="text/javascript" src="' + apiUrl + '" async defer>' );
+			$( 'body' ).append( script );
 		}
 	} else {
-		sowb.SiteOriginContactForm.init($, useRecaptcha);
+		sowb.SiteOriginContactForm.init( $, recaptcha );
 	}
-});
+} );

--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -15,11 +15,7 @@ if( $result['status'] == 'success' ) {
 	<?php
 }
 else {
-	$recaptcha_config = $instance['spam']['recaptcha'];
-	$use_recaptcha = $recaptcha_config['use_captcha'] && ! empty( $recaptcha_config['site_key'] ) && ! empty( $recaptcha_config['secret_key'] );
-
-	$settings = null;
-	if( $use_recaptcha ) {
+	if ( $recaptcha && ! empty( $recaptcha_v2 ) ) {
 		$settings = array(
 			'sitekey' => $recaptcha_config['site_key'],
 			'theme'   => $recaptcha_config['theme'],
@@ -43,15 +39,23 @@ else {
 		<input type="hidden" name="instance_hash" value="<?php echo esc_attr( $instance_hash ) ?>" />
 		<?php wp_nonce_field( '_contact_form_submit' ) ?>
 
-		<?php if( $use_recaptcha ) : ?>
+		<?php if ( $recaptcha ) : ?>
 			<div class="sow-recaptcha"
-				 data-config="<?php echo esc_attr( json_encode( $settings ) ) ?>"></div>
+				<?php if ( ! empty( $recaptcha_v2 ) ) : ?>
+					data-config="<?php echo esc_attr( json_encode( $recaptcha_v2 ) ) ?>"
+				<?php endif; ?>
+			></div>
 		<?php endif; ?>
+		<div class="sow-submit-wrapper <?php if( $instance['design']['submit']['styled'] ) echo 'sow-submit-styled'; ?>">
 
-		<div class="sow-submit-wrapper <?php if( $instance['design']['submit']['styled'] ) echo 'sow-submit-styled' ?>">
-			<input type="submit" value="<?php echo esc_attr( $instance['settings']['submit_text'] ) ?>" class="sow-submit"
-				   <?php foreach( $submit_attributes as $name => $val ) echo $name . '="' . esc_attr( $val ) . '" ' ?>
-			<?php if ( ! empty( $onclick ) ) echo 'onclick="' . esc_js( $onclick ) . '"'; ?>>
+		<button class="sow-submit<?php if ( $recaptcha && empty( $recaptcha_v2 ) ) echo ' g-recaptcha'; ?>"
+			<?php foreach( $submit_attributes as $name => $val ) echo $name . '="' . esc_attr( $val ) . '" ' ?>
+			<?php if ( ! empty( $onclick ) ) echo 'onclick="' . esc_js( $onclick ) . '"'; ?>
+		>
+			<?php echo esc_attr( $instance['settings']['submit_text'] ) ?>
+		</button>
+
+
 		</div>
 	</form>
 	<?php


### PR DESCRIPTION
This PR adds [reCAPTCHA v3](https://www.google.com/recaptcha/admin) support to the contact form. 
Please test:
- upgrading an existing contact form with v2 enabled.
- v2.
- v3.

There's unfortunately no reliable way for us to detect the reCAPTCHA version type based on the provided key so if the user inputs an invalid one, there's not much we can do about it.

It might be a good idea to introduce a global setting to the Contact Form that allows for the reCAPTCHA to be loaded sitewide. This will allow for "improved verification" as reCAPTCHA will be able to monitor behaviour throughout the site.