### PR TITLE
Post Carousel: Never Alter `SlidesToScroll` for `Overlay` Theme

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -164,7 +164,7 @@ jQuery( function ( $ ) {
 							$items.slick( 'slickGoTo', 0 );
 						}
 					// If slidesToScroll is higher than the the number of visible items, go to the last item.
-					} else if ( $$.data( 'widget' ) == 'post' && slidesToScroll >= numVisibleItemsFloor ) {
+					} else if ( $$.data( 'widget' ) == 'post' && $$.data( 'carousel_settings' ).theme == 'undefined' && slidesToScroll >= numVisibleItemsFloor ) {
 						// There's more slides than items, update Slick settings to allow for scrolling of partially visible items.
 						$items.slick( 'slickSetOption', 'slidesToShow', numVisibleItemsFloor );
 						$items.slick( 'slickSetOption', 'slidesToScroll', numVisibleItemsFloor );


### PR DESCRIPTION
This is a follow-up for https://github.com/siteorigin/so-widgets-bundle/pull/1559 which will prevent it from affecting the Overlay theme for the same reason [it's not required for the Anything Carousel widget](https://github.com/siteorigin/so-widgets-bundle/pull/1573). 

[Test layout](https://drive.google.com/uc?id=1JdOiTWd7bvzyRWkZVem3j0TokEtSaLeI)

To test this confirm the base Post Carousel works as expecteg. Then try navigating to the next set of Post Carousel items for the Overlay theme - test using the arrow navigation rather than dots. You'll notice that the number of items is reduced - regardless of whether it makes sense. Switch to this branch and that won't happen anymore.