### PR TITLE
Color: Allow Custom Palettes and No Palette At All

### DIFF
--- a/base/inc/fields/color.class.php
+++ b/base/inc/fields/color.class.php
@@ -5,6 +5,15 @@
  */
 class SiteOrigin_Widget_Field_Color extends SiteOrigin_Widget_Field_Text_Input_Base {
 
+	/**
+	 * An optional array containing the color hexes to be used as the palette. 
+	 * If set to false, no color palettes will be output.
+	 *
+	 * @access protected
+	 * @var array|bool
+	 */
+	protected $palettes;
+
 	protected function get_input_classes() {
 		$input_classes = parent::get_input_classes();
 		$input_classes[] = 'siteorigin-widget-input-color';
@@ -16,6 +25,19 @@ class SiteOrigin_Widget_Field_Color extends SiteOrigin_Widget_Field_Text_Input_B
 		if ( ! empty( $this->default ) ) {
 			$data_attributes['default-color'] = $this->default;
 		}
+
+		if ( isset( $this->palettes ) ) {
+			if ( ! empty( $this->palettes ) && is_array( $this->palettes ) ) {
+				$valid_palette = array();
+				$valid_palette = array_filter( $this->palettes, 'sanitize_hex_color' );
+				if ( ! empty( $valid_palette ) ) {
+					$data_attributes['palettes'] = wp_json_encode( $valid_palette );
+				}
+			} else {
+				$data_attributes['palettes'] = $this->palettes;
+			}
+		}
+
 		return $data_attributes;
 	}
 

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -277,6 +277,11 @@ var sowbForms = window.sowbForms || {};
 				if (colorField.data('defaultColor')) {
 					colorFieldOptions.defaultColor = colorField.data('defaultColor');
 				}
+
+				if ( colorField.data( 'palettes' ) ) {
+					colorFieldOptions.palettes = colorField.data( 'palettes' );
+				}
+
 				colorField.wpColorPicker(colorFieldOptions);
 			});
 


### PR DESCRIPTION
This PR introduces an optional parameter to the colour form field called Palettes. This parameter allows for two things:

- If set to false, it disables the color palette.
- If it contains a valid array, it'll use the provided array instead of the default color palette.

Below there are some parameter usage, you can try. I recommend trying it by modifying the Icon widget's color field. As an example of how to do this, [this](https://github.com/siteorigin/so-widgets-bundle/blob/1.43.0/widgets/icon/icon.php#L34-L37) becomes:

```
'color' => array(
	'type'  => 'color',
	'label' => __( 'Color', 'so-widgets-bundle' ),
	'palettes' => array( // Custom palette will be used.
		// Values here
	),
),
```

The following contains a valid custom palette with one invalid item that won't appear.

```
'palettes' => array( // Custom palette will be used.
	'#f00',
	'#0f0',
	'#00f',
	'aa', // This shouldn't appear.
),
```

Setting palettes to false will result in the palettes being removed.

`'palettes' => false, // No palettes be present.`

An array containing no valid options will result in the default palettes being used.
```
'palettes' => array(
	'aa', // Invalid - default palettes should apear.
),
```