### PR TITLE
Contact: Add `siteorigin_widgets_contact_validation` Filter

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1397,6 +1397,8 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			}
 		}
 
+		$errors = apply_filters( 'siteorigin_widgets_contact_validation', $errors, $post_vars, $email_fields, $instance );
+
 		if ( empty( $errors ) ) {
 			// We can send the email
 			$success = $this->send_mail( $email_fields, $instance );


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/140

This PR adds a new filter called `siteorigin_widgets_contact_validation` that allows developers to do additional filtering for the contact form.

Here's a test snippet that will always reject form submissions and show a custom error message.

```
add_filter( 'siteorigin_widgets_contact_validation', function( $errors, $post_vars, $email_fields, $instance ) {
	$errors['_general'][] = 'Filter test';

	return $errors;
}, 10, 4 );
```