### PR TITLE
SO Widgets Block: Prevent ReferenceError in Customizer

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -339,7 +339,11 @@
 
 // Setup SiteOrigin Widgets Block Validation.
 var sowbTimeoutSetup = false;
-if ( adminpage != 'widgets-php' && typeof wp.data.select == 'function' ) {
+if (
+	typeof adminpage != 'undefined' &&
+	adminpage != 'widgets-php' &&
+	typeof wp.data.select == 'function'
+) {
 	wp.data.subscribe( function() {
 		if (
 			! sowbTimeoutSetup &&


### PR DESCRIPTION
This PR resolves the following JS notice in the console when using the Customizer and the New Widget Area is active.

`Uncaught ReferenceError: adminpage is not defined`