### PR TITLE
Introduce Widget Validation: `sowbForms.validateFields` & `sow_validate_widget_data` Event

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -188,11 +188,17 @@ jQuery( function( $ ){
 
 	dialog.find( '.so-save' ).on( 'click', function( e ) {
 		e.preventDefault();
+		var $form = dialog.find( 'form' );
+
+		validSave = sowbForms.setupRequiredFields( $form )
+		if ( typeof validSave == 'boolean' && ! validSave ) {
+			return false;
+		}
 
 		var $$ = $( this );
 		$$.prop( 'disabled', true );
 
-		dialog.find( 'form' ).on( 'submit', function() {
+		$form.on( 'submit', function() {
 			$$.prop( 'disabled', false );
 			dialog.hide();
 		} ).trigger( 'submit' );

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -103,6 +103,14 @@ div.siteorigin-widget-form {
 				color: #F02311;
 				font-style: italic;
 			}
+
+			.siteorigin-widget-input {
+				transition: 300ms ease-in-out border-color;
+
+				&.sow-required-error {
+					border-color: #F02311;
+				}
+			}
 		}
 
 		input[type="text"] {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -70,6 +70,7 @@
 		edit: withState( {
 			editing: false,
 			formInitialized: false,
+			validationSetup: false,
 			previewInitialized: false,
 			widgetFormHtml: '',
 			widgetSettingsChanged: false,
@@ -133,6 +134,15 @@
 
 			function setupWidgetForm( formContainer ) {
 				var $mainForm = jQuery( formContainer ).find( '.siteorigin-widget-form-main' );
+
+				if ( props.formInitialized && ! validationSetup ) {
+					props.setState( { validationSetup: true } );
+					sowbForms.validateFields( jQuery( formContainer ) )
+					$mainForm.find( '.siteorigin-widget-field-is-required input' ).on( 'change', function() {
+						sowbForms.validateFields( jQuery( formContainer ) )
+					} );
+				}
+
 				if ( $mainForm.length > 0 && ! props.formInitialized ) {
 					var $previewContainer = $mainForm.siblings('.siteorigin-widget-preview');
 					$previewContainer.find( '> a' ).on( 'click', function ( event ) {


### PR DESCRIPTION
This PR allows for widget validation. It also introduces the `sow_validate_widget_data` event to allow other developers to validate things. It also introduces `required` support. You can set any field to required by setting `required` to `true`. Currently missing required fields are only communicated using a red border of the field but we could potentially introduce a notification similar to the data mismatch prompt we have for widgets.

![Screenshot 2022-10-12 at 16-51-46 Edit Page ‹ SO — WordPress](https://user-images.githubusercontent.com/17275120/195245951-0e8b07b2-6eef-4615-93f1-d01fde8f314b.png)

You can test this PR by adding the following [on the line after this](https://github.com/siteorigin/so-widgets-bundle/blob/1.42.2/widgets/button/button.php#L57):

`'required' => true,
`
Please test the required functionality in the following contexts:

- SiteOrigin Page Builder (the Classic Editor, Layout Builder and SiteOrigin Layouts Block. (requires https://github.com/siteorigin/siteorigin-panels/pull/1007)
- Legacy Widgets Page & new Widgets page.
- SiteOrigin Widgets Block.
- Customizer.
- SiteOrigin Widgets Settings.

You can test the `sow_validate_widget_data` event using the following snippet:

```
jQuery( document ).on('sow_validate_widget_data', function( e, valid, form, id ) {
	if ( id == 'sow-button' ) {
		var values = sowbForms.getWidgetFormValues( form );
		if ( ! values.url.length ) {
			form.find( '[name*="url"]' ).val( 'https://siteorigin.com/' );
		}
	}

	return valid;
} );
```
This JavaScript will:
- Confirm the widget is the SiteOrigin Button widget.
- If a URL isn't set, set it to https://siteorigin.com.