### PR TITLE
SO Widgets Block: Only Ever Use New Widgets Block on Widgets Page

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -8,7 +8,7 @@
 	var Toolbar = components.Toolbar;
 	var ToolbarButton = components.ToolbarButton;
 	var Placeholder = components.Placeholder;
-	var Spinner  = components.Spinner;
+	var Spinner = components.Spinner;
 	var __ = i18n.__;
 
 	var getAjaxErrorMsg = function( response ) {
@@ -337,7 +337,7 @@ if ( typeof wp.data.select == 'function' ) {
 		if ( ! sowbTimeoutSetup ) {
 			var setupTimer = false;
 
-			if ( typeof wp.data.select( 'core/edit-widgets' ) == 'object' ) {
+			if ( adminpage == 'widgets-php' && typeof wp.data.select( 'core/edit-widgets' ) == 'object' ) {
 				// New Widget Area.
 				if ( wp.data.select( 'core/edit-widgets' ).isSavingWidgetAreas() ) {
 					setupTimer = true;
@@ -354,11 +354,13 @@ if ( typeof wp.data.select == 'function' ) {
 				sowbTimeoutSetup = true;
 				var saveCheck = setInterval( function() {
 					var checkPass = false;
-					if ( typeof wp.data.select( 'core/edit-widgets' ) == 'object' ) {
+					if (
+						adminpage == 'widgets-php' && 
+						typeof wp.data.select( 'core/edit-widgets' ) == 'object' ) {
 						if ( ! wp.data.select( 'core/edit-widgets' ).isSavingWidgetAreas() ) {
 							checkPass = true;
 						}
-					} else if (
+					} else if ( 
 						typeof wp.data.select( 'core/editor' ) == 'object' &&
 						! wp.data.select( 'core/editor' ).isSavingPost() &&
 						! wp.data.select( 'core/editor' ).isAutosavingPost() &&
@@ -371,7 +373,10 @@ if ( typeof wp.data.select == 'function' ) {
 						clearInterval( saveCheck );
 
 						var showPrompt = true;
-						if ( typeof wp.data.select( 'core/edit-widgets' ) == 'object' ) {
+						if (
+							adminpage == 'widgets-php' && 
+							typeof wp.data.select( 'core/edit-widgets' ) == 'object'
+						) {
 							// New Widget Area.
 							var $widgets = jQuery( '.wp-block-widget-area .components-panel__body.is-opened .siteorigin-widget-form-main-siteorigin-widget-button-widget' );
 							jQuery.each( $widgets , function() {


### PR DESCRIPTION
[Reported here](Uncaught TypeError: Cannot read properties of null (reading ‘isSavingWidgetAreas’))

This PR will prevent the SiteOrigin Widgets Block from ever using the New Widgets Area code unless it's specifically on the widget area page. This will prevent the following error:

`Uncaught TypeError: Cannot read properties of null (reading ‘isSavingWidgetAreas’)`

This error is caused by a third-party plugin loading the new widget area code inside of the standard block editor. Testing should be done on a site that has reported this issue.