### PR TITLE
Blog Portfolio: Remove `Filter Category` Setting Requirement

### DIFF
--- a/widgets/blog/js/portfolio.js
+++ b/widgets/blog/js/portfolio.js
@@ -10,14 +10,12 @@ jQuery( function ( $ ) {
 				$buttons = $$.find( '.sow-portfolio-filter-terms button' ),
 				$container = $$.find( '.sow-blog-posts' );
 
-			if ( $buttons.length ) {
-				$container.isotope( {
-					itemSelector: '.sow-portfolio-item',
-					filter: '*',
-					layoutMode: 'fitRows',
-					resizable: true,
-				} );
-			}
+			$container.isotope( {
+				itemSelector: '.sow-portfolio-item',
+				filter: '*',
+				layoutMode: 'fitRows',
+				resizable: true,
+			} );
 
 			$buttons.on( 'click', function() {
 				var selector = $( this ).attr( 'data-filter' );


### PR DESCRIPTION
This PR removes the requirement of the Filter Category setting for the Portfolio template to work correctly.