### PR TITLE
Slider Widget: Prevent Foreground Misalignment If Link Is Present

### DIFF
--- a/widgets/slider/styles/default.less
+++ b/widgets/slider/styles/default.less
@@ -54,6 +54,7 @@
 			.sow-slider-image-foreground-wrapper,
 			& > a .sow-slider-foreground-image  {
 				display: block;
+				line-height: 0;
 				margin-right: auto;
 				margin-left: auto;
 			}


### PR DESCRIPTION
This PR resolves an alignment issue present when the Slider widget has a foreground image and a Destination URL is set, or the lightbox addon is being used. A height must be set.