### PR TITLE
State Emitters: Pass field to Callback

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -491,7 +491,14 @@ var sowbForms = window.sowbForms || {};
 						}
 
 						// Return an array that has the new states added to the array
-						return $.extend(currentStates, sowEmitters[emitter.callback](val, emitter.args));
+						return $.extend(
+							currentStates,
+							sowEmitters[ emitter.callback ] (
+								val,
+								emitter.args,
+								$$
+							)
+						);
 					};
 
 					// Run the states through the state emitters


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/1569
Documented https://github.com/siteorigin/docs/pull/135

This PR allows custom state emitters to detect the field that triggered the emitter. To test this PR, change [this line](https://github.com/siteorigin/so-widgets-bundle/blob/1.44.0/widgets/button/button.php#L173) to:

`'callback' => 'custom',`

Add a SiteOrigin Button widget to a page. Add the following JS to your browser console prior to opening the Button widget:

```
sowEmitters.custom = function( val, args, field ){
	var returnStates = {};
	console.log( val );
	console.log( field );

	return returnStates;
},
```

Open the Button widget and then tick the Use Hover Effects checkbox. You'll see the field being output to the console.