### PR TITLE
Image Grid: Add `Display Image Title` and Related Settings

### DIFF
--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -222,7 +222,6 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title_font_size' => array(
 						'type' => 'measurement',
 						'label' => __( 'Title Font Size', 'so-widgets-bundle' ),
-						'default' => '22px',
 						'state_handler' => array(
 							'title_display[show]' => array( 'show' ),
 							'title_display[hide]' => array( 'hide' ),

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -184,7 +184,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title_position' => array(
 						'type' => 'select',
 						'label' => __( 'Title Position', 'so-widgets-bundle' ),
-						'default' => 'after',
+						'default' => 'below',
 						'options' => array(
 							'above' => __( 'Above Image', 'so-widgets-bundle' ),
 							'below' => __( 'Below Image', 'so-widgets-bundle' ),

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -171,7 +171,6 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title_display' => array(
 						'type' => 'checkbox',
 						'label' => __( 'Display Image Title', 'so-widgets-bundle' ),
-						'default' => true,
 						'state_emitter' => array(
 							'callback' => 'conditional',
 							'args' => array(
@@ -222,6 +221,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					'title_font_size' => array(
 						'type' => 'measurement',
 						'label' => __( 'Title Font Size', 'so-widgets-bundle' ),
+						'default' => '0.9rem',
 						'state_handler' => array(
 							'title_display[show]' => array( 'show' ),
 							'title_display[hide]' => array( 'hide' ),

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -186,8 +186,8 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 						'label' => __( 'Title Position', 'so-widgets-bundle' ),
 						'default' => 'after',
 						'options' => array(
-							'above' => __( 'Above image', 'so-widgets-bundle' ),
-							'below' => __( 'Below image', 'so-widgets-bundle' ),
+							'above' => __( 'Above Image', 'so-widgets-bundle' ),
+							'below' => __( 'Below Image', 'so-widgets-bundle' ),
 						),
 						'state_handler' => array(
 							'title_display[show]' => array( 'show' ),

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -419,7 +419,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			$less['title_alignment'] = ! empty( $instance['display']['title_display'] ) ? $instance['display']['title_alignment'] : '';
 			$title_font = siteorigin_widget_get_font( $instance['display']['title_font'] );
 			$less['title_font'] = $title_font['family'];
-			if ( ! empty( $title_font['family'] ) ) {
+			if ( ! empty( $title_font['weight'] ) ) {
 				$less['title_font_weight'] = $title_font['weight_raw'];
 				$less['title_font_style'] = $title_font['style'];
 			}

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -178,7 +178,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 								'title_display[show]: val',
 								'title_display[hide]: ! val',
 							),
-						)
+						),
 					),
 
 					'title_position' => array(
@@ -207,7 +207,60 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 						'state_handler' => array(
 							'title_display[show]' => array( 'show' ),
 							'title_display[hide]' => array( 'hide' ),
-						)
+						),
+					),
+
+					'title_font' => array(
+						'type' => 'font',
+						'label' => __( 'Title Font', 'so-widgets-bundle' ),
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						),
+					),
+
+					'title_font_size' => array(
+						'type' => 'measurement',
+						'label' => __( 'Title Font Size', 'so-widgets-bundle' ),
+						'default' => '22px',
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						),
+					),
+
+					'title_color' => array(
+						'type' => 'color',
+						'label' => __( 'Title Color', 'so-widgets-bundle' ),
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						),
+					),
+					'title_padding' => array(
+						'type' => 'color',
+						'label' => __( 'Title Padding', 'so-widgets-bundle' ),
+						'type' => 'multi-measurement',
+						'autofill' => true,
+						'default' => '5px 0px 10px 0px',
+						'measurements' => array(
+							'top' => array(
+							'label' => __( 'Top', 'so-widgets-bundle' ),
+							),
+							'right' => array(
+								'label' => __( 'Right', 'so-widgets-bundle' ),
+							),
+							'bottom' => array(
+								'label' => __( 'Bottom', 'so-widgets-bundle' ),
+							),
+							'left' => array(
+								'label' => __( 'Left', 'so-widgets-bundle' ),
+							),
+						),
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						),
 					),
 				)
 			)
@@ -357,13 +410,26 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	 * @return mixed
 	 */
 	function get_less_variables( $instance ) {
-		return array(
+		$less = array(
 			'padding' => ! empty( $instance['display']['padding'] ) ? $instance['display']['padding'] : '5px 5px 5px 5px',
 			'alignment_horizontal' => ! empty( $instance['display']['alignment_horizontal'] ) ? $instance['display']['alignment_horizontal'] : 'center',
 			'alignment_vertical' => ! empty( $instance['display']['alignment_vertical'] ) ? $instance['display']['alignment_vertical'] : 'baseline',
-			'title_alignment' => ! empty( $instance['display']['title_display'] ) ? $instance['display']['title_alignment'] : '',
-
 		);
+
+		if ( ! empty( $instance['display']['title_display'] ) ) {
+			$less['title_alignment'] = ! empty( $instance['display']['title_display'] ) ? $instance['display']['title_alignment'] : '';
+			$title_font = siteorigin_widget_get_font( $instance['display']['title_font'] );
+			$less['title_font'] = $title_font['family'];
+			if ( ! empty( $title_font['family'] ) ) {
+				$less['title_font_weight'] = $title_font['weight_raw'];
+				$less['title_font_style'] = $title_font['style'];
+			}
+			$less['title_font_size'] = ! empty( $instance['display']['title_font_size'] ) ? $instance['display']['title_font_size'] : '';
+			$less['title_color'] = ! empty( $instance['display']['title_color'] ) ? $instance['display']['title_color'] : '';
+			$less['title_padding'] = ! empty( $instance['display']['title_padding'] ) ? $instance['display']['title_padding'] : '';
+		}
+
+		return $less;
 	}
 
 	function get_form_teaser() {

--- a/widgets/image-grid/image-grid.php
+++ b/widgets/image-grid/image-grid.php
@@ -51,7 +51,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			'images' => array(
 				'type' => 'repeater',
 				'label' => __( 'Images', 'so-widgets-bundle' ),
-				'item_name'  => __( 'Image', 'so-widgets-bundle' ),
+				'item_name' => __( 'Image', 'so-widgets-bundle' ),
 				'item_label' => array(
 					'selectorArray' => array(
 						array(
@@ -167,6 +167,48 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 							'flex-end' => __( 'Right', 'so-widgets-bundle' ),
 						),
 					),
+
+					'title_display' => array(
+						'type' => 'checkbox',
+						'label' => __( 'Display Image Title', 'so-widgets-bundle' ),
+						'default' => true,
+						'state_emitter' => array(
+							'callback' => 'conditional',
+							'args' => array(
+								'title_display[show]: val',
+								'title_display[hide]: ! val',
+							),
+						)
+					),
+
+					'title_position' => array(
+						'type' => 'select',
+						'label' => __( 'Title Position', 'so-widgets-bundle' ),
+						'default' => 'after',
+						'options' => array(
+							'above' => __( 'Above image', 'so-widgets-bundle' ),
+							'below' => __( 'Below image', 'so-widgets-bundle' ),
+						),
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						)
+					),
+
+					'title_alignment' => array(
+						'type' => 'select',
+						'label' => __( 'Title Alignment', 'so-widgets-bundle' ),
+						'default' => 'center',
+						'options' => array(
+							'left' => __( 'Left', 'so-widgets-bundle' ),
+							'center' => __( 'Center', 'so-widgets-bundle' ),
+							'right' => __( 'Right', 'so-widgets-bundle' ),
+						),
+						'state_handler' => array(
+							'title_display[show]' => array( 'show' ),
+							'title_display[hide]' => array( 'hide' ),
+						)
+					),
 				)
 			)
 		);
@@ -225,7 +267,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 
 				$image['image_html'] = wp_get_attachment_image( $image['image'], $instance['display']['attachment_size'], false, array(
 					'title' => $title,
-					'alt'   => $image['alt'],
+					'alt' => $image['alt'],
 					'class' => 'sow-image-grid-image_html',
 					'loading' => $lazy_load_current ? 'lazy' : '',
 				) );
@@ -236,6 +278,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			'images' => $images,
 			'max_height' => $instance['display']['max_height'],
 			'max_width' => $instance['display']['max_width'],
+			'title_position' => ! empty( $instance['display']['title_display'] ) ? $instance['display']['title_position'] : false,
 		);
 	}
 
@@ -267,6 +310,10 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 	}
 	
 	function modify_instance( $instance ) {
+		if ( empty( $instance ) ) {
+			return array();
+		}
+
 		if ( ! empty( $instance['display'] ) ) {
 			// Revert changes to `max_width` and `max_height` back to `number` fields.
 			if ( ! empty( $instance['display']['max_height'] ) ) {
@@ -291,8 +338,14 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 					$instance['display']['padding'] = "0px $spacing $spacing $spacing";
 				}
 			}
+
+			// If this Image Grid was created before the image title setting was added, disable it by default.
+			if ( ! isset( $instance['display']['title_display'] ) ) {
+				$instance['display']['title_display'] = false;
+			}
 		}
 		
+
 		return $instance;
 	}
 
@@ -308,6 +361,7 @@ class SiteOrigin_Widgets_ImageGrid_Widget extends SiteOrigin_Widget {
 			'padding' => ! empty( $instance['display']['padding'] ) ? $instance['display']['padding'] : '5px 5px 5px 5px',
 			'alignment_horizontal' => ! empty( $instance['display']['alignment_horizontal'] ) ? $instance['display']['alignment_horizontal'] : 'center',
 			'alignment_vertical' => ! empty( $instance['display']['alignment_vertical'] ) ? $instance['display']['alignment_vertical'] : 'baseline',
+			'title_alignment' => ! empty( $instance['display']['title_display'] ) ? $instance['display']['title_alignment'] : '',
 
 		);
 	}

--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -1,6 +1,7 @@
 @padding: default;
 @alignment_horizontal: center;
 @alignment_vertical: end;
+@title_alignment: default;
 
 .sow-image-grid-wrapper {
 	display: flex;
@@ -18,6 +19,10 @@
 			opacity: 0;
 			max-width:100%;
 			height:auto;
+		}
+
+		.widget-title {
+			text-align: @title_alignment;
 		}
 	}
 }

--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -2,6 +2,12 @@
 @alignment_horizontal: center;
 @alignment_vertical: end;
 @title_alignment: default;
+@title_color: default;
+@title_font: default;
+@title_font_size: default;
+@title_font_style: default;
+@title_font_weight: default;
+@title_padding: default;
 
 .sow-image-grid-wrapper {
 	display: flex;
@@ -21,7 +27,14 @@
 			height:auto;
 		}
 
-		.widget-title {
+		.image-title {
+			color: @title_color;
+			font-family: @title_font;
+			font-size: @title_font_size;
+			font-style: @title_font_style;
+			font-weight: @title_font_weight;
+			line-height: 1.25em;
+			padding: @title_padding;
 			text-align: @title_alignment;
 		}
 	}

--- a/widgets/image-grid/styles/default.less
+++ b/widgets/image-grid/styles/default.less
@@ -33,7 +33,7 @@
 			font-size: @title_font_size;
 			font-style: @title_font_style;
 			font-weight: @title_font_weight;
-			line-height: 1.25em;
+			line-height: 1.25;
 			padding: @title_padding;
 			text-align: @title_alignment;
 		}

--- a/widgets/image-grid/tpl/default.php
+++ b/widgets/image-grid/tpl/default.php
@@ -3,6 +3,7 @@
  * @var $images array
  * @var $max_height int
  * @var $max_width int
+ * @var $title_position string
  */
 ?>
 <?php if( ! empty( $images ) ) : ?>
@@ -11,6 +12,9 @@
 		<?php if ( !empty( $max_height ) ) echo 'data-max-height="' . (int) $max_height . '"' ?>>
 		<?php foreach( $images as $image ) : ?>
 			<div class="sow-image-grid-image">
+				<?php if ( ! empty( $title_position ) && ! empty( $image['title'] ) && $title_position == 'above' ) : ?>
+					<?php echo $args['before_title'] . wp_kses_post( $image['title'] ) . $args['after_title']; ?>
+				<?php endif; ?>
 				<?php if ( ! empty( $image['url'] ) ) : ?>
 					<a href="<?php echo sow_esc_url( $image['url'] ) ?>"
 					<?php foreach( $image['link_attributes'] as $att => $val ) : ?>
@@ -22,6 +26,9 @@
 				<?php echo $image['image_html']; ?>
 				<?php if ( ! empty( $image['url'] ) ) : ?>
 					</a>
+				<?php endif; ?>
+				<?php if ( ! empty( $title_position ) && ! empty( $image['title'] ) && $title_position == 'below' ) : ?>
+					<?php echo $args['before_title'] . wp_kses_post( $image['title'] ) . $args['after_title']; ?>
 				<?php endif; ?>
 			</div>
 		<?php endforeach; ?>

--- a/widgets/image-grid/tpl/default.php
+++ b/widgets/image-grid/tpl/default.php
@@ -13,7 +13,9 @@
 		<?php foreach( $images as $image ) : ?>
 			<div class="sow-image-grid-image">
 				<?php if ( ! empty( $title_position ) && ! empty( $image['title'] ) && $title_position == 'above' ) : ?>
-					<?php echo $args['before_title'] . wp_kses_post( $image['title'] ) . $args['after_title']; ?>
+					<div class="image-title">
+						<?php echo wp_kses_post( $image['title'] ) ?>
+					</div>
 				<?php endif; ?>
 				<?php if ( ! empty( $image['url'] ) ) : ?>
 					<a href="<?php echo sow_esc_url( $image['url'] ) ?>"
@@ -28,7 +30,9 @@
 					</a>
 				<?php endif; ?>
 				<?php if ( ! empty( $title_position ) && ! empty( $image['title'] ) && $title_position == 'below' ) : ?>
-					<?php echo $args['before_title'] . wp_kses_post( $image['title'] ) . $args['after_title']; ?>
+					<div class="image-title">
+						<?php echo wp_kses_post( $image['title'] ) ?>
+					</div>
 				<?php endif; ?>
 			</div>
 		<?php endforeach; ?>


### PR DESCRIPTION
This PR introduces the Display Image Title setting which allows users to display the image's title directly above or below the image. It introduces two additional settings, the Image Title Position and Image Title Alignment settings.

While testing this PR please first create an image Grid with some images set with and without titles present. Once you've done that please then switch to this PR and ensure the image titles don't appear - they're enabled by default, but existing users shouldn't notice them for pre-existing Image Grids.