### PR TITLE
Contact Select: Add `Allow multiple selections` Setting

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1501,6 +1501,12 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 			$body .= "\n\n";
 		}
+		foreach ( $email_fields['message'] as $m ) {
+			$body .= '<strong>' . $m['label'] . ':</strong>';
+			$body .= "\n";
+			$body .= htmlspecialchars( $m['value'] );
+			$body .= "\n\n";
+		}
 		$body = wpautop( trim( $body ) );
 
 		if ( $this->is_dev_email($instance['settings']['to']) || empty( $instance['settings']['to'] ) ) {

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -193,11 +193,11 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					),
 
 					'multiple_select' => array(
-						'type'        => 'checkbox',
-						'label'       => __( 'Allow multiple selections', 'so-widgets-bundle' ),
+						'type'  => 'checkbox',
+						'label' => __( 'Allow multiple selections', 'so-widgets-bundle' ),
 						'state_handler' => array(
 							'field_type_{$repeater}[select]' => array( 'show' ),
-							'_else[field_type_{$repeater}]'      => array( 'hide' ),
+							'_else[field_type_{$repeater}]' => array( 'hide' ),
 						),
 					),
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -192,6 +192,15 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						)
 					),
 
+					'multiple_select' => array(
+						'type'        => 'checkbox',
+						'label'       => __( 'Allow multiple selections', 'so-widgets-bundle' ),
+						'state_handler' => array(
+							'field_type_{$repeater}[select]' => array( 'show' ),
+							'_else[field_type_{$repeater}]'      => array( 'hide' ),
+						),
+					),
+
 					// This are for select, radio, and checkboxes
 					'options'  => array(
 						'type'          => 'repeater',
@@ -1282,6 +1291,15 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						$email_fields[ $field['type'] ] = $value;
 					}
 					break;
+				case 'select':
+					if ( ! empty( $field['multiple_select'] ) && is_array( $value ) ) {
+						$value = implode( ', ', $value );
+					} 
+
+					$email_fields['message'][] = array(
+						'label' => $field['label'],
+						'value' => $value,
+					);
 
 				default:
 					$email_fields['message'][] = array(
@@ -1482,15 +1500,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				$body .= '( ' . $_SERVER['REMOTE_ADDR'] . ' )';
 			}
 			$body .= "\n\n";
-		}
-
-		if ( ! empty( $email_fields['message'] ) ) {
-			foreach ( $email_fields['message'] as $m ) {
-				$body .= '<strong>' . $m['label'] . ':</strong>';
-				$body .= "\n";
-				$body .= htmlspecialchars( $m['value'] );
-				$body .= "\n\n";
-			}
 		}
 		$body = wpautop( trim( $body ) );
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1300,7 +1300,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 						'label' => $field['label'],
 						'value' => $value,
 					);
-
+					break;
 				default:
 					$email_fields['message'][] = array(
 						'label' => $field['label'],

--- a/widgets/contact/fields/select.class.php
+++ b/widgets/contact/fields/select.class.php
@@ -5,10 +5,10 @@ class SiteOrigin_Widget_ContactForm_Field_Select extends SiteOrigin_Widget_Conta
 	public function render_field( $options ) {
 		?>
 		<select
-			name="<?php echo esc_attr( $options['field_name'] ); ?><?php echo $options['field']['multiple_select'] ? '[]' : ''; ?>"
+			name="<?php echo esc_attr( $options['field_name'] ); ?><?php echo ! empty( $options['field']['multiple_select'] ) ? '[]' : ''; ?>"
 			id="<?php echo esc_attr( $options['field_id'] ); ?>"
 			<?php self::add_custom_attrs( 'select' ); ?>
-			<?php echo $options['field']['multiple_select'] ? 'multiple' : ''; ?>
+			<?php echo ! empty( $options['field']['multiple_select'] ) ? 'multiple' : ''; ?>
 		>
 			<?php
 			if ( $options['show_placeholder'] ) {

--- a/widgets/contact/fields/select.class.php
+++ b/widgets/contact/fields/select.class.php
@@ -24,10 +24,11 @@ class SiteOrigin_Widget_ContactForm_Field_Select extends SiteOrigin_Widget_Conta
 					<?php
 				}
 
-				foreach ( $options['field']['options'] as $option ) {
+				foreach ( $options['field']['options'] as $i => $option ) {
+					$value = ! empty( $options['field']['multiple_select'] ) && is_array( $options['value'] ) ? $options['value'][ $i ] : $options['value']; 
 					?>
 					<option
-						value="<?php echo esc_attr( $option['value'] ) ?>"<?php echo selected( $option['value'], $options['value'], false ); ?>>
+						value="<?php echo esc_attr( $option['value'] ) ?>"<?php echo selected( $option['value'], $value, false ); ?>>
 						<?php echo esc_html( $option['value'] ); ?>
 					</option>
 				<?php

--- a/widgets/contact/fields/select.class.php
+++ b/widgets/contact/fields/select.class.php
@@ -5,9 +5,10 @@ class SiteOrigin_Widget_ContactForm_Field_Select extends SiteOrigin_Widget_Conta
 	public function render_field( $options ) {
 		?>
 		<select
-			name="<?php echo esc_attr( $options['field_name'] ); ?>"
+			name="<?php echo esc_attr( $options['field_name'] ); ?><?php echo $options['field']['multiple_select'] ? '[]' : ''; ?>"
 			id="<?php echo esc_attr( $options['field_id'] ); ?>"
 			<?php self::add_custom_attrs( 'select' ); ?>
+			<?php echo $options['field']['multiple_select'] ? 'multiple' : ''; ?>
 		>
 			<?php
 			if ( $options['show_placeholder'] ) {


### PR DESCRIPTION
This PR will allow users to set the Select field to allow multiple selections. Selections will be listed in the email `with each, selected, item, separated, by a coma`.