### PR TITLE
Lottie Player: Filter For Applications Only

### DIFF
--- a/widgets/lottie-player/lottie-player.php
+++ b/widgets/lottie-player/lottie-player.php
@@ -48,6 +48,7 @@ class SiteOrigin_Widget_Lottie_Player_Widget extends SiteOrigin_Widget {
 			'file' => array(
 				'type' => 'media',
 				'label' => __( 'Lottie File', 'so-widgets-bundle' ),
+				'library' => 'application',
 			),
 
 			'autoplay' => array(


### PR DESCRIPTION
This will prevent images from showing up and allow users to select previously uploaded json files. There's a chance of seeing actual application files (exe, dmg, etc) but that's better than not being able to see any json files in general or just images.