### PR TITLE
Image Shapes: Prevent Potential Masking Issue After Updating

### DIFF
--- a/base/inc/shapes/shapes.php
+++ b/base/inc/shapes/shapes.php
@@ -1,57 +1,75 @@
 <?php
+if ( ! class_exists( 'SiteOrigin_Widget_Image_Shapes' ) ) {
+	class SiteOrigin_Widget_Image_Shapes {
+		public $shapes = array();
+		
+		public function __construct() {
+			add_action( 'init', array( $this, 'setup_shapes' ) );
+		}
 
-function siteorigin_widgets_image_shapes( $shape = false) {
-	$shapes = apply_filters(
-		'siteorigin_widgets_image_shapes',
-		array(
-			'circle' => __( 'Circle', 'so-widgets-bundle' ),
-			'oval' => __( 'Oval', 'so-widgets-bundle' ),
-			'triangle' => __( 'Triangle', 'so-widgets-bundle' ),
-			'square' => __( 'Square', 'so-widgets-bundle' ),
-			'diamond' => __( 'Diamond', 'so-widgets-bundle' ),
-			'rhombus' => __( 'Rhombus', 'so-widgets-bundle' ),
-			'parallelogram' => __( 'Parallelogram', 'so-widgets-bundle' ),
-			'pentagon' => __( 'Pentagon', 'so-widgets-bundle' ),
-			'hexagon' => __( 'Hexagon', 'so-widgets-bundle' ),
-		)
-	);
+		public static function single() {
+			static $single;
 
-	if ( ! $shape ) {
-		return $shapes;
-	} elseif ( isset( $shapes[ $shape ] ) ) {
-		return true;
-	} else {
-		return false;
-	}
-}
-add_filter( 'siteorigin_widgets_icon_families', 'siteorigin_widgets_icon_families_filter' );
+			return empty( $single ) ? $single = new self() : $single;
+		}
 
-
-function siteorigin_widgets_image_shape( $shape ) {
-	$shapes = siteorigin_widgets_image_shapes( $shape );
-	if (
-		$shape != 'custom' &&
-		siteorigin_widgets_image_shapes( $shape )
-	) {
-		$file = wp_normalize_path(
-			apply_filters(
-				'siteorigin_widgets_image_shape_file_path',
-				plugin_dir_path( __FILE__ ) . 'images/',
-				$shape
-			)
-		) . $shape . '.svg';
-		if ( file_exists( $file ) ) {
-			return wp_normalize_path(
-				apply_filters(
-					'siteorigin_widgets_image_shape_file_url',
-					plugin_dir_url( __FILE__ ) . 'images/',
-					$shape
+		public function setup_shapes() {
+			$this->shapes = apply_filters(
+				'siteorigin_widgets_image_shapes',
+				array(
+					'circle' => __( 'Circle', 'so-widgets-bundle' ),
+					'oval' => __( 'Oval', 'so-widgets-bundle' ),
+					'triangle' => __( 'Triangle', 'so-widgets-bundle' ),
+					'square' => __( 'Square', 'so-widgets-bundle' ),
+					'diamond' => __( 'Diamond', 'so-widgets-bundle' ),
+					'rhombus' => __( 'Rhombus', 'so-widgets-bundle' ),
+					'parallelogram' => __( 'Parallelogram', 'so-widgets-bundle' ),
+					'pentagon' => __( 'Pentagon', 'so-widgets-bundle' ),
+					'hexagon' => __( 'Hexagon', 'so-widgets-bundle' ),
 				)
-			) . $shape . '.svg';
-		} else {
+			);
+		}
+
+		function get_shapes() {
+			return $this->shapes;
+		}
+
+		public function is_valid_shape( $shape ) {
+			if (
+				! empty( $this->shapes ) &&
+				! empty( $shape ) &&
+				isset( $this->shapes[ $shape ] )
+			) {
+				return true;
+			}
+
 			return false;
 		}
-	} else {
-		return false;
+
+		public function get_image_shape( $shape ) {
+			if (
+				$this->is_valid_shape( $shape ) &&
+				$shape != 'custom'
+			) {
+				$file = wp_normalize_path(
+					apply_filters(
+						'siteorigin_widgets_image_shape_file_path',
+						plugin_dir_path( __FILE__ ) . 'images/',
+						$shape
+					)
+				) . $shape . '.svg';
+				if ( file_exists( $file ) ) {
+					return wp_normalize_path(
+						apply_filters(
+							'siteorigin_widgets_image_shape_file_url',
+							plugin_dir_url( __FILE__ ) . 'images/',
+							$shape
+						)
+					) . $shape . '.svg';
+				}
+			}
+			return false;
+		}
 	}
+	SiteOrigin_Widget_Image_Shapes::single();
 }

--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -170,7 +170,7 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 					'shape' => array(
 						'type' => 'select',
 						'label' => __( 'Image Shape', 'so-widgets-bundle' ),
-						'options' => siteorigin_widgets_image_shapes(),
+						'options' => SiteOrigin_Widget_Image_Shapes::single()->get_shapes(),
 						'state_handler' => array(
 							'image_shape[enabled]' => array( 'show' ),
 							'image_shape[disabled]' => array( 'hide' ),
@@ -371,11 +371,11 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 			'responsive_breakpoint' => $this->get_global_settings( 'responsive_breakpoint' ),
 		);
 
-		if ( ! empty( $instance['image_shape'] ) && siteorigin_widgets_image_shapes( $instance['image_shape']['shape'] ) ) {
+		if ( ! empty( $instance['image_shape'] ) &&  SiteOrigin_Widget_Image_Shapes::single()->is_valid_shape( $instance['image_shape']['shape'] ) ) {
 			$less_variables['image_shape_size'] = ! empty( $instance['image_shape']['size'] ) ? $instance['image_shape']['size'] : 'contain';
 			$less_variables['image_shape_repeat'] = ! empty( $instance['image_shape']['repeat'] ) ? $instance['image_shape']['repeat'] : 'no-repeat';
 			$less_variables['image_shape_position'] = ! empty( $instance['image_shape']['alignment'] ) ? $instance['image_shape']['alignment'] : 'center';
-			$less_variables['image_shape'] = 'url( "' . esc_url( siteorigin_widgets_image_shape( $instance['image_shape']['shape'] ) ) . '" )';
+			$less_variables['image_shape'] = 'url( "' . esc_url( SiteOrigin_Widget_Image_Shapes::single()->get_image_shape( $instance['image_shape']['shape'] ) ) . '" )';
 		}
 
 		return $less_variables;

--- a/widgets/image/styles/default.less
+++ b/widgets/image/styles/default.less
@@ -40,18 +40,21 @@
 	}
 
 	.so-widget-image {
-		-webkit-mask-image: @image_shape;
-		-webkit-mask-position: @image_shape_position;
-		-webkit-mask-repeat: @image_shape_repeat;
-		-webkit-mask-size: @image_shape_size;
 		display: block;
 		height: @image_height;
-		mask-image: @image_shape;
-		mask-position: @image_shape_position;
-		mask-repeat: @image_shape_repeat;
-		mask-size: @image_shape_size;
 		max-width: @image_max_width;
 		width: @image_width;
+
+		& when not (@image_shape = default ) {
+			-webkit-mask-image: @image_shape;
+			-webkit-mask-position: @image_shape_position;
+			-webkit-mask-repeat: @image_shape_repeat;
+			-webkit-mask-size: @image_shape_size;
+			mask-image: @image_shape;
+			mask-position: @image_shape_position;
+			mask-repeat: @image_shape_repeat;
+			mask-size: @image_shape_size;
+		}
 
 		& when (@size_enforce = 1 ) {
 			@media (max-width: @responsive_breakpoint) {


### PR DESCRIPTION
This PR will resolve a potential masking issue after updating that can result in an image appearing blank. To test it set an image up using the current release version and then update to develop. There's a chance that the image will appear blank, and this PR removes that chance.

This PR also features a partial rewrite of the image shape code to be more modular.