### PR TITLE
Contact: Avoid Notice If Missing Certain fields

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1510,8 +1510,8 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 		$headers = array(
 			'Content-Type: text/html; charset=UTF-8',
-			'From: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $instance['settings']['from'] ) . '>',
-			'Reply-To: ' . $this->sanitize_header( $email_fields['name'] ) . ' <' . sanitize_email( $email_fields['email'] ) . '>',
+			'From: ' . ( ! empty( $email_fields['name'] ) ? $this->sanitize_header( $email_fields['name'] ) : '' ) . ' <' . sanitize_email( $instance['settings']['from'] ) . '>',
+			'Reply-To: ' . ( ! empty( $email_fields['name'] ) ? $this->sanitize_header( $email_fields['name'] ) : '' ) . ' <' . sanitize_email( $email_fields['email'] ) . '>',
 		);
 
 		// Check if this is a duplicated send


### PR DESCRIPTION
This PR will prevent a notice when not including a name or message field that that occurs after submitting the form.

```
Warning: Undefined array key "message" in /bitnami/wordpress/wp-content/plugins/so-widgets-bundle/widgets/contact/contact.php on line 1470

Warning: foreach() argument must be of type array|object, null given in /bitnami/wordpress/wp-content/plugins/so-widgets-bundle/widgets/contact/contact.php on line 1470
```