### PR TITLE
Color Form Field: Add `siteorigin_widget_color_palette` Filter

### DIFF
--- a/base/inc/fields/color.class.php
+++ b/base/inc/fields/color.class.php
@@ -26,7 +26,13 @@ class SiteOrigin_Widget_Field_Color extends SiteOrigin_Widget_Field_Text_Input_B
 			$data_attributes['default-color'] = $this->default;
 		}
 
-		if ( isset( $this->palettes ) ) {
+		// Allow developers to add custom colors using a filter, and field options.
+		$this->palettes = array_merge(
+			apply_filters( 'siteorigin_widget_color_palette', array() ),
+			! empty( $this->palettes ) ? $this->palettes : array()
+		);
+
+		if ( ! empty( $this->palettes ) ) {
 			if ( ! empty( $this->palettes ) && is_array( $this->palettes ) ) {
 				$valid_palette = array();
 				$valid_palette = array_filter( $this->palettes, 'sanitize_hex_color' );


### PR DESCRIPTION
This PR introduces the `siteorigin_widget_color_palette` filter which will allow developers to globally override the colours in the color picker 

Test snippet:

```
add_filter( 'siteorigin_widget_color_palette', function( $options ) {
	return array( '#f00' );
}, 1 );
```

Please also test this PR with custom palette colors added using a form field. To do this please open widgets/icon/icon.php and [find this line](https://github.com/siteorigin/so-widgets-bundle/blob/1.46.1/widgets/icon/icon.php#L36). Add the following to the next line:

'palettes' => array(
	'#f00',
	'#0f0',
	'#00f',
),

