### PR TITLE
Blog: Resolve Error When Loading Posts Using Ajax

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1000,7 +1000,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		<?php endif;
 	}
 
-	public function post_featured_image( $settings, $categories = false, $size = 'full' ) {
+	static public function post_featured_image( $settings, $categories = false, $size = 'full' ) {
 		if ( $settings['featured_image'] && has_post_thumbnail() ) : ?>
 			<div class="sow-entry-thumbnail">
 				<?php if ( $categories && $settings['categories'] && has_category() ) : ?>

--- a/widgets/blog/tpl/alternate.php
+++ b/widgets/blog/tpl/alternate.php
@@ -1,6 +1,6 @@
 <?php $thumbnail_class = ! $settings['featured_image'] || ! has_post_thumbnail() ? 'sow-no-thumbnail' : ''; ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class( "sow-blog-columns $thumbnail_class" ); ?> style="display: flex; flex-wrap: wrap; justify-content: space-between; margin-bottom: 30px;">
-	<?php $this->post_featured_image( $settings ); ?>
+	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper">
 		<header class="sow-entry-header" style="margin-bottom: 18px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/grid.php
+++ b/widgets/blog/tpl/grid.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> style="margin: 0 0 30px;">
-	<?php $this->post_featured_image( $settings ); ?>
+	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/masonry.php
+++ b/widgets/blog/tpl/masonry.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class( 'sow-masonry-item' ); ?>>
-	<?php $this->post_featured_image( $settings, true ); ?>
+	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>

--- a/widgets/blog/tpl/offset.php
+++ b/widgets/blog/tpl/offset.php
@@ -52,7 +52,7 @@
 		<?php endif; ?>
 	</div>
 	<div class="sow-blog-entry" style="width: 78%;">
-		<?php $this->post_featured_image( $settings ); ?>
+		<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
 		<div class="sow-blog-content-wrapper" style="padding: 25px 30px 33px;">
 			<header class="sow-entry-header" style="margin-bottom: 20px;">
 				<?php

--- a/widgets/blog/tpl/standard.php
+++ b/widgets/blog/tpl/standard.php
@@ -1,5 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> style="margin: 0 0 40px">
-	<?php $this->post_featured_image( $settings ); ?>
+	<?php SiteOrigin_Widget_Blog_Widget::post_featured_image( $settings ); ?>
 	<div class="sow-blog-content-wrapper" style="padding: 25px 30px 38px;">
 		<header class="sow-entry-header" style="margin-bottom: 20px;">
 			<?php SiteOrigin_Widget_Blog_Widget::generate_post_title(); ?>


### PR DESCRIPTION
This PR resolves an error that can occur when the Blog widget loads posts using Ajax.

`[22-Sep-2022 16:05:52 UTC] PHP Fatal error:  Uncaught Error: Using $this when not in object context in **\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\widgets\blog\tpl\standard.php:2`