### PR TITLE
Carousel: Don't Autoplay in Block Editor Preview

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -94,19 +94,22 @@ jQuery( function ( $ ) {
 			if ( carouselSettings.autoplay ) {
 				var interrupted = false;
 				var autoplayNav = $$.parent().parent().find( '.sow-carousel-' + ( $$.data( 'dir' ) == 'ltr' ? 'next' : 'prev' ) );
-				setInterval( function() {
-					if ( ! interrupted ) {
-						autoplayNav.trigger( 'click' );
-					}
-				}, carouselSettings.autoplaySpeed );
+				// Check if this is a Block Editor preview, and if it is, don't autoplay.
+				if ( ! $( 'body' ).hasClass( 'block-editor-page' ) ) {
+					setInterval( function() {
+						if ( ! interrupted ) {
+							autoplayNav.trigger( 'click' );
+						}
+					}, carouselSettings.autoplaySpeed );
 
-				if ( carouselSettings.pauseOnHover ) {
-					$items.on('mouseenter.slick', function() {
-						 interrupted = true;
-					} );
-					$items.on( 'mouseleave.slick', function() {
-						 interrupted = false;
-					} );
+					if ( carouselSettings.pauseOnHover ) {
+						$items.on('mouseenter.slick', function() {
+							 interrupted = true;
+						} );
+						$items.on( 'mouseleave.slick', function() {
+							 interrupted = false;
+						} );
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR resolves an issue in the Block Editor if an Anything Carousel set to autoplay is present and the user tries to adjust a row/cell/widget color. 

[Test Layout](https://gist.githubusercontent.com/AlexGStapleton/b5a4dd547b7d8a5be5d139a9d85ad218/raw/b25b09d080fb47e4ec02930a0cd985dcd9b0d5a3/63659-test.html)