### PR TITLE
Number field: DIsplay Field at a Smaller Size

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -732,23 +732,10 @@ div.siteorigin-widget-form {
 			}
 		}
 
-		&.siteorigin-widget-field-type-number {
-			align-items: center;
-			display: flex;
-			flex-wrap: wrap;
-
-			.siteorigin-widget-field-label {
-				flex: 100%;
-			}
-
-			.siteorigin-widget-input-number  {
-				flex: 1;
-			}
-
-			.siteorigin-widget-input-number-unit {
-				padding-left: 5px;
-			}
+		&.siteorigin-widget-field-type-number .siteorigin-widget-input-number-unit {
+			padding-left: 5px;
 		}
+
 	}
 
 	.siteorigin-widget-description {

--- a/base/inc/fields/number.class.php
+++ b/base/inc/fields/number.class.php
@@ -56,10 +56,10 @@ class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_
 	}
 
 	protected function get_input_classes() {
-		$input_classes = parent::get_input_classes();
-		$input_classes[] = 'siteorigin-widget-input-number';
-
-		return $input_classes;
+		return array(
+			'siteorigin-widget-input',
+			'siteorigin-widget-input-number',
+		);
 	}
 
 	protected function render_after_field( $value, $instance ) {


### PR DESCRIPTION
Having the field be full width makes it harder for users to use the step functionality of the field and (if it's set) see the unit. 

Before:
![before](https://github.com/siteorigin/so-widgets-bundle/assets/17275120/5f92a54d-7064-43ff-89a0-b29a796d38de)

After:
![after](https://github.com/siteorigin/so-widgets-bundle/assets/17275120/966e8eab-5e42-4133-9d4b-1929875a81a9)
