### PR TITLE
Slider: Don't Set Up Modern Parallax On Mobile If Disabled

### DIFF
--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -165,7 +165,16 @@ jQuery( function($){
 				}
 
 				var slidesWithModernParallax = $$.find( '.sow-slider-image-parallax:not([data-siteorigin-parallax]) ' );
-				if ( slidesWithModernParallax.length ) {
+				var waitForParallax = false;
+				if (
+					slidesWithModernParallax.length &&
+					typeof parallaxStyles != 'undefined' &&
+					(
+						! parallaxStyles['disable-parallax-mobile'] ||
+						! window.matchMedia( '(max-width: ' + parallaxStyles['mobile-breakpoint'] + ')' ).matches
+					)
+				) {
+					waitForParallax = true;
 					// Allow slider to be size itself while preventing visual "jump" in modern parallax.
 					$base.css( 'opacity', 0 );
 				}
@@ -183,7 +192,7 @@ jQuery( function($){
 				$( window ).on('resize panelsStretchRows', resizeFrames ).trigger( 'resize' );
 				$(sowb).on('setup_widgets', resizeFrames );
 
-				if ( slidesWithModernParallax.length ) {
+				if ( waitForParallax ) {
 					// Wait for the parallax to finish setting up before
 					// setting up the rest of the slider.
 					if ( ! slidesWithModernParallax.find( '.simpleParallax' ).length ) {


### PR DESCRIPTION
This PR will prevent the modern parallax from being set up for sliders if it's disabled on mobile. The best way to test this is to add a slider, set it to parallax and then save. View the page. Navigate to **Settings > Page Builder**, open the **Content** tab and disable the parallax on mobile. Confirm the slider doesn't try to display as Parallax on mobile - you can easily confirm this by looking for the simple parallax div in the slide content.