### PR TITLE
Blog: Allow Excerpt Length to Be Set to 0, and Hide Indicator If It Is

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1076,7 +1076,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	}
 
 	function alter_excerpt_more_indicator( $indicator ) {
-		return apply_filters( 'siteorigin_widgets_blog_excerpt_trim', '...' );
+		return apply_filters( 'siteorigin_widgets_blog_excerpt_trim', get_query_var( 'siteorigin_blog_excerpt_length' ) == 0 ? '' : '...' );
 	}
 
 	function alter_excerpt_length( $length = 55 ) {

--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1061,7 +1061,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		if ( $setup ) {
 			set_query_var(
 				'siteorigin_blog_excerpt_length',
-				apply_filters( 'siteorigin_widgets_blog_excerpt_length', ! empty( $settings['excerpt_length'] ) ? $settings['excerpt_length'] : 55 )
+				apply_filters( 'siteorigin_widgets_blog_excerpt_length', isset( $settings['excerpt_length'] ) ? $settings['excerpt_length'] : 55 )
 			);
 			add_filter( 'excerpt_length', array( $this, 'alter_excerpt_length' ), 1000 );
 			add_filter( 'excerpt_more', array( $this, 'alter_excerpt_more_indicator' ) );


### PR DESCRIPTION
Prior to this PR it wasn't possible to set the Excerpt Length to 0 without using a filter and even if you did, you would have to remove the Indicator using an additional filter. This PR allows Excerpt Length to be set to 0 and removes the Indicator.