### PR TITLE
Blog Portfolio: Try to Show Correct Terms for Selected Post Type

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -852,11 +852,30 @@ public function __construct() {
 			} else {
 				$terms = get_terms( 'jetpack-portfolio-type' );
 			}
+		} else {
+			// Check if a developer has set a term for this post type.
+			$post_type = wp_parse_args( siteorigin_widget_post_selector_process_query( $instance['posts'] ) )['post_type'];
+			$taxonomy = apply_filters( 'siteorigin_widgets_blog_portfolio_taxonomy', '', $instance, $post_type );
+			if ( ! empty( $taxonomy ) ) {
+				$terms = get_terms( $taxonomy );
+			}
+			
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+				// Let's try to find a taxonomy that has terms for this post type.
+				$possible_tax = get_object_taxonomies( $post_type );
+				foreach ( $possible_tax as $tax ) {
+					$possible_terms = get_terms( $tax );
+					if ( ! empty( $possible_terms ) && ! is_wp_error( $possible_terms ) ) {
+						$terms = $possible_terms;
+						break;
+					}
+				}
+			}
 		}
 
 		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			$fallback = apply_filters( 'siteorigin_widgets_blog_portfolio_fallback_term', 'category', $instance );
-			// Unable to find posts with portfolio type. Try using fallback term.
+			// Unable to find posts for this type. Try using the fallback term.
 			if ( $post_id ) {
 				return get_the_terms( (int) $post_id, $fallback );
 			} else {


### PR DESCRIPTION
This PR will make the Portfolio template try to output relevant terms for the selected post type. Previously it would effectively be locked to Jetpack Portfolio terms or to a term called "category".   The first valid taxonomy is used which is defined by anything that returns results.

To test this, create a post type with the Custom Post Type Builder and give it a taxonomy. Save and then add some posts to that new post type and set some terms.