### PR TITLE
Features: Prevent PHP 8 error when `Features Per Row` is empty

### DIFF
--- a/widgets/features/tpl/default.php
+++ b/widgets/features/tpl/default.php
@@ -1,6 +1,7 @@
 <?php
+$per_row = ! empty( $instance['per_row'] ) ? $instance['per_row'] : 3;
 if ( ! empty( $instance['features'] ) ) {
-	$last_row = floor( ( count( $instance['features'] ) - 1 ) / $instance['per_row'] );
+	$last_row = floor( ( count( $instance['features'] ) - 1 ) / $per_row );
 }
 ?>
 
@@ -9,8 +10,8 @@ if ( ! empty( $instance['features'] ) ) {
 	<?php if( isset( $instance['features'] ) ) : ?>
 		<?php foreach( $instance['features'] as $i => $feature ) : ?>
 			<div
-				class="sow-features-feature sow-icon-container-position-<?php echo esc_attr( $feature['container_position'] ) ?> <?php if (  floor( $i / $instance['per_row'] ) == $last_row ) echo 'sow-features-feature-last-row'; ?>"
-				style="display: flex; flex-direction: <?php echo $this->get_feature_flex_direction( $feature['container_position'] ); ?>; float: left; width: <?php echo round( 100 / $instance['per_row'], 3 ); ?>%;"
+				class="sow-features-feature sow-icon-container-position-<?php echo esc_attr( $feature['container_position'] ) ?> <?php if (  floor( $i / $per_row ) == $last_row ) echo 'sow-features-feature-last-row'; ?>"
+				style="display: flex; flex-direction: <?php echo $this->get_feature_flex_direction( $feature['container_position'] ); ?>; float: left; width: <?php echo round( 100 / $per_row, 3 ); ?>%;"
 			>
 
 				<?php if ( ! empty( $feature['more_url'] ) && $instance['icon_link'] && empty( $instance['link_feature'] ) ) : ?>


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/fala-error-on-plugin-siteorigin-widgets-bundle/)

To test this, add a features widget and add a feature. Blank the Features Per Row setting and then save. While using PHP 8, the following error will occur:

`[27-Jul-2022 12:07:12 UTC] PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\widgets\features\tpl\default.php:5`