### PR TITLE
Masonry: If Preloader Is Active, Don't Add Loading Attr to Images

### DIFF
--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -53,6 +53,7 @@
 					array(
 						'title' => esc_attr( $title ),
 						'class' => 'sow-masonry-grid-image',
+						'loading' => $preloader_enabled ? false : wp_get_loading_attr_default( 'the_content' )
 					)
 				);
 				?>


### PR DESCRIPTION
We don't want to lazy load these images. We want them to be loaded asap. One user reported an issue with the preloader never disappearing until scrolling all the way to the bottom of the widget (they had at least 40 to 50 images) but I haven't been able to replicate that on a test site (won't be replicable on a local install).