### PR TITLE
Carousel: Only Allow Positive Slides to scroll and Slides to show

### DIFF
--- a/base/inc/fields/number.class.php
+++ b/base/inc/fields/number.class.php
@@ -14,7 +14,7 @@ class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_
 	protected $step;
 
 	 /**
-	 * Whether to apply abs() when saving to ensure only positive numbers are possible..
+	 * Whether to apply abs() when saving to ensure only positive numbers are possible.
 	 *
 	 * @access protected
 	 * @var boolean

--- a/base/inc/fields/number.class.php
+++ b/base/inc/fields/number.class.php
@@ -13,6 +13,14 @@ class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_
 	 */
 	protected $step;
 
+	 /**
+	 * Whether to apply abs() when saving to ensure only positive numbers are possible..
+	 *
+	 * @access protected
+	 * @var boolean
+	 */
+	protected $abs;
+
 	protected function get_default_options() {
 		return array(
 			'input_type' => 'number',
@@ -36,6 +44,10 @@ class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
-		return ( $value === '' ) ? false : (float) $value;
+		if ( ! empty( $value ) ) {
+			return ( float ) ( ! empty( $this->abs ) ? abs( $value ) : $value );
+		} else {
+			return false;
+		}
 	}
 }

--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -419,6 +419,9 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 			$variables['mobile_slides_to_show'] = ! empty( $responsive['mobile']['slides_to_show'] ) ? $responsive['mobile']['slides_to_show'] : $carousel_settings['slides_to_show']['mobile'];
 		}
 
+		// Negative values can be problematic so let's avoid them by ensuring everything is positive.
+		$variables = array_map( 'abs', $variables );
+
 		return $encode ? json_encode( $variables ) : $variables;
 	}
 

--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -132,6 +132,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 			$section['fields']['slides_to_scroll'] = array(
 				'type' => 'number',
 				'label' => __( 'Slides to scroll', 'so-widgets-bundle' ),
+				'abs' => true,
 				'description' => sprintf(
 					__( 'Set the number of slides to scroll per navigation click or swipe on %s', 'so-widgets-bundle' ),
 					strtolower( $field['label'] )
@@ -142,6 +143,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 			if ( ! empty( $carousel_settings['slides_to_show'] ) ) {
 				$section['fields']['slides_to_show'] = array(
 					'type' => 'number',
+					'abs' => true,
 					'label' => __( 'Slides to show ', 'so-widgets-bundle' ),
 					'description' => sprintf(
 						__( 'The number of slides to show on %s.', 'so-widgets-bundle' ),

--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -163,7 +163,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 				);
 			}
 
-			if ( isset( $field['navigation_dots'] )  && ! empty( $carousel_settings['navigation_dots_label'] ) ) {
+			if ( isset( $field['navigation_dots'] ) && ! empty( $carousel_settings['navigation_dots_label'] ) ) {
 				$section['fields']['navigation_dots'] = array(
 					'type' => 'checkbox',
 					'label' => $carousel_settings['navigation_dots_label'],
@@ -336,7 +336,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 			unset( $fields['fields']['arrows'] );
 		}
 
-		if ( ! isset( $carousel_settings['navigation_dots'] )  || empty( $carousel_settings['navigation_dots_label'] ) ) {
+		if ( ! isset( $carousel_settings['navigation_dots'] ) || empty( $carousel_settings['navigation_dots_label'] ) ) {
 			unset( $fields['fields']['dots'] );
 		}
 


### PR DESCRIPTION
This PR resolves an issue that occurs if you set negative Slides to scroll or Slides to show value. Basically, the browser hangs. This PR ensures the values can only be positive. For example, `-2` is treated as `2`.