### PR TITLE
Image Size: Show Description After Field

### DIFF
--- a/base/inc/fields/image-size.class.php
+++ b/base/inc/fields/image-size.class.php
@@ -82,7 +82,7 @@ class SiteOrigin_Widget_Field_Image_Size extends SiteOrigin_Widget_Field_Select 
 			<?php
 		}
 		
-		parent::render_after_field( $value, $instance )
+		parent::render_after_field( $value, $instance );
 	}
 
 	public function get_custom_size_setting_prefix( $base_name ) {


### PR DESCRIPTION
This PR will allow the Image Size field to show descriptions. You can test this PR by [modifying the Post Carousel Image Size field](https://github.com/siteorigin/so-widgets-bundle/blob/60eea044a74f73cde5077d03dc666ac5120311d1/widgets/post-carousel/post-carousel.php#L281-L285) to have a description. Prior to this PR, it won't display. After this PR it will.