### PR TITLE
Simple Masonry: Resolve Pre WP 5.9 Error

### DIFF
--- a/widgets/simple-masonry/tpl/default.php
+++ b/widgets/simple-masonry/tpl/default.php
@@ -46,6 +46,7 @@
 				<?php endif; ?>
 
 				<?php
+				$loading_val = function_exists( 'wp_get_loading_attr_default' ) ? wp_get_loading_attr_default( 'the_content' ) : 'lazy';
 				echo siteorigin_widgets_get_attachment_image(
 					$item['image'],
 					'full',
@@ -53,7 +54,7 @@
 					array(
 						'title' => esc_attr( $title ),
 						'class' => 'sow-masonry-grid-image',
-						'loading' => $preloader_enabled ? false : wp_get_loading_attr_default( 'the_content' )
+						'loading' => $preloader_enabled ? false : $loading_val,
 					)
 				);
 				?>


### PR DESCRIPTION
This PR resolves the following error on sites using versions of WordPress older than 5.9.

`Fatal error: Uncaught Error: Call to undefined function wp_get_loading_attr_default()`