### PR TITLE
Icon Field: Resolve jQuery Migrate Flag

### DIFF
--- a/base/inc/fields/js/icon-field.js
+++ b/base/inc/fields/js/icon-field.js
@@ -60,7 +60,7 @@
 			}
 		};
 
-		$search.keyup( searchIcons ).on( 'change', searchIcons );
+		$search.on( 'keyup change', searchIcons );
 		
 		var renderStylesSelect = function ( init ) {
 			var $familySelect = $is.find( 'select.siteorigin-widget-icon-family' );


### PR DESCRIPTION
This PR resolves a jQuery migrate notice due to the usage of `keyup`. This notice was present in the browser console when a widget included the Icon form field. 

`jQuery.fn.key event shorthand is deprecated`