### PR TITLE
Google Maps: Fix Potential Custom Style PHP 8.x Error

### DIFF
--- a/widgets/google-map/google-map.php
+++ b/widgets/google-map/google-map.php
@@ -743,11 +743,8 @@ class SiteOrigin_Widget_GoogleMap_Widget extends SiteOrigin_Widget {
 				}
 				break;
 			case 'raw_json':
-				if ( ! empty( $style_config['raw_json_map_styles'] ) ) {
-					
-					$styles_string = $style_config['raw_json_map_styles'];
-
-					$styles['styles'] = json_decode( $styles_string, true );
+				if ( ! empty( $style_config['raw_json_map_styles'] ) && is_string( $style_config['raw_json_map_styles'] ) ) {
+					$styles['styles'] = json_decode( $style_config['raw_json_map_styles'], true );
 				}
 				break;
 			case 'normal':


### PR DESCRIPTION
This PR resolves the following error:

`E_ERROR wurde in der Zeile 750 der Datei /var/www/vhosts/***/httpdocs/wp-content/plugins/so-widgets-bundle/widgets/google-map/google-map.php verursacht. Fehlermeldung: Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /var/www/vhosts/***/httpdocs/wp-content/plugins/so-widgets-bundle/widgets/google-map/google-map.php:750`

This error is linked to the Predefined Style **RAW JSON Styles** field. It's not however clear how it is though so I haven't been able to replicate the error. I've reached out to the user for further information to help with testing.