### PR TITLE
Font Field: Resolve PHP 8.x Deprecated notice

### DIFF
--- a/base/inc/fields/font.class.php
+++ b/base/inc/fields/font.class.php
@@ -24,6 +24,10 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		if ( empty( $value ) ) {
+			return isset( $this->default ) ? $this->default : 'default';
+		}
+
 		$sanitized_value = trim( $value );
 		// Any alphanumeric character followed by alphanumeric or whitespace characters (except newline),
 		// with optional colon followed by optional variant.


### PR DESCRIPTION
This PR resolves the following notice:

`[01-Apr-2023 02:05:57 UTC] PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in C:\Users\alex\Local Sites\siteorigin\app\public\wp-content\plugins\so-widgets-bundle\base\inc\fields\font.class.php on line 27`