### PR TITLE
Blog Alternate: Left Align Odd Images

### DIFF
--- a/widgets/blog/styles/alternate.less
+++ b/widgets/blog/styles/alternate.less
@@ -58,34 +58,26 @@
 		margin-top: 0;
 		width: 100%;
 
+		.sow-entry-thumbnail {
+			width: 100%;
+		}
+
 		// Alternating featured image alignment.
 		@media (min-width: @responsive_breakpoint) {
+			.sow-entry-thumbnail {
+				width: 41.5006%;
+
+				a {
+					text-align: left;
+				}
+			}
 
 			&:nth-of-type(2n) {
 				flex-direction: row-reverse;
 			}
 
-			&:nth-of-type(2n) {
-
-				.sow-entry-thumbnail a {
+			&:nth-of-type(2n) .sow-entry-thumbnail a {
 					text-align: right;
-				}
-			}
-		}
-
-		@media (max-width: @responsive_breakpoint) {
-			width: 100%;
-		}
-
-		.sow-entry-thumbnail {
-			width: 41.5006%;
-
-			@media (max-width: @responsive_breakpoint) {
-				width: 100%;
-
-				a {
-					text-align: left;
-				}
 			}
 		}
 

--- a/widgets/blog/styles/alternate.less
+++ b/widgets/blog/styles/alternate.less
@@ -77,7 +77,7 @@
 			}
 
 			&:nth-of-type(2n) .sow-entry-thumbnail a {
-					text-align: right;
+				text-align: right;
 			}
 		}
 


### PR DESCRIPTION
This PR will left align odd images in the Alternate Template. Currently, they're centered. It also cleans up the CSS for the featured image in this layout.

![Screenshot 2022-09-08 at 02-15-46 SO](https://user-images.githubusercontent.com/17275120/188930221-b0aa5791-f4c5-4e2f-a8fb-615585a59083.png)
