### PR TITLE
Features: Restore Column Width When Not Using Container Shape

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -91,12 +91,13 @@
 			height: @container_size;
 			text-decoration: none;
 			width: @container_size;
+			flex: 0 0 @container_size;
 
 			& when not ( @per_row = 1 ) {
 				margin: auto;
 			}
 
-			[class^="sow-icon-"],
+			&:not(.sow-container-none) [class^="sow-icon-"],
 			.sow-icon-image {
 				align-items: center;
 				color: #FFFFFF;


### PR DESCRIPTION
Resolved https://github.com/siteorigin/so-widgets-bundle/issues/1526

Please test using the layout in the resolved issue. Please also try using various different container shapes and icon images.