### PR TITLE
Contact: Add `siteorigin_widgets_contact_field_attr`

### DIFF
--- a/widgets/contact/fields/base.class.php
+++ b/widgets/contact/fields/base.class.php
@@ -8,6 +8,7 @@ abstract class SiteOrigin_Widget_ContactForm_Field_Base {
 	 * @var array
 	 */
 	protected $options;
+	private $type;
 
 	public function __construct( $options ) {
 		$this->options = $options;
@@ -25,5 +26,12 @@ abstract class SiteOrigin_Widget_ContactForm_Field_Base {
 
 	public function render() {
 		$this->render_field( $this->options );
+	}
+
+	public static function add_custom_attrs( $type ) {
+		$attr = apply_filters( 'siteorigin_widgets_contact_field_attr', array() , $type );
+		foreach ( $attr as $k => $v ) {
+			echo esc_attr( $k ) . '="' . esc_attr( $v ) . '" ';
+		}
 	}
 }

--- a/widgets/contact/fields/checkboxes.class.php
+++ b/widgets/contact/fields/checkboxes.class.php
@@ -20,6 +20,7 @@ class SiteOrigin_Widget_ContactForm_Field_Checkboxes extends SiteOrigin_Widget_C
 							name="<?php echo esc_attr( $options['field_name'] ) ?>[]"
 							id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"
 							<?php echo checked( $is_checked, true, false ) ?>
+							<?php self::add_custom_attrs( 'checkboxes' ); ?>
 						/>
 						<label for="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>">
 							<?php echo wp_kses_post( $option['value'] ); ?>

--- a/widgets/contact/fields/email.class.php
+++ b/widgets/contact/fields/email.class.php
@@ -1,5 +1,8 @@
 <?php
 
 class SiteOrigin_Widget_ContactForm_Field_Email extends SiteOrigin_Widget_ContactForm_Field_Text {
-	// This class just exists for autoloading purposes, but is the same as the text field.
+	// Outside of the construct, this class just exists for autoloading purposes, but is the same as the text field.
+	public function __construct( $options ) {
+		$this->type = 'email';
+	}
 }

--- a/widgets/contact/fields/name.class.php
+++ b/widgets/contact/fields/name.class.php
@@ -3,9 +3,15 @@
 class SiteOrigin_Widget_ContactForm_Field_Name extends SiteOrigin_Widget_ContactForm_Field_Base {
 
 	public function render_field( $options ) {
-
 		?>
-		<input type="text" name="<?php echo esc_attr( $options['field_name'] ) ?>" id="<?php echo esc_attr( $options['field_id'] ) ?>" value="<?php echo esc_attr( $options['value'] ) ?>" class="sow-text-field"<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ) ?>/>
+		<input
+			type="text"
+			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			id="<?php echo esc_attr( $options['field_id'] ); ?>"
+			value="<?php echo esc_attr( $options['value'] ); ?>"
+			class="sow-text-field"
+			<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ); ?>
+		/>
 		<?php
 	}
 }

--- a/widgets/contact/fields/number.class.php
+++ b/widgets/contact/fields/number.class.php
@@ -1,5 +1,8 @@
 <?php
 
 class SiteOrigin_Widget_ContactForm_Field_Number extends SiteOrigin_Widget_ContactForm_Field_Text {
-	// This class just exists for autoloading purposes, but is the same as the text field.
+	// Outside of the construct, this class just exists for autoloading purposes, but is the same as the text field.
+	public function __construct( $options ) {
+		$this->type = 'number';
+	}
 }

--- a/widgets/contact/fields/radio.class.php
+++ b/widgets/contact/fields/radio.class.php
@@ -8,7 +8,14 @@ class SiteOrigin_Widget_ContactForm_Field_Radio extends SiteOrigin_Widget_Contac
 				<?php foreach ( $options['field']['options'] as $i => $option ): ?>
 					<li>
 						<label>
-							<input type="radio" value="<?php echo esc_attr( $option['value'] ) ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>" id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i ?>"<?php echo checked( $option['value'], $options['value'], false ) ?>/>
+							<input
+								type="radio"
+								value="<?php echo esc_attr( $option['value'] ); ?>"
+								name="<?php echo esc_attr( $options['field_name'] ); ?>"
+								id="<?php echo esc_attr( $options['field_id'] ) . '-' . $i; ?>"
+								<?php echo checked( $option['value'], $options['value'], false ); ?>
+								<?php self::add_custom_attrs( 'radio' ); ?>
+							/>
 							<?php echo esc_html( $option['value'] ); ?>
 						</label>
 					</li>

--- a/widgets/contact/fields/select.class.php
+++ b/widgets/contact/fields/select.class.php
@@ -3,29 +3,37 @@
 class SiteOrigin_Widget_ContactForm_Field_Select extends SiteOrigin_Widget_ContactForm_Field_Base {
 
 	public function render_field( $options ) {
-		?><select  name="<?php echo esc_attr( $options['field_name'] ) ?>"
-		           id="<?php echo esc_attr( $options['field_id'] ) ?>">
-		<?php
-		if ( $options['show_placeholder'] ) {
-			?>
-			<option selected disabled><?php esc_html_e( $options['field']['label'] ); ?></option>
+		?>
+		<select
+			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			id="<?php echo esc_attr( $options['field_id'] ); ?>"
+			<?php self::add_custom_attrs( 'select' ); ?>
+		>
 			<?php
-		}
-
-		if ( ! empty( $options['field']['options'] ) ) {
-			if ( ! $options['show_placeholder'] && $options['field']['required']['required'] ) {
+			if ( $options['show_placeholder'] ) {
 				?>
-				<option selected <?php if ( ! $options['field']['required']['required'] ) echo 'disabled'; ?>></option>
+				<option selected disabled><?php esc_html_e( $options['field']['label'] ); ?></option>
 				<?php
 			}
 
-			foreach ( $options['field']['options'] as $option ) { ?>
-				<option
-					value="<?php echo esc_attr( $option['value'] ) ?>"<?php echo selected( $option['value'], $options['value'], false ) ?>>
-					<?php echo esc_html( $option['value'] ) ?>
-				</option>
-			<?php }
-		} ?>
-		</select><?php
+			if ( ! empty( $options['field']['options'] ) ) {
+				if ( ! $options['show_placeholder'] && $options['field']['required']['required'] ) {
+					?>
+					<option selected <?php if ( ! $options['field']['required']['required'] ) echo 'disabled'; ?>></option>
+					<?php
+				}
+
+				foreach ( $options['field']['options'] as $option ) {
+					?>
+					<option
+						value="<?php echo esc_attr( $option['value'] ) ?>"<?php echo selected( $option['value'], $options['value'], false ); ?>>
+						<?php echo esc_html( $option['value'] ); ?>
+					</option>
+				<?php
+				}
+			}
+			?>
+		</select>
+		<?php
 	}
 }

--- a/widgets/contact/fields/subject.class.php
+++ b/widgets/contact/fields/subject.class.php
@@ -5,7 +5,15 @@ class SiteOrigin_Widget_ContactForm_Field_Subject extends SiteOrigin_Widget_Cont
 	public function render_field( $options ) {
 
 		?>
-		<input type="text" name="<?php echo esc_attr( $options['field_name'] ) ?>" id="<?php echo esc_attr( $options['field_id'] ) ?>" value="<?php echo esc_attr( $options['value'] ) ?>" class="sow-text-field"<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ) ?>/>
+		<input
+			type="text"
+			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			id="<?php echo esc_attr( $options['field_id'] ); ?>"
+			value="<?php echo esc_attr( $options['value'] ); ?>"
+			class="sow-text-field"
+			<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ); ?>
+			<?php self::add_custom_attrs( 'subject' ); ?>
+		/>
 		<?php
 	}
 }

--- a/widgets/contact/fields/tel.class.php
+++ b/widgets/contact/fields/tel.class.php
@@ -1,5 +1,8 @@
 <?php
 
 class SiteOrigin_Widget_ContactForm_Field_Tel extends SiteOrigin_Widget_ContactForm_Field_Text {
-	// This class just exists for autoloading purposes, but is the same as the text field.
+	// Outside of the construct, this class just exists for autoloading purposes, but is the same as the text field.
+	public function __construct( $options ) {
+		$this->type = 'tel';
+	}
 }

--- a/widgets/contact/fields/text.class.php
+++ b/widgets/contact/fields/text.class.php
@@ -1,11 +1,21 @@
 <?php
 
 class SiteOrigin_Widget_ContactForm_Field_Text extends SiteOrigin_Widget_ContactForm_Field_Base {
+	public function __construct( $options ) {
+		$this->type = 'text';
+	}
 
 	public function render_field( $options ) {
 
 		?>
-		<input type="<?php echo $options['field']['type'] ?>" name="<?php echo esc_attr( $options['field_name'] ) ?>" id="<?php echo esc_attr( $options['field_id'] ) ?>" value="<?php echo esc_attr( $options['value'] ) ?>" class="sow-text-field"<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ) ?>/>
+		<input
+			type="<?php echo $options['field']['type']; ?>"
+			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			id="<?php echo esc_attr( $options['field_id'] ); ?>"
+			value="<?php echo esc_attr( $options['value'] ); ?>"
+			class="sow-text-field"<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ); ?>
+			<?php self::add_custom_attrs( $this->type ); ?>
+		/>
 		<?php
 	}
 }

--- a/widgets/contact/fields/textarea.class.php
+++ b/widgets/contact/fields/textarea.class.php
@@ -4,7 +4,14 @@ class SiteOrigin_Widget_ContactForm_Field_TextArea extends SiteOrigin_Widget_Con
 
 	public function render_field( $options ) {
 		?>
-		<textarea name="<?php echo esc_attr( $options['field_name'] ) ?>" id="<?php echo esc_attr( $options['field_id'] ) ?>" rows="10"<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ) ?>><?php echo esc_textarea($options['value'])
+		<textarea
+			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			id="<?php echo esc_attr( $options['field_id'] ); ?>"
+			rows="10"
+			<?php echo ( $options['show_placeholder'] ? 'placeholder="' . esc_attr( $options['label'] ) . '"' : '' ); ?>
+			<?php self::add_custom_attrs( $this->type ); ?>
+		><?php
+		echo esc_textarea( $options['value'] );
 		?></textarea>
 		<?php
 	}


### PR DESCRIPTION
This PR adds the `siteorigin_widgets_contact_field_attr` filter to contact form field types to allow developers to add custom attributes.

Test snippet:

```
add_filter( 'siteorigin_widgets_contact_field_attr', function( $attrs, $type ) {
	if (
		$type != 'checkboxes' &&
		$type != 'radio' &&
		$type != 'select'
	) {
		return array(
			'example' => 'true',
		);
	}
} );
```

You'll need to inspect the markup to validate the above. [Here's a test layout containing all fields already added](https://drive.google.com/uc?id=1GUjf8MCQK41tILeSlTeb8s4EU7hux_lR).