### PR TITLE
Blog: Add `siteorigin_widgets_blog_excerpt_trim`

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1036,7 +1036,11 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		$excerpt = get_the_excerpt();
 		$excerpt_add_read_more = str_word_count( $excerpt, 0, '0..9' ) >= $length;
 		if ( ! has_excerpt() ) {
-			$excerpt = wp_trim_words( $excerpt, $length, '...' );
+			$excerpt = wp_trim_words(
+				$excerpt,
+				$length,
+				apply_filters( 'siteorigin_widgets_blog_excerpt_trim', '...' )
+			);
 		}
 
 		if ( $settings['read_more'] && ( has_excerpt() || $excerpt_add_read_more ) ) {

--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1018,7 +1018,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	}
 
 	function alter_excerpt_more_indicator( $indicator ) {
-		return '...';
+		return apply_filters( 'siteorigin_widgets_blog_excerpt_trim', '...' );
 	}
 
 	function alter_excerpt_length( $length = 55 ) {


### PR DESCRIPTION
This PR adds a filter that controls the trim indicator when the excerpt is generated. Filter example:

```
add_filter( 'siteorigin_widgets_blog_excerpt_trim', function( $trim ) {
	return '[...]';
} );
```

You can also completely remove the excerpt (leaving only the continue reading link) using the following PHP:

```
add_filter( 'siteorigin_widgets_blog_excerpt_length', function( $length ) {
	return 0;
} );

add_filter( 'siteorigin_widgets_blog_excerpt_trim', function( $trim ) {
	return '';
} );
```
