### PR TITLE
Slider: Resolve Deprecated Warning

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -657,7 +657,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 
 		// Pass the Widgets Bundle directory path to allow us to include the volume controls font.
 		$sow_plugin_dir_url = str_replace( site_url(), '', plugin_dir_url( SOW_BUNDLE_BASE_FILE ) );
-		$less_variables['volume_controls_font'] = "'${sow_plugin_dir_url}css/slider/fonts/volume-controls'";
+		$less_variables['volume_controls_font'] = "'{$sow_plugin_dir_url}css/slider/fonts/volume-controls'";
 
 		return $less_variables;
 	}


### PR DESCRIPTION
`Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /Sites/block-editor/wp-content/plugins/so-widgets-bundle/base/inc/widgets/base-slider.class.php on line 660`