### PR TITLE
Hero: Improve Extra Top Padding Migration

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -439,11 +439,12 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 	 * @return $instance
 	 */
 	private static function migrate_padding( $instance, $context ) {
-		// If both padding and extra top padding exist, we need to override
-		// the extra top padding and unit of measurement to prevent unexpected changes.
+		// If padding and extra top padding unit of measurement is different,
+		// we need to reset the extra top padding unit to be the same as the
+		// base padding to prevent unexpected changes.
 		if (
-			 ! empty( $instance['layout'][ $context ]['padding'] ) &&
-			 $instance['layout'][ $context ]['padding'] != '50px'
+			! empty( $instance['layout'][ $context ]['padding'] ) &&
+			$instance['layout'][ $context ]['padding_unit'] != $instance['layout'][ $context ]['extra_top_padding_unit']
 		) {
 			$instance['layout'][ $context ]['padding_extra_top'] = str_replace(
 				$instance['layout'][ $context ]['extra_top_padding_unit'],
@@ -452,6 +453,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 			);
 			$instance['layout'][ $context ]['padding_extra_top_unit'] = $instance['layout'][ $context ]['padding_unit'];
 		} else {
+			// No adjustments needed, copy extra padding setting to new setting structure.
 			$instance['layout'][ $context ]['padding_extra_top_unit'] = $instance['layout'][ $context ]['extra_top_padding_unit'];
 			$instance['layout'][ $context ]['padding_extra_top'] = $instance['layout'][ $context ]['extra_top_padding'];
 		}


### PR DESCRIPTION
Follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1521.

This PR disregards the desktop default and bases everything purely on the unit of measurement. If the Top and Bottom **Padding** Unit of Measurement are different to the **Extra Top Padding** unit of measurement, override it to prevent an unexpected difference. If no difference, copy the settings over to the new field structure.