### PR TITLE
Carousel:  Add Compatibility For Virtue Premium Home Slider

### DIFF
--- a/js/lib/slick.js
+++ b/js/lib/slick.js
@@ -1861,7 +1861,7 @@
         var _ = this, breakpoint, currentBreakpoint, l,
             responsiveSettings = _.options.responsive || null;
 
-        if ( responsiveSettings !== null && typeof responsiveSettings !== 'undefined' && 'length' in responsiveSettings && responsiveSettings.length !== 0 )
+        if ( responsiveSettings !== null && typeof responsiveSettings !== 'undefined' && 'length' in responsiveSettings && responsiveSettings.length !== 0 ) {
 
             _.respondTo = _.options.respondTo || 'window';
 


### PR DESCRIPTION
This PR resolves the following error with the Virtue Premium Home Slider when used alongside our carousel widgets.

![Screenshot 2023-05-05 at 12 49 33](https://user-images.githubusercontent.com/17275120/236638641-e81a31e8-a3a7-404b-aa99-ab0a748bfd73.png)
