### PR TITLE
Contact: Resolve Warnings Related to PHP 8.2

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -395,6 +395,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 							'background'   => array(
 								'type'    => 'color',
 								'label'   => __( 'Background color', 'so-widgets-bundle' ),
+								'alpha'   => true,
 								'default' => '#f2f2f2',
 							),
 							'padding'      => array(
@@ -1018,7 +1019,6 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 
 				if (
 					! empty( $template_vars['result'] ) &&
-					! empty( $template_vars['result'] ) &&
 					! empty( $template_vars['result']['errors'] ) &&
 					! empty( $template_vars['result']['errors']['_general'] ) &&
 					! empty( $template_vars['result']['errors']['_general']['simple'] )
@@ -1171,8 +1171,9 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 	 *
 	 * @param array $errors
 	 */
-	public function render_form_fields( $fields, $errors, $instance ) {
+	public function render_form_fields( $fields, $result, $instance ) {
 		$field_ids = array();
+		$errors = ! empty( $result['errors'] ) ? $result['errors'] : array();
 		$label_position = $instance['design']['labels']['position'];
 
 		$indicate_required_fields = $instance['settings']['required_field_indicator'];
@@ -1183,24 +1184,30 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 			<?php
 		}
 
+		$fields = apply_filters( 'siteorigin_widgets_contact_email_fields', $fields );
 		foreach ( $fields as $i => $field ) {
 			if ( empty( $field['type'] ) ) {
 				continue;
 			}
+			$field_name = $this->name_from_label( ! empty( $field['label'] ) ? $field['label'] : $i, $field_ids );
+
 			// Using `$instance['_sow_form_id']` to uniquely identify contact form fields across widgets.
 			// I.e. if there are many contact form widgets on a page this will prevent field name conflicts.
-			$field_name = $this->name_from_label( ! empty( $field['label'] ) ? $field['label'] : $i, $field_ids ) . '-' . $instance['_sow_form_id'];
+			$field_name .= ! empty( $instance['_sow_form_id'] ) ? '-' . $instance['_sow_form_id'] : '';
+
 			$field_id = 'sow-contact-form-field-' . $field_name;
 
 			$value = '';
 
 			if ( ! empty( $_POST[ $field_name ] ) && wp_verify_nonce( $_POST['_wpnonce'], '_contact_form_submit' ) ) {
 				$value = stripslashes_deep( $_POST[ $field_name ] );
+			} elseif ( ! empty( $field['value'] ) ) {
+				$value = $field['value'];
 			}
 
 			?>
-            <div class="sow-form-field sow-form-field-<?php echo sanitize_html_class( $field['type'] ); ?>">
-            	<?php
+			<div class="sow-form-field sow-form-field-<?php echo sanitize_html_class( $field['type'] ); ?>">
+				<?php
 
 				$label = $field['label'];
 				$indicate_as_required = $indicate_required_fields && ! empty( $field['required']['required'] );
@@ -1302,7 +1309,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		}
 
 		if ( empty( $_POST['instance_hash'] ) || $_POST['instance_hash'] != $storage_hash ) {
-			return false;
+			return array();
 		}
 
 		if ( empty( $instance['fields'] ) ) {

--- a/widgets/contact/fields/base.class.php
+++ b/widgets/contact/fields/base.class.php
@@ -7,7 +7,7 @@ abstract class SiteOrigin_Widget_ContactForm_Field_Base {
 	 * @var array
 	 */
 	protected $options;
-	private $type;
+	public $type;
 
 	public function __construct( $options ) {
 		$this->options = $options;


### PR DESCRIPTION
This PR can be tested using the latest version of PHP and viewing a Contact Form with default settings.

`E_WARNING Trying to access array offset on value of type bool widgets/contact/tpl/default.php:8`
widgets/contact/tpl/default.php:41

`E_WARNING Undefined array key "_sow_form_id"`
widgets/contact/contact.php:1192

`E_WARNING Undefined property: SiteOrigin_Widget_ContactForm_Field_TextArea::$type`
widgets/contact/fields/textarea.class.php[11]