### PR TITLE
Update textarea.class.php to dedupe editor

### DIFF
--- a/base/inc/fields/textarea.class.php
+++ b/base/inc/fields/textarea.class.php
@@ -14,19 +14,6 @@ class SiteOrigin_Widget_Field_Textarea extends SiteOrigin_Widget_Field_Text_Inpu
 	protected function render_field( $value, $instance ) {
 		?>
 		<textarea
-		type="text"
-		name="<?php echo esc_attr( $this->element_name ) ?>"
-		id="<?php echo esc_attr( $this->element_id ) ?>"
-		<?php
-		$this->render_CSS_classes( $this->get_input_classes() );
-
-			if ( ! empty( $this->placeholder ) ) {
-				echo 'placeholder="' . esc_attr( $this->placeholder ) . '"';
-		}
-			if ( ! empty( $this->readonly ) ) {
-				echo 'readonly';
-			} ?>><?php echo esc_textarea( $value ); ?></textarea>
-		<textarea
 			type="text"
 			name="<?php echo esc_attr( $this->element_name ); ?>"
 			id="<?php echo esc_attr( $this->element_id ); ?>"


### PR DESCRIPTION
Looks like an old version of the textarea layout was left in the class and causing a duplicate textarea in the WordPress editor when textarea was in a widget.