### PR TITLE
Anything Carousel: Don't Clear Cloned IDs

### DIFF
--- a/js/lib/slick.js
+++ b/js/lib/slick.js
@@ -2424,9 +2424,6 @@
                         .attr('data-slick-index', slideIndex + _.slideCount)
                         .appendTo(_.$slideTrack).addClass('slick-cloned');
                 }
-                _.$slideTrack.find('.slick-cloned').find('[id]').each(function() {
-                    $(this).attr('id', '');
-                });
 
             }
 


### PR DESCRIPTION
This PR will resolve a display issue when adding Layout Builder items. To replicate it:

- Add an item that has a Layout Builder content type.
- Open it and add two Editor widgets. Apply 40px of margin to the first widget (or really, any Widget Style).
- Duplicate that item 6 times.
- Open the Carousel Settings and tick Loop Items.

When you scroll through the items. Item 5 & 6 will have the correct spacing while the cloned slides (the last two) won't.