### PR TITLE
Features: Prevent Mobile Misalignment with Align Bottom More

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -189,7 +189,9 @@
 			font-size: @text_size;
 			font-style: @text_font_style;
 			& when ( @more_text_bottom_align = true ) {
-				height: 100%;
+				@media (min-width: @responsive_breakpoint) {
+					height: 100%;
+				}
 			}
 
 			> @{title_tag} {


### PR DESCRIPTION
This PR will prevent a misalignment that occurs with the More Text on mobile when the Bottom Align More Link Text setting is enabled. Previously it would appear on top of the next features icon, or outside of the feature. Now it'll appear within the boundaries of the feature widet.