### PR TITLE
Avoid using strpos with empty string in include_widgets_css_in_autoptimize

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -895,11 +895,14 @@ class SiteOrigin_Widgets_Bundle {
 	public function include_widgets_css_in_autoptimize( $excluded, $content ) {
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
+		if (!$excluded) return $excluded;
+
 		$excl = array_map( 'trim', explode( ',', $excluded ) );
 		$add = array();
 		$uploads_dir = wp_upload_dir();
+
 		foreach ( $excl as $index => $path ) {
-			if ( strpos( $uploads_dir['basedir'], untrailingslashit( $path ) ) !== false ) {
+			if ( untrailingslashit( $path ) && strpos( $uploads_dir['basedir'], untrailingslashit( $path ) ) !== false ) {
 				// Iterate over items in uploads and add to excluded, except for the 'siteorigin-widgets' folder.
 				$excl[ $index ] = '';
 				$uploads_items  = list_files( $uploads_dir['basedir'], 1, array( 'siteorigin-widgets' ) );


### PR DESCRIPTION
This will clean up error logs. "PHP Warning:  strpos(): Empty needle"