### PR TITLE
Contact: Prevent Notice Before Edit

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1251,7 +1251,8 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			if ( empty( $field['type'] ) ) {
 				continue;
 			}
-			$field_name = $this->name_from_label( ! empty( $field['label'] ) ? $field['label'] : $i, $field_ids ) . '-' . $instance['_sow_form_id'];
+
+			$field_name = $this->name_from_label( ! empty( $field['label'] ) ? $field['label'] : $i, $field_ids ) . '-' . ( ! empty( $instance['_sow_form_id'] ) ? $instance['_sow_form_id'] : '' );
 			$value      = isset( $post_vars[ $field_name ] ) ? $post_vars[ $field_name ] : '';
 
 			// Can't just use `strlen` here as $value could be an array. E.g. for checkboxes field.


### PR DESCRIPTION
This PR prevents the following notice:

`( ! ) Notice: Undefined index: _sow_form_id in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\widgets\contact\contact.php on line 1273`

This notice occurs if you add a contact form and then save the page without opening the contact. View the page and you'll get the above error message. Opening the widget will generate `_sow_form_id` and that's required to allow for multiple contact forms on the same page without submitting them all at once. We assume this exists because it almost always does outside of this one specific instance. This is more so to account for situations where I user adds a contact form and previews it prior to editing it - likely situation for that would be while using the Live Editor.