### PR TITLE
Blog Read More: Factor Numbers to Word Count

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1034,7 +1034,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 
 		$length = get_query_var( 'siteorigin_blog_excerpt_length' );
 		$excerpt = get_the_excerpt();
-		$excerpt_add_read_more = str_word_count( $excerpt ) >= $length;
+		$excerpt_add_read_more = str_word_count( $excerpt, 0, '0..9' ) >= $length;
 		if ( ! has_excerpt() ) {
 			$excerpt = wp_trim_words( $excerpt, $length, '...' );
 		}


### PR DESCRIPTION
This PR will alter the Read More calculation (which is done to determine if we need to add the read more text) factors in numbers. For an example of why this change was made, take the following text:

> Archives August 2022 July 2022 May 2022 February 2022 January 2022 October 2021 March 2021 October 2020 September 2020 July 2020 June 2020 April 2020 January 2020 November 2019 November 2018 January 2013 March 2012 January 2012 March 2011 October 2010 September 2010 August 2010 July 2010 June 2010 May 2010 April 2010 March 2010

This was calculated as 28 words while it's actually 55. WordPress will still pick up on the numbers and due to the default being 55, it'll show the dots without a Read More.