### PR TITLE
Tabs: Add `siteorigin_widgets_tabs_always_scroll`

### DIFF
--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -84,7 +84,7 @@ jQuery( function ( $ ) {
 								start: function () {
 									// Sometimes the content of the panel relies on a window resize to setup correctly.
 									// Trigger it here so it's hopefully done before the animation.
-									if ( shouldScroll( $tab ) ) {
+									if ( shouldScroll( $tab ) || sowTabs.always_scroll ) {
 										// It's possible a resize may result in a scroll so we put it behind a check.
 										$( window ).trigger( 'resize' );
 									}

--- a/widgets/tabs/tabs.php
+++ b/widgets/tabs/tabs.php
@@ -60,6 +60,7 @@ class SiteOrigin_Widget_Tabs_Widget extends SiteOrigin_Widget {
 			array(
 				'scrollto_after_change' => ! empty( $global_settings['scrollto_after_change'] ),
 				'scrollto_offset' => (int) apply_filters( 'siteorigin_widgets_tabs_scrollto_offset', 90 ),
+				'always_scroll' => (bool) apply_filters( 'siteorigin_widgets_tabs_always_scroll', false ),
 			)
 		);
 	}


### PR DESCRIPTION
This PR is a follow up to https://github.com/siteorigin/so-widgets-bundle/pull/1187 which is intended to prevent an unexpected scroll after showing a tab even when scroll to is disabled. There are situations (third party plugin compatibility) where the user will want a resize regardless of that and the `siteorigin_widgets_tabs_always_scroll` filter will allow for that.

`add_filter( 'siteorigin_widgets_tabs_always_scroll', '__return_true' );`