### PR TITLE
Hero always migrate extra top padding

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -489,11 +489,11 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 		$instance = parent::modify_instance( $instance );
 
 		// Migrate `extra_top_padding` to `padding_extra_top`.
-		if ( ! empty( $instance['layout']['desktop']['extra_top_padding'] ) && $instance['layout']['desktop']['extra_top_padding'] != '0px' ) {
+		if ( ! empty( $instance['layout']['desktop']['extra_top_padding'] ) ) {
 			$instance = self::migrate_padding( $instance, 'desktop' );
 		}
 
-		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) && $instance['layout']['mobile']['extra_top_padding'] != '0px' ) {
+		if ( ! empty( $instance['layout']['mobile']['extra_top_padding'] ) ) {
 			$instance = self::migrate_padding( $instance, 'mobile' );
 		}
 

--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -537,10 +537,10 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 				$settings = $instance['layout']['mobile'];
 
 				$meas_options['slide_height_responsive'] = ! empty( $settings['height_responsive'] ) ? $settings['height_responsive'] : '';
-				if ( ! empty( $settings['padding'] ) || ! empty( $settings['padding_extra_top'] ) ) {
-					$meas_options['slide_padding_responsive'] = ! empty( $settings['padding'] ) ? $settings['padding'] : 0;
+				if ( $settings['padding'] != '' || $settings['padding_extra_top'] != '' ) {
+					$meas_options['slide_padding_responsive'] = ! empty( $settings['padding'] ) ? $settings['padding'] : '0px';
 
-					$meas_options['slide_padding_extra_top_responsive'] = ! empty( $settings['padding_extra_top'] ) ? $settings['padding_extra_top'] : 0;
+					$meas_options['slide_padding_extra_top_responsive'] = ! empty( $settings['padding_extra_top'] ) ? $settings['padding_extra_top'] : '0px';
 				}
 				$meas_options['slide_padding_sides_responsive'] = ! empty( $settings['padding_sides'] ) ? $settings['padding_sides'] : '';
 			}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1545

To test https://github.com/siteorigin/so-widgets-bundle/commit/38a30b0a93a15e6564bab9ddf0ed634b49c61be9
- Install 1.35.1.
- Set up a Hero widget with a frame.
- Set Responsive Extra Top and Bottom padding. Don't alter the Extra Top Padding setting.
- Save and view the Hero on the frontend. Confirm the mobile padding isn't working as desired. (you'll get a 0 without a unit of measurement or default).
- Upgrade to this branch and confirm it's working as expected.


To make testing easier, try not to save after enabling this branch. This will allow you to easily switch to 1.35.1 without needing to recreate the layout.