### PR TITLE
Page Builder: Prevent Unintended Widget Asset Enqueue in Classic Editor

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -185,8 +185,12 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		// Add any missing default values to the instance
 		$instance = $this->add_defaults( $form_options, $instance );
 
-		$css_name = $this->generate_and_enqueue_instance_styles( $instance );
-		$this->enqueue_frontend_scripts( $instance );
+		if ( empty( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] ) ) {
+			$css_name = $this->generate_and_enqueue_instance_styles( $instance );
+			$this->enqueue_frontend_scripts( $instance );
+		} else {
+			$css_name = 'panels-preview';
+		}
 
 		$template_vars = $this->get_template_variables($instance, $args);
 		$template_vars = apply_filters( 'siteorigin_widgets_template_variables_' . $this->id_base, $template_vars, $instance, $args, $this );


### PR DESCRIPTION
This PR resolves an issue caused by a recent PB change to help with SEO analysis tools. That change caused scripts loaded using [register_frontend_scripts and register_frontend_styles](https://siteorigin.com/docs/widgets-bundle/getting-started/initializing-a-widget/#heading-registering-front-end-scripts-and-styles) to be loaded in the editor if they're present when the editor is loaded. This isn't ideal as those scripts aren't designed to be used like that in the Classic Editor so it can potentially cause issues.

To test this PR, add a SiteOrign Accoridon to a page (no adjustments needed) and then save. Reload the editor and then search the browser source for so-accordion-js and you'll notice that a frontend script was loaded in the admin area - this should only happen in the Block Editor. Enable this PR and reload again. You'll notice the script is no longer present. 

Please ensure the Accordion widget works without issue in the SiteOrigin Layouts Block while using this PR.