### PR TITLE
Editor: Pass All Expected `widget_text` Arguments

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -95,7 +95,7 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 				remove_filter( 'widget_text', 'do_shortcode', $widget_text_do_shortcode_priority );
 			}
 
-			$instance['text'] = apply_filters( 'widget_text', $instance['text'] );
+			$instance['text'] = apply_filters( 'widget_text', $instance['text'], $instance, $this );
 
 			if ( $widget_text_do_shortcode_priority !== false ) {
 				add_filter( 'widget_text', 'do_shortcode', $widget_text_do_shortcode_priority );


### PR DESCRIPTION
This PR should resolve the following type of error:

`Fatal error: Uncaught ArgumentCountError: Too few arguments to function , 1 passed
/home/**/public_html/wp-content/plugins/so-widgets-bundle/widgets/editor/editor.php(98): apply_filters('widget_text', '<p>[jobs]</p>\n')`

I've submitted it to the users for confirmation.

To test this PR simply add any shortcode using the SiteOrigin Editor widget and confirm it works as expected.