### PR TITLE
Moved color to .sow-carousel-item-title link

### DIFF
--- a/widgets/post-carousel/styles/base.less
+++ b/widgets/post-carousel/styles/base.less
@@ -91,7 +91,6 @@
 			}
 
 			@{item_title_tag}.sow-carousel-item-title {
-				color: @item_title_color;
 				font-size: @item_title_font_size;
 				font-weight: 500;
 				margin: 10px 0 0 0;
@@ -99,7 +98,7 @@
 
 				a {
 					text-decoration: none;
-					color: inherit;
+					color: @item_title_color;
 				}
 			}
 


### PR DESCRIPTION
@AlexGStapleton This PR aims to resolve the potential situation where a theme has a rule in place, such as:

```
.site-content a { color: yellow; }
```

The above rule will beat the existing rule, which uses `inherit`. 

```
h3.sow-carousel-item-title a { color: inherit; }
```