### PR TITLE
Missing Widget Detection: Identify SO Widget Fix

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -746,8 +746,8 @@ class SiteOrigin_Widgets_Bundle {
 		// We only want to worry about missing widgets.
 		if ( ! empty( $the_widget ) ) return $the_widget;
 
-		if ( preg_match( '/SiteOrigin_Widgets?_( [A-Za-z]+ )_Widget/', $class, $matches ) ) {
-			$name = $matches[1];
+		if ( preg_match( '/^(SiteOrigin_Widgets|SiteOrigin_Widget)_(\w+)_Widget/', $class, $matches ) ) {
+			$name = $matches[2];
 			$id = strtolower( implode( '-', array_filter( preg_split( '/(?=[A-Z])/', $name ) ) ) );
 
 			if ( $id == 'contact-form' ) {


### PR DESCRIPTION
This PR resolves the widget detection fix for loading missing widgets. The previous pattern only looked for Widget_s_ while most of our widgets don't use widget_s_ in the class name. It also just wasn't detecting anything reliably. [Here's a regex for the before](https://regex101.com/r/Nmhh4C/1) and [here's one for this PR](https://regex101.com/r/IZfEPn/1). 