### PR TITLE
Image: Restore Simple Lightbox Compatibility

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -287,8 +287,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 
 	function generate_anchor_open( $url, $link_attributes ) {
 		?>
-		<a
-			href="<?php echo sow_esc_url( $url ); ?>"
+		<a href="<?php echo sow_esc_url( $url ); ?>"
 			<?php
 			foreach ( $link_attributes as $attr => $val ) {
 				if ( ! empty( $val ) ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1555

This PR accounts for an issue with SImple Lightbox's link parsing that prevents it from being able to detect links split over multiple lines.