### PR TITLE
Videos: Internally Convert Short YouTube URLS to Full

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -48,6 +48,10 @@ class SiteOrigin_Video {
 		) ) );
 
 		// Standardize YouTube video URL.
+		if ( strpos(  $src, 'youtu.be' ) !== false ) {
+			$src = str_replace( 'youtu.be/', 'youtube.com/watch?v=', $src );
+		}
+
 		if ( strpos( $src, 'youtube.com/watch' ) !== false ) {
 			$src_parse = parse_url( $src, PHP_URL_QUERY );
 			// Check if the URL was encoded.


### PR DESCRIPTION
This will ensure we're able to process it correctly.

To test this PR, add a SiteOrgin Video Player widget and set it to a short YouTube link (for example, https://youtu.be/piI9vJ9-UZ0). Set the video to Loop and then save. View he page and you'll see that YouTube says the video isn't valid. Apply this PR and it'll appear as expected.