### PR TITLE
Standardize YouTube video URLs

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -48,8 +48,18 @@ class SiteOrigin_Video {
 			'loop'     => $loop,
 		) ) );
 		
-		// Convert embed format to standard format to be compatible with wp_oembed_get
-		$this->src = preg_replace( '/https?:\/\/www.youtube.com\/embed\/([^\/]+)/', 'https://www.youtube.com/watch?v=$1', $src );
+		// Standardize YouTube video URL.
+		if ( strpos(  $src, 'youtube.com/watch' ) !== false ) {
+			$src_parse = parse_url( $src, PHP_URL_QUERY );
+			// Check if the URL was encoded.
+			if ( strpos( $src_parse, '&amp;' ) !== false ) {
+				$src_parse = str_replace( '&amp;', '&', $src_parse );
+			}
+			parse_str( $src_parse, $src_parse );
+			$this->src = ! empty( $src_parse['v'] ) ? 'https://www.youtube.com/watch?v='. $src_parse['v'] : $src;
+		} else {
+			$this->src = $src;
+		}
 
 		$html = get_transient( 'sow-vid-embed[' . $hash . ']' );
 		if ( empty( $html ) ) {


### PR DESCRIPTION
This PR accounts for a situation where the supplied video URL doesn't have the `v` parameter first and it also removes the URL rewrite to the embed URL as that's no longer needed (it appears it was removed shortly after implementation).

To test this PR:
- Add a SiteOrign VIdeo Player widget and set it to use an **External VIdeo** and use: `https://www.youtube.com/watch?app=desktop&v=zlrb_X6fYZ0`
- Add a Video widget and add the above video also.

Confirm that the video widget works while the SiteOrigin Video Player widget doesn't. Switch to this PR branch and check if the Video Player widget is working as expected.