### PR TITLE
Contact: Add Really Simple CAPTCHA Integration

### DIFF
--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -46,6 +46,27 @@ else {
 				<?php endif; ?>
 			></div>
 		<?php endif; ?>
+
+		<?php if ( ! empty( $really_simple_spam ) ) :
+			if ( $really_simple_spam == 'missing' ) :
+				echo __( 'Unable to detect Really Simple CAPTCHA plugin', 'so-widgets-bundle' );
+			else: ?>
+				<div class="sow-form-field sow-form-field-subject">
+					<label class="sow-form-field-label-above" for="sow-contact-form-field-subject-1039044186296274de5a8b577595978">
+						<strong>Subject</strong>
+					</label>
+					<img
+						src="<?php echo esc_url( plugins_url() . '/really-simple-captcha/tmp/' . $really_simple_spam_image ); ?>"
+						width="<?php echo esc_attr( $really_simple_spam->img_size[0] ); ?>"
+						height="<?php echo esc_attr( $really_simple_spam->img_size[1] ); ?>"
+					>
+					<span class="sow-field-container">
+						<input type="text" name="really-simple-captcha-<?php echo esc_attr( $instance_hash ); ?>" id="really-simple-captcha-<?php echo esc_attr( $instance_hash ); ?>" value="" class="sow-text-field">
+					</span>
+					<input type="hidden" name="really-simple-captcha-prefix-<?php echo esc_attr( $instance_hash ); ?>" value="<?php echo esc_attr( $really_simple_spam_prefix ) ?>" />
+				</div>
+			<?php endif; ?>
+		<?php endif; ?>
 		<div class="sow-submit-wrapper <?php if( $instance['design']['submit']['styled'] ) echo 'sow-submit-styled'; ?>">
 
 		<button class="sow-submit<?php if ( $recaptcha && empty( $recaptcha_v2 ) ) echo ' g-recaptcha'; ?>"


### PR DESCRIPTION
This PR adds integration for the [Really Simple CAPTCHA](https://wordpress.org/plugins/really-simple-captcha/) plugin. This allows users to add a DSGVO complaint captcha that's widely supported and used (600k installs).

To test:

- Install Really Simple CAPTCHA
- Open a contact form or add a new one.
- Open the Spam Protection Settings group and open the Really Simple CAPTCHA settings, and tick Use Really Simple CAPTCHA.
- Fill Out the form incorrectly and confirm the rejection.
- Fill it out correctly and confirm the submission.