### PR TITLE
Increased article specificity for Grid and Alternate Blog layouts

### DIFF
--- a/widgets/blog/styles/alternate.less
+++ b/widgets/blog/styles/alternate.less
@@ -50,6 +50,11 @@
 
 .sow-blog-layout-alternate {
 
+	.sow-blog-posts article {
+		background: @post_background;
+		border: 1px solid @post_border_color;
+	}
+
 	article {
 		background: @post_background;
 		border: 1px solid @post_border_color;

--- a/widgets/blog/styles/grid.less
+++ b/widgets/blog/styles/grid.less
@@ -56,15 +56,18 @@
 		column-gap: @column_spacing;
 		display: grid;
 		grid-template-columns: repeat( @columns, 1fr );
+
+		article {
+			background: @post_background;
+			border: 1px solid @post_border_color;
+
+			@media (max-width: @responsive_breakpoint) {
+				width: 100%;
+			}
+		}
 	}
 
 	article {
-		background: @post_background;
-		border: 1px solid @post_border_color;
-
-		@media (max-width: @responsive_breakpoint) {
-			width: 100%;
-		}
 
 		.sow-entry-header {
 


### PR DESCRIPTION
@AlexGStapleton

The Vantage and WB stylesheet load order is different on https://vantage-demo.packs.siteorigin.com/blog-grid-layout/. The result was the article's last-child rule in Vantage was removing the last article's bottom border for the Grid and Alternate layout. This PR increases the specificity of the article tag for those two layouts.