### PR TITLE
Add siteorigin_esc_url_protocols and Steam Protocol suppot

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -213,7 +213,7 @@ function sow_esc_url( $url ) {
 		if( empty($url) ) return '';
 	}
 
-	$protocols = wp_allowed_protocols();
+	$protocols = apply_filters( 'siteorigin_esc_url_protocols', wp_allowed_protocols() );
 	$protocols[] = 'skype';
 	return esc_url( $url, $protocols );
 }
@@ -231,7 +231,7 @@ function sow_esc_url_raw( $url ) {
 		$url = get_the_permalink( (int) $matches[1] );
 	}
 
-	$protocols = wp_allowed_protocols();
+	$protocols = apply_filters( 'siteorigin_esc_url_raw_protocols', wp_allowed_protocols() );
 	$protocols[] = 'skype';
 	return esc_url_raw( $url, $protocols );
 }

--- a/base/base.php
+++ b/base/base.php
@@ -215,6 +215,7 @@ function sow_esc_url( $url ) {
 
 	$protocols = apply_filters( 'siteorigin_esc_url_protocols', wp_allowed_protocols() );
 	$protocols[] = 'skype';
+	$protocols[] = 'steam';
 	return esc_url( $url, $protocols );
 }
 
@@ -233,6 +234,7 @@ function sow_esc_url_raw( $url ) {
 
 	$protocols = apply_filters( 'siteorigin_esc_url_raw_protocols', wp_allowed_protocols() );
 	$protocols[] = 'skype';
+	$protocols[] = 'steam';
 	return esc_url_raw( $url, $protocols );
 }
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1543

This PR adds the Stream protocol support for any usage of sow_esc_url and sow_esc_url_raw. To test this, please add a SiteOrigin Button widget and set the Destination URL to:

`steam://connect/IP:Port/`

This PR also adds a filter called siteorigin_esc_url_protocols which allows users to easily add custom protocols specifically for Widgets Bundle. Test snippet:

```
add_filter( 'siteorigin_esc_url_protocols', function( $protocols ) {
	$protocols[] = 'test';
	return $protocols;
} );
```

Then add a SiteOrign Button widget with the following Destination URL:
`test://example`

(inspect the button href to confirm this works as depending on how your browser handles unknown protocols nothing may happen).