### PR TITLE
Fix fatal error mce_external_plugins missing editor_id

### DIFF
--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -362,7 +362,7 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			}
 			
 
-			$mce_external_plugins = apply_filters( 'mce_external_plugins', $this->mce_external_plugins );
+			$mce_external_plugins = apply_filters( 'mce_external_plugins', $this->mce_external_plugins, $this->element_id );
 			$tmce_settings['external_plugins'] = ! empty( $mce_external_plugins ) && is_array( $mce_external_plugins ) ? array_unique( $mce_external_plugins ) : array();
 			
 			$suffix = SCRIPT_DEBUG ? '' : '.min';


### PR DESCRIPTION
if site origin hooks to mce_external_plugins before a plugin written to expect the second param $editor_id, it will cause a fatal error.