### PR TITLE
Ensure We're Able to Detect Widget Before Enqueuing Widget Script

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -840,10 +840,13 @@ class SiteOrigin_Widgets_Bundle {
 							/* @var $widget SiteOrigin_Widget */
 							$opt_wid = get_option( 'widget_' . $widget->id_base );
 							preg_match( '/-([0-9]+$)/', $id, $num_match );
-							$widget_instance = $opt_wid[ $num_match[1] ];
-							$widget->enqueue_frontend_scripts( $widget_instance);
-							// TODO: Should be calling modify_instance here before generating the CSS.
-							$widget->generate_and_enqueue_instance_styles( $widget_instance );
+							if ( ! empty( $num_match ) && isset( $num_match[1] ) ) {
+								$widget_instance = $opt_wid[ $num_match[1] ];
+								$widget->enqueue_frontend_scripts( $widget_instance);
+								// TODO: Should be calling modify_instance here before generating the CSS.
+								$widget->generate_and_enqueue_instance_styles( $widget_instance );
+							}
+						}
 						}
 					}
 				}


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/php-8-0-8-1-version/)

This PR resolves the following warning:

`Warning: Undefined array key “1” in /web/htdocs/www.vendicompraffitta.it/home/wp-content/plugins/so-widgets-bundle/so-widgets-bundle.php on line 843`

There's no reliable way for us to test this at this time as it's dependent on an unknown third party widget. Sending a build to the user for confirmation.