### PR TITLE
Image: Add External Image Size Setting

### DIFF
--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -6,6 +6,7 @@
 		var $field = $( this );
 		var $media = $field.find('> .media-field-wrapper');
 		var $inputField = $field.find( '.siteorigin-widget-input' ).not('.media-fallback-external');
+		var $externalField = $field.find( '.media-fallback-external' );
 
 		if ( $media.data( 'initialized' ) ) {
 			return;
@@ -402,7 +403,15 @@
 				} else {
 					$field.find( 'a.media-remove-button' ).trigger( 'click' );
 				}
+
 			}
+			$externalField.trigger( 'change' );
+		} );
+
+		// Ensure both state both the media field and external field are kept up to date.
+		$externalField.on( 'change', function() {
+			$inputField.trigger( 'change' );
+
 		} );
 
 		$media.data( 'initialized', true );

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -525,7 +525,7 @@ var sowbForms = window.sowbForms || {};
 
 			$fields.filter('[data-state-emitter]').each(function () {
 				
-				var $input = $( this ).find( '.siteorigin-widget-input:not(.custom-image-size)' );
+				var $input = $( this ).find( '.siteorigin-widget-input' );
 				
 				// Listen for any change events on an emitter field
 				$input.on('keyup change', stateEmitterChangeHandler);

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -32,12 +32,32 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 				'label' => __( 'Image file', 'so-widgets-bundle' ),
 				'library' => 'image',
 				'fallback' => true,
+				'state_emitter' => array(
+					'callback' => 'conditional',
+					'args'     => array(
+						'has_external_image[show]: isNaN( val )',
+						'has_external_image[hide]: ! isNaN( val )'
+					),
+				)
 			),
 
 			'size' => array(
 				'type' => 'image-size',
 				'label' => __( 'Image size', 'so-widgets-bundle' ),
 				'custom_size' => true,
+			),
+
+			'size_external' => array(
+				'type' => 'image-size',
+				'label' => __( 'External image size', 'so-widgets-bundle' ),
+				'sizes' => array(
+					'full' => __( 'Full', 'so-widgets-bundle' ),
+				),
+				'custom_size' => true,
+				'state_handler' => array(
+					'has_external_image[show]' => array( 'show' ),
+					'has_external_image[hide]' => array( 'hide' ),
+				),
 			),
 
 			'align' => array(
@@ -142,10 +162,18 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			);
 		}
 
+		if ( ! empty( $instance['size_external'] ) && $instance['size_external'] == 'custom_size' ) {
+			$external_size = array(
+				'width' => $instance['size_external_width'],
+				'height' => $instance['size_external_height'],
+			);
+		}
+
 		$src = siteorigin_widgets_get_attachment_image_src(
 			$instance['image'],
 			$instance['size'],
-			! empty( $instance['image_fallback'] ) ? $instance['image_fallback'] : false
+			! empty( $instance['image_fallback'] ) ? $instance['image_fallback'] : false,
+			! empty( $external_size ) ? $external_size : array()
 		);
 
 		$attr = array();

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -105,8 +105,8 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 						'state_emitter' => array(
 							'callback' => 'conditional',
 							'args' => array(
-								'show_height[show]: val',
-								'show_height[hide]: ! val'
+								'show_height[show]: val && ! isNaN( val )',
+								'show_height[hide]: ! val || isNaN( val )'
 							),
 						),
 					),


### PR DESCRIPTION
This PR introduces the External Image Size setting to the Image widget. To do this [State Emitter Detection For External Fields](https://github.com/siteorigin/so-widgets-bundle/commit/edf50817453af51c5148ae7dee58b5ce04d343e1)
was required. An adjustment to the Slider widget was also required to maintain compatibility for the Slider widget. To test change, simply set a Foreground image and confirm the Height setting appears.