### PR TITLE
Hero: Background Image Emitters & Background Color Opacity

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -113,8 +113,8 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 								'state_emitter' => array(
 									'callback' => 'conditional',
 									'args'     => array(
-										'has_background_image[show]: isNaN( val )',
-										'has_background_image[hide]: ! isNaN( val )',
+										'has_background_image[show]: val',
+										'has_background_image[hide]: ! val',
 									),
 								),
 							),


### PR DESCRIPTION
This PR Hide Background Image Settings if No Background Image Is Set and enables Alpha Support For Frame Background Color. The latter is useful for users who want the page background to be visible behind a translucent slide background.