### PR TITLE
Slider: Prevent Unexpected Space Below Active Slide

### DIFF
--- a/widgets/slider/styles/default.less
+++ b/widgets/slider/styles/default.less
@@ -47,8 +47,9 @@
 			}
 
 			.sow-slider-image-foreground-wrapper {
-				margin-right: auto;
+				line-height: 0;
 				margin-left: auto;
+				margin-right: auto;
 			}
 		}
 	}


### PR DESCRIPTION
This PR will prevent some potential spacing after a slide foreground image. This spacing can result in the row resizing after the slide changes.