### PR TITLE
Blog: Add `siteorigin_widgets_blog_image_sizes`

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -8,8 +8,6 @@ Documentation: https://siteorigin.com/widgets-bundle/blog-widget/
 */
 
 class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
-	private $image_sizes;
-
 	function __construct() {
 		parent::__construct(
 			'sow-blog',
@@ -27,6 +25,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	}
 
 	function initialize() {
+		add_action( 'wp_loaded', array( $this, 'register_image_sizes' ) );
 		$this->register_frontend_styles(
 			array(
 				array(
@@ -37,11 +36,26 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		);
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_template_assets' ) );
 
-		$this->image_sizes = apply_filters( 'siteorigin_widgets_blog_image_sizes', array(
-			'portfolio' => array( 375, 375 ),
-			'grid' => array( 420, 275 ),
-			'alternate' => array( 475, 315 ),
+	}
+
+	function register_image_sizes() {
+		$image_sizes = apply_filters( 'siteorigin_widgets_blog_image_sizes', array(
+			'portfolio' => array(
+				375,
+				375
+			),
+			'grid' => array(
+				720,
+				480
+			),
+			'alternate' => array(
+				475,
+				315
+			)
 		) );
+		foreach ( $image_sizes as $k => $size ) {
+			add_image_size( 'sow-blog-' . $k, (int) $size[0], (int) $size[1], true );
+		}
 	}
 
 	function get_widget_form() {
@@ -981,11 +995,8 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 				<a href="<?php the_permalink(); ?>">
 					<?php
 					// Check if this template has a different default image size.
-					if (
-						$size == 'post-thumbnail' &&
-						! empty( $this->image_sizes[ $settings['template'] ] )
-					) {
-						$size = $this->image_sizes[ $settings['template'] ];
+					if ( $size == 'post-thumbnail' && has_image_size( 'sow-blog-' . $settings['template'] ) ) {
+						$size = 'sow-blog-' . $settings['template'];
 					}
 					the_post_thumbnail( $size );
 					?>

--- a/widgets/blog/tpl/alternate.php
+++ b/widgets/blog/tpl/alternate.php
@@ -1,6 +1,6 @@
 <?php $thumbnail_class = ! $settings['featured_image'] || ! has_post_thumbnail() ? 'sow-no-thumbnail' : ''; ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class( "sow-blog-columns $thumbnail_class" ); ?> style="display: flex; flex-wrap: wrap; justify-content: space-between; margin-bottom: 30px;">
-	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
+	<?php $this->post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper">
 		<header class="sow-entry-header" style="margin-bottom: 18px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/grid.php
+++ b/widgets/blog/tpl/grid.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> style="margin: 0 0 30px;">
-	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
+	<?php $this->post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/masonry.php
+++ b/widgets/blog/tpl/masonry.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class( 'sow-masonry-item' ); ?>>
-	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings, true ); ?>
+	<?php $this->post_featured_image( $settings, true ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/offset.php
+++ b/widgets/blog/tpl/offset.php
@@ -52,7 +52,7 @@
 		<?php endif; ?>
 	</div>
 	<div class="sow-blog-entry" style="width: 78%;">
-		<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
+		<?php $this->post_featured_image( $settings ); ?>
 		<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 			<header class="sow-entry-header" style="margin-bottom: 20px;">
 				<?php

--- a/widgets/blog/tpl/standard.php
+++ b/widgets/blog/tpl/standard.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> style="margin: 0 0 40px">
-	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
+	<?php $this->post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 38px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>


### PR DESCRIPTION
This PR adds the `siteorigin_widgets_blog_image_sizes` filter, which is used to override the featured image size in certain templates. Currently, those templates are:

- Portfolio
- Grid
- Alternate

These sizes are based on an approximation of their Corp sizing. Users can override the image sizes using the `siteorigin_widgets_blog_image_sizes`. Users can also introduce new sizing for other templates using the same filter. For example, the following PHP will override the Offset featured image size to 123x321.

`add_filter( 'siteorigin_widgets_blog_image_sizes', function( $sizes ) {
  	$sizes['offset'] = array( 123, 321 );
	return $sizes;
} );`

Users can also return an image size name instead of dimensions if preferred. For example, the following PHP will override the Grid Featured Image to Medium.

```
add_filter( 'siteorigin_widgets_blog_image_sizes', function( $sizes ) {
  	$sizes['grid'] = 'medium';
	return $sizes;
} );
```

This PR removes the `sow-blog-portfolio` image size as that's now superseded by this filer.