### PR TITLE
Blog: Resolve Potential Missing Read More If Non-Latin Characters Present

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1081,7 +1081,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 
 		$length = get_query_var( 'siteorigin_blog_excerpt_length' );
 		$excerpt = get_the_excerpt();
-		$excerpt_add_read_more = str_word_count( $excerpt, 0, '0..9' ) >= $length;
+		$excerpt_add_read_more = count( preg_split( '~[^\p{L}\p{N}\']+~u', $excerpt ) ) >= $length;
 		if ( ! has_excerpt() ) {
 			$excerpt = wp_trim_words(
 				$excerpt,


### PR DESCRIPTION
This PR resolves an issue that can occur for posts with non-Latin characters and without an excerpt.
To replicate this issue, please add some non-Latin characters to the top of a post. Please add enough words to exceed the standard read more (55). Create a page with a blog widget and then view the page. Does the Read More appear for the post with the Latin characters? If not, try switching to this branch.