### PR TITLE
Blog: Add `siteorigin_widgets_blog_featured_image_markup` filter

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1013,6 +1013,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 
 	static public function post_featured_image( $settings, $categories = false, $size = 'full' ) {
 		if ( $settings['featured_image'] && has_post_thumbnail() ) : ?>
+			<?php ob_start(); ?>
 			<div class="sow-entry-thumbnail">
 				<?php if ( $categories && $settings['categories'] && has_category() ) : ?>
 					<div class="sow-thumbnail-meta">
@@ -1037,6 +1038,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 				</a>
 			</div>
 			<?php
+			echo apply_filters( 'siteorigin_widgets_blog_featured_image_markup', ob_get_clean(), $settings, $categories = false, $size = 'full' );
 		endif;
 	}
 


### PR DESCRIPTION
This PR introduces a new filter that allows you to override the featured image markup of the Blog widget. This is useful when users need to nest the featured image or override the image itself with something else.

Here's an intentionally very basic test snippet that simply overrides the featured image with markup with just the featured image. This is used to demonstrate the override rather than something more useful.

```
add_filter( 'siteorigin_widgets_blog_featured_image_markup', function( $markup, $settings, $categories, $size ) {
	return the_post_thumbnail( $size );
}, 10, 4 );
```