### PR TITLE
Sliders: Wait for Modern Parallax to Be Setup

### DIFF
--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -168,7 +168,7 @@ jQuery( function($){
 				if ( slidesWithModernParallax.length ) {
 					// Wait for the parallax to finish setting up before
 					// setting up the slider itself.
-					if ( ! slidesWithParallax.find( '.simpleParallax' ).length ) {
+					if ( ! slidesWithModernParallax.find( '.simpleParallax' ).length ) {
 						setTimeout( setupSlider, 100 );
 						return;
 					}

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -164,6 +164,16 @@ jQuery( function($){
 					return;
 				}
 
+				var slidesWithModernParallax = $$.find( '.sow-slider-image-parallax:not([data-siteorigin-parallax]) ' );
+				if ( slidesWithModernParallax.length ) {
+					// Wait for the parallax to finish setting up before
+					// setting up the slider itself.
+					if ( ! slidesWithParallax.find( '.simpleParallax' ).length ) {
+						setTimeout( setupSlider, 100 );
+						return;
+					}
+				}
+
 				// Show everything for this slider
 				$base.show();
 				

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -166,12 +166,8 @@ jQuery( function($){
 
 				var slidesWithModernParallax = $$.find( '.sow-slider-image-parallax:not([data-siteorigin-parallax]) ' );
 				if ( slidesWithModernParallax.length ) {
-					// Wait for the parallax to finish setting up before
-					// setting up the slider itself.
-					if ( ! slidesWithModernParallax.find( '.simpleParallax' ).length ) {
-						setTimeout( setupSlider, 100 );
-						return;
-					}
+					// Allow slider to be size itself while preventing visual "jump" in modern parallax.
+					$base.css( 'opacity', 0 );
 				}
 
 				// Show everything for this slider
@@ -186,6 +182,21 @@ jQuery( function($){
 				// Setup each of the slider frames
 				$( window ).on('resize panelsStretchRows', resizeFrames ).trigger( 'resize' );
 				$(sowb).on('setup_widgets', resizeFrames );
+
+				if ( slidesWithModernParallax.length ) {
+					// Wait for the parallax to finish setting up before
+					// setting up the rest of the slider.
+					if ( ! slidesWithModernParallax.find( '.simpleParallax' ).length ) {
+						setTimeout( setupSlider, 50 );
+						return;
+					} else {
+						// Trigger resize to allow for parallax to work after showing Slider.
+						window.dispatchEvent( new Event( 'resize' ) );
+						setTimeout( function() {
+							$base.css( 'opacity', 1 );
+						}, 200 );
+					}
+				}
 
 				// Set up the Cycle with videos
 				$$


### PR DESCRIPTION
This PR will help prevent a visual "jump" for sliders using the modern parallax. Prior to this PR, this jump is as a result of the image not parallaxing on load and that jump is the image correctly parallaxing.

To test this PR, please add a slider to the top of the page and to the second row. Add a slide or two and enable parallax for those slies. Save and view the page. If you see a jump shortly after load, try the PR. Otherwise, try simulating a slower connection to see if that allows you to replicate the jump.