### PR TITLE
Multiple Media: Resolve Issues Related To Removing Items When Multiple Instances of Field

### DIFF
--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -138,14 +138,14 @@
 
 			// Finally, open the modal.
 			frame.open();
-		});
+		} );
 
 		if ( ! repeater ) {
-			$( document ).on( 'click','.siteorigin-widget-field-type-multiple_media a.media-remove-button', function( e ) {
+			$field.on( 'click', 'a.media-remove-button', function( e ) {
 				e.preventDefault();
 				var $currentItem = $( this ).parent();
 
-				selectedMedia.splice( selectedMedia.indexOf( $currentItem.data( 'id' ) ) );
+				selectedMedia.splice( selectedMedia.indexOf( $currentItem.data( 'id' ) ), 1 );
 				$data.val( selectedMedia.join( ',' ) );
 
 				$currentItem.remove();


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/deleting-an-image-from-multiple-media-field-does-not-work-correctly/)

You can test this PR by adding the following PHP [to the next line](https://github.com/siteorigin/so-widgets-bundle/blob/develop/widgets/editor/editor.php#L44).

```
'example_multiple_media' => array(
    'type' => 'multiple_media',
    'label' => __( 'Example multiple media', 'so-widgets-bundle' ),
),
'example_multiple_media_2' => array(
    'type' => 'multiple_media',
    'label' => __( 'Example multiple media 2', 'so-widgets-bundle' ),
),
```

Open a SiteOrigin Editor widget add at least four images to both fields, and then duplicate the widget. Save. Open the original instance of the widget and remove one image from each field and then save. Reopen the edited widget and you'll notice the wrong number of images has been removed. Switch to this PR and do the same edit to the duplicated widget.