### PR TITLE
Autocomplete Form Field: Add `multiple` Option

### DIFF
--- a/base/inc/fields/autocomplete.class.php
+++ b/base/inc/fields/autocomplete.class.php
@@ -23,6 +23,14 @@ class SiteOrigin_Widget_Field_Autocomplete extends SiteOrigin_Widget_Field_Text_
 	protected $source;
 
 	/**
+	 * Whether to allow multiple items to be selected.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $multiple;
+
+	/**
 	 * The CSS classes to be applied to the rendered text input.
 	 */
 	protected function get_input_classes() {
@@ -32,19 +40,23 @@ class SiteOrigin_Widget_Field_Autocomplete extends SiteOrigin_Widget_Field_Text_
 	protected function get_default_options() {
 		$defaults = parent::get_default_options();
 		$defaults['source'] = 'posts';
+		$defaults['multiple'] = true;
 		return $defaults;
 	}
 
 	protected function render_after_field( $value, $instance ) {
 		$post_types = ! empty( $this->post_types ) && is_array( $this->post_types ) ? implode( ',', $this->post_types ) : '';
 		?>
-		<div class="existing-content-selector">
+		<div class="existing-content-selector" data-multiple="<?php echo esc_attr( $this->multiple ); ?>">
 
-			<input type="text" class="content-text-search"
-			       data-post-types="<?php echo esc_attr( $post_types ) ?>"
-			       data-source="<?php echo esc_attr( $this->source ) ?>"
-			       placeholder="<?php esc_attr_e( 'Search', 'so-widgets-bundle' ) ?>"
-			       tabindex="0"/>
+			<input
+				type="text"
+				class="content-text-search"
+				data-post-types="<?php echo esc_attr( $post_types ) ?>"
+				data-source="<?php echo esc_attr( $this->source ) ?>"
+				placeholder="<?php esc_attr_e( 'Search', 'so-widgets-bundle' ) ?>"
+				tabindex="0"
+			/>
 
 			<ul class="items"></ul>
 

--- a/base/inc/fields/js/autocomplete-field.js
+++ b/base/inc/fields/js/autocomplete-field.js
@@ -3,7 +3,8 @@
 (function( $ ) {
 
 	$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-autocomplete', function ( e ) {
-		var $$ = $(this);
+		var $$ = $( this );
+		var $contentSelector = $$.find(' .existing-content-selector' );
 
 		if ( $$.data( 'initialized' ) ) {
 			return;
@@ -73,11 +74,10 @@
 		};
 
 		$$.find( '.siteorigin-widget-autocomplete-input' ).on( 'click', function () {
-			var $s = $$.find('.existing-content-selector');
-			$s.show();
+			$contentSelector.show();
 
 			var refreshPromise = new $.Deferred();
-			if( $s.is(':visible') && $s.find('ul.items li').length === 0 ) {
+			if( $contentSelector.is(':visible') && $contentSelector.find('ul.items li').length === 0 ) {
 				refreshPromise = refreshList();
 			} else {
 				refreshPromise.resolve();
@@ -87,7 +87,7 @@
 		});
 
 		var closeContent = function () {
-			$$.find('.existing-content-selector').hide();
+			$contentSelector.hide();
 		};
 
 		$( window ).on( 'mousedown', function( event ) {
@@ -106,22 +106,29 @@
 			if ( e.type == 'keyup' && ! window.sowbForms.isEnter( e ) ) {
 				return;
 			}
-
-			var $li = $(this);
-			var selectedItems = getSelectedItems();
+			var $input = $$.find('input.siteorigin-widget-input');
+			var $li = $( this );
 			var clickedItem = $li.data( 'value' );
 
-			var curIndex = selectedItems.indexOf( clickedItem );
+			if ( $contentSelector.data( 'multiple' ) ) {
+				var selectedItems = getSelectedItems();
 
-			if ( curIndex > -1 ) {
-				selectedItems.splice( curIndex, 1 );
-				$li.removeClass( 'selected' );
+				var curIndex = selectedItems.indexOf( clickedItem );
+
+				if ( curIndex > -1 ) {
+					selectedItems.splice( curIndex, 1 );
+					$li.removeClass( 'selected' );
+				} else {
+					selectedItems.push( clickedItem );
+					$li.addClass( 'selected' );
+				}				
+				$input.val( selectedItems.join(',') );
 			} else {
-				selectedItems.push( clickedItem );
+				$li.parent().find( '.selected' ).removeClass( 'selected' );
 				$li.addClass( 'selected' );
+				$input.val( clickedItem );
+				closeContent();
 			}
-			var $input = $$.find('input.siteorigin-widget-input');
-			$input.val( selectedItems.join(',') );
 			$input.trigger( 'change' );
 		} );
 


### PR DESCRIPTION
This allows the autocomplete field to only allow a single selection.

To test this PR, add the following [to the line after this line](https://github.com/siteorigin/so-widgets-bundle/blob/1.46.7/base/inc/fields/posts.class.php#L43):

`'multiple' => false,`