### PR TITLE
Post Carousel: Remove Loop Requirement when few posts

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -175,12 +175,11 @@ jQuery( function ( $ ) {
 					} else {
 						$items.slick( 'slickNext' );
 					}
-
 				} else if ( $( this ).hasClass( 'sow-carousel-previous' ) ) {
 					if ( $$.data( 'carousel_settings' ).loop && $items.slick( 'slickCurrentSlide' ) == 0 ) {
 						$items.slick( 'slickGoTo', lastPosition );
-					} else if ( ! $$.data( 'carousel_settings' ).loop && $items.slick( 'slickCurrentSlide' ) <= slidesToScroll ) {
-						$items.slick( 'slickGoTo', 1 );
+					} else if ( $items.slick( 'slickCurrentSlide' ) <= slidesToScroll ) {
+						$items.slick( 'slickGoTo', 0 );
 					} else {
 						$items.slick( 'slickPrev' );
 					}


### PR DESCRIPTION
This PR will allow for users to disable the Loop Items setting while only a few items are present - just barely enough to cause a scroll (how much that is really dependent on the theme being used). It's effectively a continuation of [this PR](https://github.com/siteorigin/so-widgets-bundle/pull/1559).