### PR TITLE
Blog: More Specific Article Reset

### DIFF
--- a/widgets/blog/css/style.less
+++ b/widgets/blog/css/style.less
@@ -8,7 +8,7 @@
 	}
 
 	// Global Styles.
-	article {
+	.sow-blog-posts article {
 		border: none;
 		box-sizing: border-box;
 		margin: 0;

--- a/widgets/blog/css/style.less
+++ b/widgets/blog/css/style.less
@@ -7,12 +7,15 @@
 		justify-content: space-between;
 	}
 
-	// Global Styles.
 	.sow-blog-posts article {
 		border: none;
 		box-sizing: border-box;
 		margin: 0;
 		padding: 0;
+	}
+
+	// Global Styles.
+	article {
 
 		.sow-entry-thumbnail {
 


### PR DESCRIPTION
This PR will ensure some of our adjustments using the article are more specific. This is important as it appears certain themes (such as Vantage) apply styles to the `article` element containing the post using `article.post`. In the case of Vantage, that results in unexpected padding while using the Alternate template.

![Screenshot 2022-09-08 at 02-06-09 SO](https://user-images.githubusercontent.com/17275120/188928022-af70fa47-2544-41f8-862e-ef225b4f7a4c.png)
