### PR TITLE
Contact: Add `Honeypot` and `Browser Check` Anti-spam Options

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -236,7 +236,16 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				'label'  => __( 'Spam Protection', 'so-widgets-bundle' ),
 				'hide'   => true,
 				'fields' => array(
-
+					'honeypot' => array(
+						'type'        => 'checkbox',
+						'label'       => __( 'Honeypot', 'so-widgets-bundle' ),
+						'description' => __( 'Add an invisible field to your form that if filled out, the form will be rejected.', 'so-widgets-bundle' ),
+					),
+					'browser_check' => array(
+						'type'        => 'checkbox',
+						'label'       => __( 'Browser Check', 'so-widgets-bundle' ),
+						'description' => __( 'Runs a check on submission that confirms the submission came from a browser. Requires the user to have JavaScript enabled.', 'so-widgets-bundle' ),
+					),
 					'recaptcha' => array(
 						'type'   => 'section',
 						'label'  => __( 'reCAPTCHA', 'so-widgets-bundle' ),
@@ -881,12 +890,16 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'onclick' => ! empty( $instance['settings']['on_click'] ) ? $instance['settings']['on_click'] : '',
 		);
 
+		$submit_attributes = array();
+		if ( ! empty( $instance['spam']['browser_check'] ) ) {
+			$submit_attributes['data-js-key'] = $instance['_sow_form_id'];
+		}
+
 		// Include '_sow_form_id' in generation of 'instance_hash' to allow multiple instances of the same form on a page.
 		$template_vars['instance_hash'] = md5( serialize( $instance ) );
 		$template_vars['result'] = $this->contact_form_action( $instance, $template_vars['instance_hash'] );
 		unset( $instance['_sow_form_id'] );
 
-		$submit_attributes = array();
 		if ( ! empty( $instance['settings']['submit_id'] ) ) {
 			$submit_attributes['id'] = $instance['settings']['submit_id'];
 		}
@@ -907,6 +920,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				);
 			}
 		}
+		$template_vars['submit_attributes'] = $submit_attributes;
 
 		if ( ! empty( $instance['spam']['simple'] ) && ! empty( $instance['spam']['simple']['enabled'] ) ) {
 			if ( ! class_exists( 'ReallySimpleCaptcha' ) ) {
@@ -950,7 +964,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 		}
 
-		$template_vars['submit_attributes'] = $submit_attributes;
+		$template_vars['honeypot'] = ! empty( $instance['spam']['honeypot'] );
 
 		return $template_vars;
 	}
@@ -1203,9 +1217,11 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			// In those cases `$_POST['_wpnonce']` doesn't exist and calling `wp_die` will halt script execution and break things.
 			return false;
 		}
+
 		if ( empty( $_POST['instance_hash'] ) || $_POST['instance_hash'] != $storage_hash ) {
 			return false;
 		}
+
 		if ( empty( $instance['fields'] ) ) {
 			array(
 				'status' => null,
@@ -1473,6 +1489,19 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					$errors['simple'] = __( 'Error validating your Captcha response. Please try again.', 'so-widgets-bundle' );
 				}
 				$captcha->remove( $prefix );
+			}
+		}
+
+		if ( ! empty( $instance['spam']['honeypot'] ) && ! empty( $_POST[ 'sow-' . $instance['_sow_form_id'] ] ) ) {
+			$errors['spam-js'] = __( 'Unfortunately our system identified your message as spam.', 'so-widgets-bundle' );
+		}
+
+		if ( ! empty( $instance['spam']['browser_check'] ) ) {
+			if (
+				empty( $_POST[ 'sow-js-' . $instance['_sow_form_id'] ] ) ||
+				$_POST[ 'sow-js-' . $instance['_sow_form_id'] ] != $instance['_sow_form_id']
+			) {
+				$errors['spam-honeypot'] = __( 'Unfortunately our system identified your message as spam.', 'so-widgets-bundle' );
 			}
 		}
 

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -239,7 +239,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 					'honeypot' => array(
 						'type'        => 'checkbox',
 						'label'       => __( 'Honeypot', 'so-widgets-bundle' ),
-						'description' => __( 'Add an invisible field to your form that if filled out, the form will be rejected.', 'so-widgets-bundle' ),
+						'description' => __( 'Adds a hidden form field that only bots can see. The form will reject the submission if the hidden field is populated.', 'so-widgets-bundle' ),
 					),
 					'browser_check' => array(
 						'type'        => 'checkbox',

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1493,7 +1493,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		}
 
 		if ( ! empty( $instance['spam']['honeypot'] ) && ! empty( $_POST[ 'sow-' . $instance['_sow_form_id'] ] ) ) {
-			$errors['spam-js'] = __( 'Unfortunately our system identified your message as spam.', 'so-widgets-bundle' );
+			$errors['spam-js'] = __( 'Unfortunately, our system identified your message as spam.', 'so-widgets-bundle' );
 		}
 
 		if ( ! empty( $instance['spam']['browser_check'] ) ) {
@@ -1501,7 +1501,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				empty( $_POST[ 'sow-js-' . $instance['_sow_form_id'] ] ) ||
 				$_POST[ 'sow-js-' . $instance['_sow_form_id'] ] != $instance['_sow_form_id']
 			) {
-				$errors['spam-honeypot'] = __( 'Unfortunately our system identified your message as spam.', 'so-widgets-bundle' );
+				$errors['spam-honeypot'] = __( 'Unfortunately, our system identified your message as spam.', 'so-widgets-bundle' );
 			}
 		}
 

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -5,7 +5,9 @@ window.sowb = window.sowb || {};
 sowb.SiteOriginContactForm = {
 	init: function ($, useRecaptcha) {
 		var $contactForms = $('form.sow-contact-form,.sow-contact-form-success');
-		$contactForms.each(function () {
+		$( '.sow-js-hp' ).hide();
+
+		$contactForms.each( function() {
 			var $el = $( this );
 			var formId = $el.attr( 'id' );
 			var formSubmitted = window.location.hash.indexOf( formId ) > -1;
@@ -68,6 +70,11 @@ sowb.SiteOriginContactForm = {
 						locationHash = locationHash.replace( re, '' );
 					}
 					$( this ).attr( 'action', formAction + ',' + locationHash.replace( /^#/, '' ) );
+				}
+
+				if ( $submitButton.data( 'js-key' ) ) {
+					var js_key = $submitButton.data( 'js-key' );
+					$( this ).append( `<input type="hidden" name="sow-js-${js_key}" value="${js_key}">` );
 				}
 			} );
 		} );

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -5,8 +5,6 @@ window.sowb = window.sowb || {};
 sowb.SiteOriginContactForm = {
 	init: function ($, useRecaptcha) {
 		var $contactForms = $('form.sow-contact-form,.sow-contact-form-success');
-		$( '.sow-js-hp' ).hide();
-
 		$contactForms.each( function() {
 			var $el = $( this );
 			var formId = $el.attr( 'id' );

--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -34,8 +34,9 @@ else {
 		<?php endif ?>
 
 		<?php $this->render_form_fields( $instance['fields'], $result['errors'], $instance ) ?>
-		<input type="hidden" name="instance_hash" value="<?php echo esc_attr( $instance_hash ) ?>" />
-		<?php wp_nonce_field( '_contact_form_submit' ) ?>
+		<?php if ( $template_vars['honeypot'] ) : ?>
+			<input type="text" name="sow-<?php echo esc_attr( $instance['_sow_form_id'] ); ?>" class="sow-text-field" style="display:none !important; visibility:hidden !important;" autocomplete="off">
+		<?php endif; ?>
 
 		<?php if ( $recaptcha ) : ?>
 			<div class="sow-recaptcha"
@@ -54,6 +55,9 @@ else {
 			}
 		}
 		?>
+
+		<input type="hidden" name="instance_hash" value="<?php echo esc_attr( $instance_hash ) ?>" />
+		<?php wp_nonce_field( '_contact_form_submit' ) ?>
 		<div class="sow-submit-wrapper <?php if ( $instance['design']['submit']['styled'] ) echo 'sow-submit-styled'; ?>">
 
 		<button class="sow-submit<?php if ( $recaptcha && empty( $recaptcha_v2 ) ) echo ' g-recaptcha'; ?>"


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1593

This PR implements two new anti-spam options the honeypot and a browser check. The browser check is stronger overall, but it requires JavaScript to be enabled so not all users will be okay with that.

To test the honeypot option: find the (CSS) hidden field in the markup and set it to show. Give it a value and submit it. If it failed after inputting data into the field, it worked.

To test the browser check, disable JavaScript.