### PR TITLE
Simple Image Masonry: Use Pure CSS (`object-fit`) for Sizing Images & Resolve Image Title Sizing Issue

### DIFF
--- a/widgets/simple-masonry/js/simple-masonry.js
+++ b/widgets/simple-masonry/js/simple-masonry.js
@@ -53,25 +53,7 @@ jQuery( function ( $ ) {
 							}
 						}
 
-						var imgAR = $img.height() > 0 ? $img.width() / $img.height() : 1;
-						var itemAR = $$.height() > 0 ? $$.width() / $$.height() : 1;
-						imgAR = parseFloat( imgAR.toFixed( 3 ) );
-						itemAR = parseFloat( itemAR.toFixed( 3 ) );
-						if ( imgAR > itemAR ) {
-							$img.css( 'width', 'auto' );
-							if ( ! heightSet ) {
-								$img.css( 'height', '100%' );
-							}
-							$img.css( 'margin-top', '' );
-							var marginLeft = ( $img.width() - $$.width() ) * -0.5;
-							$img.css( 'margin-left', marginLeft + 'px' );
-						} else {
-							$img.css( 'height', 'auto' );
-							$img.css( 'width', '100%' );
-							$img.css( 'margin-left', '' );
-							var marginTop = ( $img.height() - $$.height() ) * -0.5;
-							$img.css( 'margin-top', marginTop + 'px' );
-						}
+						$img.css( 'height', heightSet ? $$.height() - title_height : $$.height() + 'px' );
 					} );
 
 					$gridEl.packery( {

--- a/widgets/simple-masonry/styles/default.less
+++ b/widgets/simple-masonry/styles/default.less
@@ -15,6 +15,8 @@
 	img {
 		display: block;
 		max-width: inherit;
+		object-fit: cover;
+		width: 100%;
 	}
 
 	.image-title {


### PR DESCRIPTION
This PR moves away from using JavaScript to size the image dimensions and uses pure CSS instead. [object-fit](https://caniuse.com/#search=object-fit) is widely supported at this point with 98.63% global support so it's very safe to use. This change should reduce the potential for future CLS flagging due to measurement changes, make the widget lighter weight overall (fewer repaints), and it also resolves a sizing issue when titles are used.