### PR TITLE
Blog: Account For Offset After the First Page

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1223,6 +1223,18 @@ public function __construct() {
 		}
 	}
 
+	public function total_pages( $posts ) {
+		// WP Query's max_num_pages doesn't account for offset, so let's do that now.
+		if (
+			! empty( $posts->query['offset'] ) &&
+			is_numeric( $posts->query['offset'] )
+		) {
+			return ceil( max( $posts->found_posts - $posts->query['offset'], 1 ) / $posts->query['posts_per_page'] );
+		} else {
+			return $posts->max_num_pages;
+		}
+	}
+
 	public function get_form_teaser() {
 		if ( class_exists( 'SiteOrigin_Premium' ) ) {
 			return false;

--- a/widgets/blog/tpl/base.php
+++ b/widgets/blog/tpl/base.php
@@ -11,7 +11,7 @@
 		data-template="<?php echo esc_attr( $instance['template'] ); ?>"
 		data-settings="<?php echo esc_attr( json_encode( $settings ) ); ?>"
 		data-paged="<?php echo esc_attr( $posts->query['paged'] ); ?>"
-		data-total-pages="<?php echo esc_attr( $posts->max_num_pages ); ?>"
+		data-total-pages="<?php echo esc_attr( $this->total_pages( $posts ) ); ?>"
 		data-hash="<?php echo esc_attr( $storage_hash ); ?>"
 	>
 		<?php


### PR DESCRIPTION
This will prevent a situation where the wrong post can appear when navigating between pages.

To test this PR add a SiteOrigin Block widget and set the Post Query additional field to:

`post__not_in=11143&offset=1`

Adjust the id of 11143 to the most recent post. Now set the pagination to **Load More** and then save. You should repeatedly see the same post over and over each time you load a new page. This PR will fix that.