### PR TITLE
Contact: Add Scroll Top and `siteorigin_widgets_contact_scrollto_offset` filter

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -39,6 +39,18 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			)
 		);
 		add_filter( 'siteorigin_widgets_sanitize_field_multiple_emails', array( $this, 'sanitize_multiple_emails' ) );
+		add_action( 'siteorigin_widgets_enqueue_frontend_scripts_sow-contact-form', array( $this, 'enqueue_widget_scripts' ) );
+	}
+
+	function enqueue_widget_scripts() {
+		$global_settings = $this->get_global_settings();
+		wp_localize_script(
+			'sow-contact',
+			'sowContact',
+			array(
+				'scrollto' => ! empty( $global_settings['scrollto'] ),
+			)
+		);
 	}
 
 	function get_widget_form() {
@@ -983,6 +995,12 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 				'label'       => __( 'Responsive Breakpoint', 'so-widgets-bundle' ),
 				'default'     => '780px',
 				'description' => __( 'This setting controls when the field max width will be disabled. The default value is 780px', 'so-widgets-bundle' ),
+			),
+			'scrollto' => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Scroll top', 'so-widgets-bundle' ),
+				'default'     => true,
+				'description' => __( 'After submission, scroll the user to the top of the contact form.', 'so-widgets-bundle' ),
 			)
 		);
 	}

--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -49,6 +49,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			'sowContact',
 			array(
 				'scrollto' => ! empty( $global_settings['scrollto'] ),
+				'scrollto_offset' => (int) apply_filters( 'siteorigin_widgets_contact_scrollto_offset', 0 ),
 			)
 		);
 	}

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -17,7 +17,7 @@ sowb.SiteOriginContactForm = {
 					if ( $el.is( ':hidden' ) ) {
 						// The form is hidden, so scroll to it's closest visible ancestor.
 						var $container = $el.closest( ':visible' );
-						formPosition = $container.offset().top;
+						formPosition = $container.offset().top + parseInt( scrollto_offset );
 						// If the closest visible ancestor is either SOWB Accordion or Tabs widget, try to open the panel.
 						if ( $container.is( '.sow-accordion-panel' ) ) {
 							$container.find( '> .sow-accordion-panel-header-container > .sow-accordion-panel-header' ).trigger( 'click' );

--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -12,20 +12,22 @@ sowb.SiteOriginContactForm = {
 			var formSubmitSuccess = $el.is( '.sow-contact-form-success' );
 			if ( formSubmitted ) {
 				// The form was submitted. Let's try to scroll to it so the user can see the result.
-				var formPosition = $el.offset().top;
-				if ( $el.is( ':hidden' ) ) {
-					// The form is hidden, so scroll to it's closest visible ancestor.
-					var $container = $el.closest( ':visible' );
-					formPosition = $container.offset().top;
-					// If the closest visible ancestor is either SOWB Accordion or Tabs widget, try to open the panel.
-					if ( $container.is( '.sow-accordion-panel' ) ) {
-						$container.find( '> .sow-accordion-panel-header-container > .sow-accordion-panel-header' ).trigger( 'click' );
-					} else if ( $container.is( '.sow-tabs-panel-container' ) ) {
-						var tabIndex = $el.closest( '.sow-tabs-panel' ).index();
-						$container.siblings( '.sow-tabs-tab-container' ).find( '> .sow-tabs-tab' ).eq( tabIndex ).trigger( 'click' );
+				if ( sowContact.scrollto ) {
+					var formPosition = $el.offset().top;
+					if ( $el.is( ':hidden' ) ) {
+						// The form is hidden, so scroll to it's closest visible ancestor.
+						var $container = $el.closest( ':visible' );
+						formPosition = $container.offset().top;
+						// If the closest visible ancestor is either SOWB Accordion or Tabs widget, try to open the panel.
+						if ( $container.is( '.sow-accordion-panel' ) ) {
+							$container.find( '> .sow-accordion-panel-header-container > .sow-accordion-panel-header' ).trigger( 'click' );
+						} else if ( $container.is( '.sow-tabs-panel-container' ) ) {
+							var tabIndex = $el.closest( '.sow-tabs-panel' ).index();
+							$container.siblings( '.sow-tabs-tab-container' ).find( '> .sow-tabs-tab' ).eq( tabIndex ).trigger( 'click' );
+						}
 					}
+					$( 'html, body' ).scrollTop( formPosition );
 				}
-				$( 'html, body' ).scrollTop( formPosition );
 				
 				if ( formSubmitSuccess ) {
 					// The form was submitted successfully, so we don't need to do anything else.


### PR DESCRIPTION
This PR adds the Scroll Top setting to the contact global settings, which allows users to disable the scroll after submission, and the `siteorigin_widgets_contact_scrollto_offset` filter to control the scroll offset of the scroll. 

You can test `siteorigin_widgets_contact_scrollto_offset` using the following snippet:

```
add_filter( 'siteorigin_widgets_contact_scrollto_offset', function( $offset ) {
	return 200;
} );
```