### PR TITLE
LiteSpeed Cache Compat: Don't set Purge Header If Headers Already Sent

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -131,7 +131,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			Breeze_PurgeCache::breeze_cache_flush();
 		}
 
-		if ( function_exists( 'run_litespeed_cache' ) ) {
+		if ( function_exists( 'run_litespeed_cache' ) && ! headers_sent() ) {
 			header( 'x-litespeed-purge: *' );
 		}
 	}


### PR DESCRIPTION
This PR will resolve the following warning if [LiteSpeed Cache](https://wordpress.org/plugins/litespeed-cache/) is active and headers have already been sent.

`Warning: Cannot modify header information – headers already sent by (output started at /home/**/public_html/wp-includes/functions.php:5275) in /home/**/public_html/wp-content/plugins/so-widgets-bundle/compat/compat.php on line 135`