### PR TITLE
Contact scrollto adjustments

### DIFF
--- a/widgets/contact/js/contact.js
+++ b/widgets/contact/js/contact.js
@@ -61,17 +61,6 @@ sowb.SiteOriginContactForm = {
 			// Disable the submit button on click to avoid multiple submits.
 			$contactForms.on( 'submit', function() {
 				$submitButton.prop( 'disabled', true );
-				// Preserve existing anchors, if any.
-				var locationHash = window.location.hash;
-				if ( locationHash ) {
-					var formAction = $( this ).attr( 'action' );
-					
-					if ( locationHash.indexOf( formId ) > -1 ) {
-						var re = new RegExp( formId + ',?', 'g' );
-						locationHash = locationHash.replace( re, '' );
-					}
-					$( this ).attr( 'action', formAction + ',' + locationHash.replace( /^#/, '' ) );
-				}
 
 				if ( $submitButton.data( 'js-key' ) ) {
 					var js_key = $submitButton.data( 'js-key' );

--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -23,7 +23,7 @@ if ( $result['status'] == 'success' ) {
 	$global_settings = $this->get_global_settings();
 	?>
 	<form
-		action="<?php echo add_query_arg( null, null ); ?>"
+		action="<?php echo esc_urL( add_query_arg( null, null ) ); ?>"
 		method="POST"
 		class="sow-contact-form<?php echo ! empty( $global_settings['scrollto'] ) && ! empty( $result ) ? ' sow-contact-submitted' : ''; ?>"
 		id="contact-form-<?php echo esc_attr( $short_hash ); ?>"


### PR DESCRIPTION
This PR escapes the contact form action, and it prevents a potential issue where an anchor is added to the URL would cause issues.

To test the latter, open any page with a contact form and append the following to a URL:

`#test`

Submit the form and you'll notice that the page will redirect to a 404. This PR will fix this by not retaining the page jump on submission. While we could retain it, it would interfere with the contact form and that's less than ideal.