### PR TITLE
Blog: Add Sticky Indicator to Meta

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -907,6 +907,12 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	}
 
 	static public function post_meta( $settings ) {
+		if ( is_sticky() ) {
+			?>
+			<span class="sow-featured-post"><?php echo esc_html__( 'Sticky', 'so-widgets-bundle' ); ?></span>
+			<?php
+		}
+
 		if ( $settings['date'] ) :	
 			$date_format = isset( $settings['date_format'] ) ? $settings['date_format'] : null;
 			?>


### PR DESCRIPTION
This PR will replicate how the sticky tag looks in Corp by adding the words Sticky to the post meta when a post is set to sticky.