### PR TITLE
Video Embed: Fix Loop

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -124,9 +124,9 @@ class SiteOrigin_Video {
 
 		$new_url = add_query_arg(
 			array(
-				'loop' => 1,
 				// Adding the current video in a playlist allows for YouTube to loop the video.
 				'playlist' => ! empty( $vars['v'] ) ? $vars['v'] : '',
+				'loop' => 1,
 			),
 			$match[1]
 		);


### PR DESCRIPTION
For whatever reason, YouTube now requires loop to be after the playlist id. Otherwise, YouTube will say the video is unavailable. This change is undocumented by YouTube and I can replicate it when viewing an the generated embed URL directly so it's likely not intentional. Regardless, this fixes it.

To test this please add a YouTube video using the SiteOrigin Video Player, Set it to loop and autoplay. Save and view the video.