### PR TITLE
Hero: Better Top Padding Handling

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -488,13 +488,12 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				$settings = $instance['layout']['mobile'];
 
 				$meas_options['slide_height_responsive'] = ! empty( $settings['height_responsive'] ) ? $settings['height_responsive'] : '';
-				$meas_options['slide_padding_responsive'] = ! empty( $settings['padding'] ) ? $settings['padding'] : '';
-				$meas_options['slide_padding_sides_responsive'] = ! empty( $settings['padding_sides'] ) ? $settings['padding_sides'] : '';
+				if ( ! empty( $settings['padding'] ) || ! empty( $settings['extra_top_padding'] ) ) {
+					$meas_options['slide_padding_responsive'] = ! empty( $settings['padding'] ) ? $settings['padding'] : 0;
 
-				if ( ! empty( $settings['extra_top_padding'] ) ) {
-					// Add extra padding to top padidng.
-					$meas_options['slide_padding_top_responsive'] = (int) $meas_options['slide_padding_responsive'] + (int) $settings['extra_top_padding'];
+					$meas_options['slide_padding_extra_top_responsive'] = ! empty( $settings['extra_top_padding'] ) ? $settings['extra_top_padding'] : 0;
 				}
+				$meas_options['slide_padding_sides_responsive'] = ! empty( $settings['padding_sides'] ) ? $settings['padding_sides'] : '';
 			}
 		}
 

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -491,7 +491,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 			$instance = self::migrate_padding( $instance, 'desktop' );
 		}
 
-		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) && $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) && $instance['layout']['mobile']['extra_top_padding'] != '0px' ) {
 			$instance = self::migrate_padding( $instance, 'mobile' );
 		}
 

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -487,11 +487,11 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		$instance = parent::modify_instance( $instance );
 
 		// Migrate `extra_top_padding` to `padding_extra_top`.
-		if ( ! empty( $instance['layout']['desktop']['extra_top_padding'] ) || $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+		if ( ! empty( $instance['layout']['desktop']['extra_top_padding'] ) && $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
 			$instance = self::migrate_padding( $instance, 'desktop' );
 		}
 
-		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) || $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) && $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
 			$instance = self::migrate_padding( $instance, 'mobile' );
 		}
 

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -56,7 +56,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 							'valueMethod' => 'html',
 						),
 						array(
-							'selector' => '.siteorigin-widget-field-videos .siteorigin-widget-field-repeater-items  .media-field-wrapper .current .title',
+							'selector' => '.siteorigin-widget-field-videos .siteorigin-widget-field-repeater-items .media-field-wrapper .current .title',
 							'valueMethod' => 'html',
 						),
 						array(
@@ -193,7 +193,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 								'default' => '50px',
 							),
 
-							'extra_top_padding' => array(
+							'padding_extra_top' => array(
 								'type' => 'measurement',
 								'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
 								'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
@@ -228,7 +228,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 								'label' => __( 'Top and bottom padding', 'so-widgets-bundle' ),
 							),
 
-							'extra_top_padding' => array(
+							'padding_extra_top' => array(
 								'type' => 'measurement',
 								'label' => __( 'Extra top padding', 'so-widgets-bundle' ),
 								'description' => __( 'Additional padding added to the top of the slider', 'so-widgets-bundle' ),
@@ -428,6 +428,41 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	/**
+	 * Handle Migration of `extra_top_padding` to `padding_top_padding` setting.
+	 *
+	 * The `padding_top_padding` setting was introduced because of an issue
+	 * With padding being unreliably set.
+	 *
+	 * @param $instance
+	 * @param $context
+	 *
+	 * @return $instance
+	 */
+	private static function migrate_padding( $instance, $context ) {
+		// If both padding and extra top padding exist, we need to override
+		// the extra top padding and unit of measurement to prevent unexpected changes.
+		if (
+			 ! empty( $instance['layout'][ $context ]['padding'] ) &&
+			 $instance['layout'][ $context ]['padding'] != '50px'
+		) {
+			$instance['layout'][ $context ]['padding_extra_top'] = str_replace(
+				$instance['layout'][ $context ]['extra_top_padding_unit'],
+				$instance['layout'][ $context ]['padding_unit'],
+				$instance['layout'][ $context ]['extra_top_padding']
+			);
+			$instance['layout'][ $context ]['padding_extra_top_unit'] = $instance['layout'][ $context ]['padding_unit'];
+		} else {
+			$instance['layout'][ $context ]['padding_extra_top_unit'] = $instance['layout'][ $context ]['extra_top_padding_unit'];
+			$instance['layout'][ $context ]['padding_extra_top'] = $instance['layout'][ $context ]['extra_top_padding'];
+		}
+
+		unset( $instance['layout'][ $context ]['extra_top_padding'] );
+		unset( $instance['layout'][ $context ]['extra_top_padding_unit'] );
+
+		return $instance;
+	}
+
+	/**
 	 * Migrate Slider settings.
 	 *
 	 * @param $instance
@@ -448,7 +483,19 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 			$instance['design']['text_shadow'] *= 100;
 		}
 
-		return parent::modify_instance( $instance );
+		// Run general slider migrations.
+		$instance = parent::modify_instance( $instance );
+
+		// Migrate `extra_top_padding` to `padding_extra_top`.
+		if ( ! empty( $instance['layout']['desktop']['extra_top_padding'] ) || $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+			$instance = self::migrate_padding( $instance, 'desktop' );
+		}
+
+		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) || $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+			$instance = self::migrate_padding( $instance, 'mobile' );
+		}
+
+		return $instance;
 	}
 
 	/**
@@ -479,7 +526,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 
 				$meas_options['slide_height'] = ! empty( $settings['height'] ) ? $settings['height'] : '';
 				$meas_options['slide_padding'] = ! empty( $settings['padding'] ) ? $settings['padding'] : '';
-				$meas_options['slide_padding_extra_top'] = ! empty( $settings['extra_top_padding'] ) ? $settings['extra_top_padding'] : '';
+				$meas_options['slide_padding_extra_top'] = ! empty( $settings['padding_extra_top'] ) ? $settings['padding_extra_top'] : '';
 				$meas_options['slide_padding_sides'] = ! empty( $settings['padding_sides'] ) ? $settings['padding_sides'] : '';
 				$meas_options['slide_width'] = ! empty( $settings['width'] ) ? $settings['width'] : '';
 			}
@@ -488,10 +535,10 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				$settings = $instance['layout']['mobile'];
 
 				$meas_options['slide_height_responsive'] = ! empty( $settings['height_responsive'] ) ? $settings['height_responsive'] : '';
-				if ( ! empty( $settings['padding'] ) || ! empty( $settings['extra_top_padding'] ) ) {
+				if ( ! empty( $settings['padding'] ) || ! empty( $settings['padding_extra_top'] ) ) {
 					$meas_options['slide_padding_responsive'] = ! empty( $settings['padding'] ) ? $settings['padding'] : 0;
 
-					$meas_options['slide_padding_extra_top_responsive'] = ! empty( $settings['extra_top_padding'] ) ? $settings['extra_top_padding'] : 0;
+					$meas_options['slide_padding_extra_top_responsive'] = ! empty( $settings['padding_extra_top'] ) ? $settings['padding_extra_top'] : 0;
 				}
 				$meas_options['slide_padding_sides_responsive'] = ! empty( $settings['padding_sides'] ) ? $settings['padding_sides'] : '';
 			}

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -66,7 +66,7 @@
 				justify-content: center;
 			}
 
-			& when ( isnumber( @slide_height_responsive ) ) {
+			& when ( isnumber( @responsive_breakpoint ) ) {
 				@media (max-width: @responsive_breakpoint) {			
 					height: @slide_height_responsive;
 					padding-top: ~"calc( @{slide_padding_responsive} + @{slide_padding_extra_top_responsive} )";

--- a/widgets/hero/styles/default.less
+++ b/widgets/hero/styles/default.less
@@ -16,6 +16,7 @@
 @responsive_breakpoint: 780px;
 @slide_height_responsive: default;
 @slide_padding_responsive: default;
+@slide_padding_extra_top_responsive: default;
 @slide_padding_top_responsive: default;
 @slide_padding_sides_responsive: default;
 
@@ -54,7 +55,7 @@
 		min-height: 0 !important;
 
 		.sow-slider-image-wrapper {
-			padding: @slide_padding+@slide_padding_extra_top @slide_padding_sides @slide_padding @slide_padding_sides;
+			padding: ~"calc( @{slide_padding} + @{slide_padding_extra_top} )" @slide_padding_sides @slide_padding @slide_padding_sides;
 
 			max-width: @slide_width;
 			height: @slide_height;
@@ -67,19 +68,11 @@
 
 			& when ( isnumber( @slide_height_responsive ) ) {
 				@media (max-width: @responsive_breakpoint) {			
-					& when ( isnumber( @slide_height_responsive ) ) {
-						height: @slide_height_responsive;
-					}
-
-					& when ( isnumber( @slide_padding_top_responsive ) ) {
-						padding-top: @slide_padding_top_responsive;
-					}
-
-					& when ( isnumber( @slide_padding_sides_responsive ) ) {
-						padding-right: @slide_padding_sides_responsive;
-						padding-left: @slide_padding_sides_responsive;
-					}
-					& when ( isnumber( @slide_padding_responsive ) ) {
+					height: @slide_height_responsive;
+					padding-top: ~"calc( @{slide_padding_responsive} + @{slide_padding_extra_top_responsive} )";
+					padding-right: @slide_padding_sides_responsive;
+					padding-left: @slide_padding_sides_responsive;
+					& when not ( @slide_padding_responsive = 0 ) {
 						padding-bottom: @slide_padding_responsive;
 					}
 				}


### PR DESCRIPTION
This PR ensures that the top padding unit of measurement actually matters. Before this PR the Top and Bottom Padding and Extra Top Padding are simply added together and the unit of measurement isn't really factored in. After this PR the unit of measurement does matter.

To test:
- Add A Hero widget with a frame.
- Give the Hero some height (be it frame content or actual Height).
- Set Padding and Extra Top Padding using two different unit of measurements.
- Do the same for the Mobile version of those settings.
- Save and view the Hero.
- Inspect the Hero's `.sow-slider-image-wrapper` for the padding.