### PR TITLE
Customizer New Widget Area TypeError Fix

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1622,11 +1622,14 @@ var sowbForms = window.sowbForms || {};
 
 	// Validate widget added using Classic Widgets & Customizer
 	$( 'body' ).on( 'click', '.widget-control-save', function( e ) {
-		var $form = $( this ).parents( '.widget.open' ).find( '.widget-content' );
+		var $form = $( this ).parents( '.widget.open' );
 		if ( $form.length ) {
-			if ( ! sowbForms.validateFields( $form ) ) {
-				e.preventDefault();
-				e.stopPropagation();
+			$form = $form.find( '.widget-content' );
+			if ( $form.length ) {
+				if ( ! sowbForms.validateFields( $form ) ) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
 			}
 		}
 	} );


### PR DESCRIPTION
This PR resolves a TypeError that occurs in the Customizer if the new widget area is enabled and the user attempts to edit a widget (well, block).  

` admin.min.js?ver=1.45.0:1 Uncaught TypeError: i.find is not a function`