### PR TITLE
`html` Form Field

### DIFF
--- a/base/inc/fields/html.class.php
+++ b/base/inc/fields/html.class.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Class SiteOrigin_Widget_Field_Html
+ */
+class SiteOrigin_Widget_Field_Html extends SiteOrigin_Widget_Field_Base {
+	/**
+	 * The markup of this field.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $markup;
+
+	protected function render_field( $value, $instance ) {
+		if ( empty( $this->markup ) ) return;
+		?>
+		<div class="siteorigin-widget-html-field">
+			<?php echo wp_kses_post( $this->markup ); ?>
+		</div>
+		<?php
+	}
+
+	protected function sanitize_field_input( $value, $instance ) {
+		return;
+	}	
+}

--- a/base/inc/fields/html.class.php
+++ b/base/inc/fields/html.class.php
@@ -23,5 +23,5 @@ class SiteOrigin_Widget_Field_Html extends SiteOrigin_Widget_Field_Base {
 
 	protected function sanitize_field_input( $value, $instance ) {
 		return;
-	}	
+	}
 }


### PR DESCRIPTION
To test this PR, add the following to any WB `form_options`:

```
'html' => array(
	'type' => 'html',
	'label' => __( 'HTML Example', 'so-widgets-bundle' ),
	'markup' => '<p>This is an example. <hr> Another <em>example</em></p>', // Intentionally not using __.
),
```