### PR TITLE
Add `siteorigin_web_font_url_processed`

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -176,7 +176,16 @@ function siteorigin_widget_get_font( $font_value ) {
 			global $sow_registered_fonts;
 
 			$font_weight_styles = array_keys( $sow_registered_fonts[ $font['family'] ] );
-			$wp_styles->registered[ $style_name ]->src = esc_url( apply_filters( 'siteorigin_web_font_url', 'https://fonts.googleapis.com/css' ) . '?family=' . urlencode( $font['family'] . ':' . implode( ',', $font_weight_styles ) ) );
+			$wp_styles->registered[ $style_name ]->src = esc_url(
+				apply_filters(
+					'siteorigin_web_font_url_processed',
+					apply_filters(
+						'siteorigin_web_font_url',
+						'https://fonts.googleapis.com/css' ) . '?family=' . urlencode(
+						$font['family'] . ':' . implode( ',', $font_weight_styles )
+					)
+				)
+			);
 		}
 	} else {
 		$font['family'] = $font_value;


### PR DESCRIPTION
This filter allows developers to easily filter the import URL of processed Google Fonts.