### PR TITLE
Blog: Resolve Potential Incorrect URL When Added Using Widgets Block

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1124,6 +1124,18 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		}
 
 		if ( ! empty( $pagination_markup ) ) {
+			// To resolve a potential issue with the Block Editor, we need to override REST URLs with the actual permalink.
+			if (
+				defined( 'REST_REQUEST' ) &&
+				strpos( $pagination_markup, 'sowb/v1/widgets/previews' ) !== false
+			) {
+				$pagination_markup = str_replace(
+					// All non-standard pagination won't have the full URL present so what we replace changes.
+					strpos( $pagination_markup, rest_url() ) !== false ? esc_url_raw( rest_url() ) . 'sowb/v1/widgets/previews/' : '/wp-json/sowb/v1/widgets/previews',
+					get_the_permalink(),
+					$pagination_markup
+				);
+			}
 			?>
 			<nav class="sow-post-navigation">
 				<h2 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'so-widgets-bundle' ); ?></h2>


### PR DESCRIPTION
This PR prevents a situation where the URL for pagination links will be incorrect for the Blog widget when added using the SiteOrigin Widgets Block. This issue is detectable by navigating using the permalink and getting a 404. The URL will be: https://example.site/**wp-json/sowb/v1/widgets/previews/?**sow-1234=2

To test this PR you'll need to add a Blog widget using the SiteOrgin Widgets Block, and then save. View the page, and confirm the issue is present (doesn't always appear to happen). Switch to this branch, make a change to the block (required so it regenerates) and then save. View the page and it should work as expected. Edit the Blog widget and change the pagination to something other than the standard and confirm that also works.