### PR TITLE
Google Maps Consent: Only Setup if Google Maps Not Already Setup

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -448,7 +448,7 @@ jQuery( window.sowb ).on( 'sow-google-map-loaded', function() {
 jQuery(function ($) {
 	sowb.googleMapsData = [];
 	sowb.googleMapsData.libraries = [];
-	sowb.setupGoogleMaps = function( e, forceLoad = false  ) {
+	sowb.setupGoogleMaps = function( e, forceLoad = false ) {
 		var $mapCanvas = $( '.sow-google-map-canvas' );
 		if ( ! $mapCanvas.length ) {
 			return;
@@ -584,8 +584,10 @@ jQuery(function ($) {
 			$( '.sow-google-map-consent button' ).on( 'click', function() {
 				$( '.sow-google-map-consent' ).remove();
 				$( '.sow-google-map-canvas' ).show();
-				$( 'body' ).append( '<script async type="text/javascript" id="sow-google-maps-js" src="' + apiUrl + '">' );
-				sowb.mapsApiInitialized = true;
+				if ( ! sowb.mapsApiInitialized ) {
+					$( 'body' ).append( '<script async type="text/javascript" id="sow-google-maps-js" src="' + apiUrl + '">' );
+					sowb.mapsApiInitialized = true;
+				}
 			} );
 		} else {
 			$( 'body' ).append( '<script async type="text/javascript" id="sow-google-maps-js" src="' + apiUrl + '">' );


### PR DESCRIPTION
This PR prevents a situation where Google Maps Consent _may_ attempt to load the Google Maps API multiple times. To test this PR, test the standard consent prompt.