### PR TITLE
Sliders: Enable Video Backgrounds On Mobile By Default

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -176,6 +176,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				'type' => 'checkbox',
 				'label' => __( 'Show slide background videos on mobile', 'so-widgets-bundle' ),
 				'description' => __( 'Allow slide background videos to appear on mobile devices that support autoplay.', 'so-widgets-bundle' ),
+				'default' => true,
 			),
 		);
 	}


### PR DESCRIPTION
This PR changes the default for the **Show slide background videos on mobile** setting to true. This is most in line with our default enabled settings and there's no real reason not to have it enabled by default anymore.