### PR TITLE
Add `siteorigin_widgets_load_cache_compatibility`

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -24,9 +24,11 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		}
 
 		// These actions handle alerting cache plugins that they need to regenerate a page cache.
-		add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
-		add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
-		add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
+		if ( apply_filters( 'siteorigin_widgets_load_cache_compatibility', true ) ) {
+			add_action( 'siteorigin_widgets_stylesheet_deleted', array( $this, 'clear_page_cache' ) );
+			add_action( 'siteorigin_widgets_stylesheet_added', array( $this, 'clear_page_cache' ) );
+			add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
+		}
 
 		if (
 			function_exists( 'amp_is_enabled' ) &&


### PR DESCRIPTION
This allows users to disable our caching plugin compatibility. This is useful in certain situations where the user wishes to manage their cache manually or there's a non-standard Minify setup present. For example, the user who initially reached out about this wanted this due to their usage of [the Disable Automatic Caching Clearing WP Rocket plugin](https://docs.wp-rocket.me/article/137-disable-automatic-cache-clearing) which works better without our code in place.

Snippe to disable our compatibility:

`add_filter( 'siteorigin_widgets_load_cache_compatibility', '__return_false' );`