### PR TITLE
New Widget Area: Prevent Error When Adding Empty Editor Widget

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -94,7 +94,10 @@
 			}
 
 			function generateWidgetPreview( widgetData = false) {
-				if ( typeof wp.data.dispatch( 'core/editor' ) == 'object' ) {
+				if (
+					typeof wp.data.select( 'core/editor' ) == 'object' &&
+					typeof wp.data.dispatch( 'core/editor' ) == 'object'
+				) {
 					wp.data.dispatch( 'core/editor' ).lockPostSaving();
 				}
 
@@ -119,7 +122,11 @@
 						widgetHtml: widgetPreview.html,
 						widgetIcons: widgetPreview.icons
 					} );
-					if ( typeof wp.data.dispatch( 'core/editor' ) == 'object' ) {
+
+					if (
+						typeof wp.data.select( 'core/editor' ) == 'object' &&
+						typeof wp.data.dispatch( 'core/editor' ) == 'object'
+					) {
 						wp.data.dispatch( 'core/editor' ).unlockPostSaving();
 					}
 				} )


### PR DESCRIPTION
This PR resolves an issue when adding a SiteOrigin Widgets Block with the Editor widget selected and no text added. It's possible other widgets also cause this issue but it's not clear what else does.

`Uncaught TypeError: wp.data.dispatch(...) is null`