### PR TITLE
Post Query: Account For Offset in Post Total

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -143,7 +143,13 @@ function siteorigin_widget_post_selector_all_post_types() {
  */
 function siteorigin_widget_post_selector_count_posts( $query ) {
 	$query = siteorigin_widget_post_selector_process_query( $query );
+
 	$posts = new WP_Query( $query );
 
-	return $posts->found_posts;
+	// WP Query doesn't reduce found_posts by the offset value, let's do that now.
+	if ( ! empty( $query['offset'] ) && is_numeric( $query['offset'] ) ) {
+		$total = max( $posts->found_posts - $query['offset'], 0 );
+	}
+
+	return empty( $total ) ? $posts->found_posts : $total;
 }


### PR DESCRIPTION
This PR will account for offsets if set by the user. To test this PR, add a Post Loop widget to a page and set the Offset to, say, 50. Save and reload the page. You'll notice the total off. Switch to this PR and reload and you'll notice the total is correct now - negative numbers aren't possible.