### PR TITLE
Tab/Accordion: Prevent Unexpected Scroll

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -38,7 +38,10 @@ jQuery( function ( $ ) {
 						start: function () {
 							// Sometimes the content of the panel relies on a window resize to setup correctly.
 							// Trigger it here so it's hopefully done before the animation.
-							$( window ).trigger( 'resize' );
+							if ( sowAccordion.scrollto_after_change ) {
+								// It's possible a resize may result in a scroll so we put it behind a check.
+								$( window ).trigger( 'resize' );
+							}
 							$( sowb ).trigger( 'setup_widgets' );
 						},
 						complete: function() {

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -84,7 +84,10 @@ jQuery( function ( $ ) {
 								start: function () {
 									// Sometimes the content of the panel relies on a window resize to setup correctly.
 									// Trigger it here so it's hopefully done before the animation.
-									$( window ).trigger( 'resize' );
+									if ( shouldScroll( $tab ) ) {
+										// It's possible a resize may result in a scroll so we put it behind a check.
+										$( window ).trigger( 'resize' );
+									}
 									$( sowb ).trigger( 'setup_widgets' );
 								},
 								complete: function() {


### PR DESCRIPTION
This PR will stop the Tab and Accordion widgets from triggering a resize when changing tab if the Scroll Top setting is disabled. This isn't ideal, but there's a high chance that triggering a resize could result in a scroll so it could result in a scroll anyway (albeit to a completely unrelated spot). As a result, this change ensures that if the setting is disabled, it won't scroll.