### PR TITLE
Social Media Buttons: Prevent Email Dissociation

### DIFF
--- a/widgets/social-media-buttons/data/networks.php
+++ b/widgets/social-media-buttons/data/networks.php
@@ -19,7 +19,7 @@ return array(
 		'icon_color' => '#FFFFFF',
 		'button_color' => '#FAA21B'
 	),
-	'email'   => array(
+	'envelope'   => array(
 		'label'    => __( 'Email', 'so-widgets-bundle' ),
 		'base_url' => 'mailto:',
 		'icon_color' => '#FFFFFF',


### PR DESCRIPTION
This PR will prevent the email network from losing its network after saving and attempting to edit the widget.

To test this:

- Add SiteOrigin Social Media Buttons widget and add an Email network. Save.
- Open widget, confirm widget is lost and then save.
- View the widget and you'll notice that the network is gone on the frontend.

Switch to this branch and then complete the above steps again.