### PR TITLE
PHP 8.1 Form Field Deprecated Fixes

### DIFF
--- a/base/inc/fields/date-range.class.php
+++ b/base/inc/fields/date-range.class.php
@@ -36,10 +36,12 @@ class SiteOrigin_Widget_Field_Date_Range extends SiteOrigin_Widget_Field_Base {
 	}
 
 	private function render_relative_date_selector( $value ) {
-		$value = json_decode(
-			$value,
-			true
-		);
+		if ( ! empty( $value ) ) {
+			$value = json_decode(
+				$value,
+				true
+			);
+		}
 
 		$from = ! empty( $value['from'] ) ? $value['from'] : array();
 		$this->render_relative_date_selector_part( 'from', __( 'From', 'so-widgets-bundle' ), $from );

--- a/base/inc/fields/measurement.class.php
+++ b/base/inc/fields/measurement.class.php
@@ -34,11 +34,13 @@ class SiteOrigin_Widget_Field_Measurement extends SiteOrigin_Widget_Field_Text_I
 	 * @return array
 	 */
 	protected function get_render_values( $value ) {
-		preg_match('/(\d+\.?\d*)([a-z%]+)*/', $value, $matches);
-		$num_matches = count( $matches );
+		if ( ! empty( $vlaue ) ) {
+			preg_match('/(\d+\.?\d*)([a-z%]+)*/', $value, $matches);
+			$num_matches = count( $matches );
+		}
 		$val = array();
-		$val['value'] = $num_matches > 1 ? $matches[1] : null;
-		$val['unit'] = $num_matches > 2 ? $matches[2] : null;
+		$val['value'] = ! empty( $num_matches ) && $num_matches > 1 ? $matches[1] : null;
+		$val['unit'] = ! empty( $num_matches ) && $num_matches > 2 ? $matches[2] : null;
 		return $val;
 	}
 

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -425,7 +425,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		
 		$value = apply_filters( 'the_editor_content', $value, $this->selected_editor );
 		
-		if ( false !== stripos( $value, 'textarea' ) ) {
+		if ( ! empty( $value ) && stripos( $value, 'textarea' ) !== false ) {
 			$value = preg_replace( '%</textarea%i', '&lt;/textarea', $value );
 		}
 
@@ -451,7 +451,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			<?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
 			<?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
 			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
-			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo htmlentities( $value, ENT_QUOTES, 'UTF-8' ) ?></textarea>
+			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo ! empty( $value ) ? htmlentities( $value, ENT_QUOTES, 'UTF-8' ) : ''; ?></textarea>
 		</div>
 		<input type="hidden"
 		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -250,14 +250,14 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 	
 	function add_wpc_shortcodes_plugin( $plugins ) {
 		if( ! isset( $plugins['wpc_shortcodes'] ) ) {
-			$shortcodes_path     = 'wc-shortcodes/includes/mce/js/shortcodes-tinymce-4.js';
+			$shortcodes_path = 'wc-shortcodes/includes/mce/js/shortcodes-tinymce-4.js';
 			if ( file_exists( WP_PLUGIN_DIR . '/' . $shortcodes_path ) ) {
 				$plugins['wpc_shortcodes'] = plugins_url( $shortcodes_path . '?ver=' . WC_SHORTCODES_VERSION );
 			}
 		}
 		
 		if( ! isset( $plugins['wpc_font_awesome'] ) ) {
-			$fontawesome_path     = 'wc-shortcodes/includes/mce/js/font-awesome-tinymce-4.js';
+			$fontawesome_path = 'wc-shortcodes/includes/mce/js/font-awesome-tinymce-4.js';
 			if ( file_exists( WP_PLUGIN_DIR . '/' . $fontawesome_path ) ) {
 				$plugins['wpc_font_awesome'] = plugins_url( $fontawesome_path . '?ver=' . WC_SHORTCODES_VERSION );
 			}
@@ -351,9 +351,9 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			
 			$tmce_settings = array(
 				'toolbar1' => apply_filters( 'mce_buttons', $this->mce_buttons, $this->element_id ),
-				'toolbar2' => apply_filters( 'mce_buttons_2', $this->mce_buttons_2, $this->element_id  ),
-				'toolbar3' => apply_filters( 'mce_buttons_3',$this->mce_buttons_3, $this->element_id  ),
-				'toolbar4' => apply_filters( 'mce_buttons_4',$this->mce_buttons_4, $this->element_id  ),
+				'toolbar2' => apply_filters( 'mce_buttons_2', $this->mce_buttons_2, $this->element_id ),
+				'toolbar3' => apply_filters( 'mce_buttons_3', $this->mce_buttons_3, $this->element_id ),
+				'toolbar4' => apply_filters( 'mce_buttons_4', $this->mce_buttons_4, $this->element_id ),
 				'plugins' => ! empty( $tiny_mce_plugins ) && is_array( $tiny_mce_plugins ) ? array_unique( $tiny_mce_plugins ) : array(),
 			);
 			
@@ -398,7 +398,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 				unset( $jdec );
 				if ( ! empty( $tmce_settings[ $name ] ) ) {
 					// Attempt to decode setting as JSON. For back compat with filters used by WP editor.
-					if ( is_string( $setting )  ) {
+					if ( is_string( $setting ) ) {
 						$jdec = json_decode( $setting, true );
 					}
 					$settings['tinymce'][ $name ] = empty( $jdec ) ? $setting : $jdec;
@@ -436,27 +436,33 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		$settings['baseURL'] = includes_url( 'js/tinymce' );
 		$settings['suffix'] = SCRIPT_DEBUG ? '' : '.min';
 		
-		?><div class="siteorigin-widget-tinymce-container"
+		?>
+		<div
+			class="siteorigin-widget-tinymce-container"
 			<?php if ( $this->media_buttons && ! empty( $media_buttons_html ) ) : ?>
-			   data-media-buttons="<?php echo esc_attr( json_encode( array( 'html' => $media_buttons_html ) ) ) ?>"
+				data-media-buttons="<?php echo esc_attr( json_encode( array( 'html' => $media_buttons_html ) ) ); ?>"
 			<?php endif; ?>
-			   data-editor-settings="<?php echo esc_attr( json_encode( $settings ) ) ?>">
-		<textarea id="<?php echo esc_attr( $this->element_id ) ?>"
-		          name="<?php echo esc_attr( $this->element_name ) ?>"
+			data-editor-settings="<?php echo esc_attr( json_encode( $settings ) ); ?>"
+		>
+		<textarea
+			id="<?php echo esc_attr( $this->element_id ); ?>"
+			name="<?php echo esc_attr( $this->element_name ); ?>"
 			<?php if ( isset( $this->editor_height ) ) : ?>
 				style="height: <?php echo (int) $this->editor_height; ?>px"
 			<?php else : ?>
-				rows="<?php echo esc_attr( $this->rows ) ?>"
+				rows="<?php echo esc_attr( $this->rows ); ?>"
 			<?php endif; ?>
-			<?php $this->render_data_attributes( $this->get_input_data_attributes() ) ?>
-			<?php $this->render_CSS_classes( $this->get_input_classes() ) ?>
-			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"' ?>
+			<?php $this->render_data_attributes( $this->get_input_data_attributes() ); ?>
+			<?php $this->render_CSS_classes( $this->get_input_classes() ); ?>
+			<?php if ( ! empty( $this->placeholder ) ) echo 'placeholder="' . esc_attr( $this->placeholder ) . '"'; ?>
 			<?php if( ! empty( $this->readonly ) ) echo 'readonly' ?>><?php echo ! empty( $value ) ? htmlentities( $value, ENT_QUOTES, 'UTF-8' ) : ''; ?></textarea>
 		</div>
-		<input type="hidden"
-		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"
-		       class="siteorigin-widget-input siteorigin-widget-tinymce-selected-editor"
-		       value="<?php echo esc_attr( $this->selected_editor ) ?>"/>
+		<input
+			type="hidden"
+			name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container ) ); ?>"
+			class="siteorigin-widget-input siteorigin-widget-tinymce-selected-editor"
+			value="<?php echo esc_attr( $this->selected_editor ); ?>"
+		/>
 		<?php
 		
 	}
@@ -477,19 +483,22 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		preg_match( '/widget-(.+?)\[/', $this->element_name, $id_base_matches );
 		$widget_id_base = empty($id_base_matches) || count($id_base_matches) < 2 ? '' : $id_base_matches[1];
 		?>
-		<div class="siteorigin-widget-tinymce-container"
-		     data-mce-settings="<?php echo esc_attr( json_encode( $settings['tinymce'] ) ) ?>"
-		     data-qt-settings="<?php echo esc_attr( json_encode( array() ) ) ?>"
-		     data-widget-id-base="<?php echo esc_attr( $widget_id_base ) ?>"
+		<div
+			class="siteorigin-widget-tinymce-container"
+			data-mce-settings="<?php echo esc_attr( json_encode( $settings['tinymce'] ) ); ?>"
+			data-qt-settings="<?php echo esc_attr( json_encode( array() ) ); ?>"
+			data-widget-id-base="<?php echo esc_attr( $widget_id_base ); ?>"
 		>
 			<?php
-			wp_editor( $value, esc_attr( $this->element_id ), $settings )
+			wp_editor( $value, esc_attr( $this->element_id ), $settings );
 			?>
 		</div>
-		<input type="hidden"
-		       name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container) ) ?>"
-		       class="siteorigin-widget-input siteorigin-widget-tinymce-selected-editor"
-		       value="<?php echo esc_attr( $this->selected_editor ) ?>"/>
+		<input
+			type="hidden"
+			name="<?php echo esc_attr( $this->for_widget->so_get_field_name( $this->base_name . '_selected_editor', $this->parent_container ) ); ?>"
+			class="siteorigin-widget-input siteorigin-widget-tinymce-selected-editor"
+			value="<?php echo esc_attr( $this->selected_editor ) ?>"
+		/>
 		<?php
 		
 		if( $this->selected_editor == 'html' ) {


### PR DESCRIPTION
This PR resolves the following PHP 8.1 notices:

Date Range:
`PHP Deprecated:  json_decode(): Passing null to parameter https://github.com/siteorigin/so-widgets-bundle/issues/1 ($json) of type string is deprecated in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\base\inc\fields\date-range.class.php on line 41`

TinyMCE:
`PHP Deprecated:  stripos(): Passing null to parameter https://github.com/siteorigin/so-widgets-bundle/issues/1 ($haystack) of type string is deprecated in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\base\inc\fields\tinymce.class.php on line 428
PHP Deprecated:  htmlentities(): Passing null to parameter https://github.com/siteorigin/so-widgets-bundle/issues/1 ($string) of type string is deprecated in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\base\inc\fields\tinymce.class.php on line 454`

Measurement
`PHP Deprecated:  preg_match(): Passing null to parameter https://github.com/siteorigin/so-widgets-bundle/pull/2 ($subject) of type string is deprecated in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\base\inc\fields\measurement.class.php on line 37`

You can verify this PR has helped by loading Page Builder in the Classic Editor while Widgets Bundle is enabled.