### PR TITLE
Google Maps Static: Fix Custom Style Notice

### DIFF
--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -791,11 +791,10 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 						if ( ! empty( $st_string ) ) {
 							$st_string .= "|";
 						}
-						if ( $prop_val[0] == "#" ) {
-							$prop_val = "0x" . substr( $prop_val, 1 );
-						}
 						if ( is_bool( $prop_val ) ) {
 							$prop_val = $prop_val ? 'true' : 'false';
+						} elseif ( $prop_val[0] == "#" ) {
+							$prop_val = "0x" . substr( $prop_val, 1 );
 						}
 						$st_string .= $prop_name . ":" . $prop_val;
 					}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1517

You can replicate this issue by:
- Set up a Static Google Map.
- Add some basic custom styling.
- View the map and then check the error log.
- Switch to this PR and confirm notice isn't occurring anymore.