### PR TITLE
Buttons: Only Apply Hover Text Color If Hover Effects Enabled

### DIFF
--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -70,14 +70,11 @@
 			}
 		}
 
-		&:active,
-		&:hover{
-			color: @hover_text_color !important;
-		}
-
+		&.ow-button-hover:active,
 		&.ow-button-hover:hover {
 			.gradient(lighten(@hover_background_color, 2%), lighten(darken(@hover_background_color, 10%), 2%), lighten(@hover_background_color, 2%));
 			border-color: lighten(lighten(@hover_background_color, 2%), 2%) lighten(@hover_background_color, 2%) darken(lighten(@hover_background_color, 2%), 3%) lighten(@hover_background_color, 2%);
+			color: @hover_text_color !important;
 		}
 	}
 }

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -70,14 +70,11 @@
 			}
 		}
 
-		&:active,
-		&:hover{
-			color: @hover_text_color !important;
-		}
-
+		&.ow-button-hover:active,
 		&.ow-button-hover:hover {
 			background: lighten(@hover_background_color, 4%);
 			border-color: lighten(@hover_background_color, 4%);
+			color: @hover_text_color !important;
 		}
 	}
 }

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -70,12 +70,13 @@
 
 		&:active,
 		&:hover{
-			color: @hover_text_color !important;
 		}
 
+		&.ow-button-hover:active,
 		&.ow-button-hover:hover {
 			background: @hover_background_color;
 			border-color: @hover_background_color;
+			color: @hover_text_color !important;
 		}
 	}
 }


### PR DESCRIPTION
This PR prevents the Hover Text Color from being applied if Hover Effects isn't enabled. Prior to this PR, if the user had set a Hover Text Color it wouldn't be adjustable on the backend but would still output.