### PR TITLE
Button: Only Apply Flex If An Icon is Set

### DIFF
--- a/widgets/button/button.php
+++ b/widgets/button/button.php
@@ -388,6 +388,7 @@ class SiteOrigin_Widget_Button_Widget extends SiteOrigin_Widget {
 			'responsive_breakpoint' => $this->get_global_settings( 'responsive_breakpoint' ),
 			'align' => $instance['design']['align'],
 			'mobile_align' => $instance['design']['mobile_align'],
+			'has_button_icon' => empty( $instance['button_icon']['icon_selected'] ) ? 'false' : 'true',
 		);
 
 		if ( ! empty( $instance['design']['font'] ) ) {

--- a/widgets/button/styles/atom.less
+++ b/widgets/button/styles/atom.less
@@ -21,6 +21,7 @@
 @rounding: 0.25em;
 @padding: 1em;
 @has_text: true;
+@has_button_icon: false;
 
 .ow-button-base {
 
@@ -70,31 +71,34 @@
 				margin: 0;
 			}
 		}
-		& > span {
-			display: flex;
-			justify-content: center;
 
-			[class^="sow-icon-"] {
-				font-size: @icon_size;
+		& when ( @has_button_icon = true ) {
+			& > span {
+				display: flex;
+				justify-content: center;
+
+				[class^="sow-icon-"] {
+					font-size: @icon_size;
+				}
+			}
+
+			&.ow-icon-placement-top > span {
+				flex-direction: column;
+			}
+
+			&.ow-icon-placement-right > span {
+				flex-direction: row-reverse;
+			}
+
+			&.ow-icon-placement-bottom > span {
+				flex-direction: column-reverse;
+			}
+
+			&.ow-icon-placement-left > span {
+				align-items: start;
 			}
 		}
-		
-		&.ow-icon-placement-top > span {
-			flex-direction: column;
-		}
 
-		&.ow-icon-placement-right > span {
-			flex-direction: row-reverse;
-		}
-		
-		&.ow-icon-placement-bottom > span {
-			flex-direction: column-reverse;
-		}
-
-		&.ow-icon-placement-left > span {
-			align-items: start;
-		}
-		
 		&.ow-button-hover:active,
 		&.ow-button-hover:hover {
 			.gradient(lighten(@hover_background_color, 2%), lighten(darken(@hover_background_color, 10%), 2%), lighten(@hover_background_color, 2%));

--- a/widgets/button/styles/flat.less
+++ b/widgets/button/styles/flat.less
@@ -21,6 +21,7 @@
 @rounding: 0.25em;
 @padding: 1em;
 @has_text: true;
+@has_button_icon: false;
 
 .ow-button-base {
 	.clearfix();
@@ -70,29 +71,32 @@
 				margin: 0;
 			}
 		}
-		& > span {
-			display: flex;
-			justify-content: center;
 
-			[class^="sow-icon-"] {
-				font-size: @icon_size;
+		& when ( @has_button_icon = true ) {
+			& > span {
+				display: flex;
+				justify-content: center;
+
+				[class^="sow-icon-"] {
+					font-size: @icon_size;
+				}
 			}
-		}
-		
-		&.ow-icon-placement-top > span {
-			flex-direction: column;
-		}
 
-		&.ow-icon-placement-right > span {
-			flex-direction: row-reverse;
-		}
-		
-		&.ow-icon-placement-bottom > span {
-			flex-direction: column-reverse;
-		}
+			&.ow-icon-placement-top > span {
+				flex-direction: column;
+			}
 
-		&.ow-icon-placement-left > span {
-			align-items: start;
+			&.ow-icon-placement-right > span {
+				flex-direction: row-reverse;
+			}
+
+			&.ow-icon-placement-bottom > span {
+				flex-direction: column-reverse;
+			}
+
+			&.ow-icon-placement-left > span {
+				align-items: start;
+			}
 		}
 
 		&.ow-button-hover:active,

--- a/widgets/button/styles/wire.less
+++ b/widgets/button/styles/wire.less
@@ -20,6 +20,7 @@
 @rounding: 0.25em;
 @padding: 1em;
 @has_text: true;
+@has_button_icon: false;
 
 .ow-button-base {
 	.clearfix();
@@ -69,29 +70,31 @@
 			}
 		}
 
-		& > span {
-			display: flex;
-			justify-content: center;
+		& when ( @has_button_icon = true ) {
+			& > span {
+				display: flex;
+				justify-content: center;
 
-			[class^="sow-icon-"] {
-				font-size: @icon_size;
+				[class^="sow-icon-"] {
+					font-size: @icon_size;
+				}
 			}
-		}
-		
-		&.ow-icon-placement-top > span {
-			flex-direction: column;
-		}
 
-		&.ow-icon-placement-right > span {
-			flex-direction: row-reverse;
-		}
-		
-		&.ow-icon-placement-bottom > span {
-			flex-direction: column-reverse;
-		}
+			&.ow-icon-placement-top > span {
+				flex-direction: column;
+			}
 
-		&.ow-icon-placement-left > span {
-			align-items: start;
+			&.ow-icon-placement-right > span {
+				flex-direction: row-reverse;
+			}
+
+			&.ow-icon-placement-bottom > span {
+				flex-direction: column-reverse;
+			}
+
+			&.ow-icon-placement-left > span {
+				align-items: start;
+			}
 		}
 
 		&.ow-button-hover:active,


### PR DESCRIPTION
This PR will prevent flex from being applied to the button if an icon isn't set. This will resolve a reported issue (I wasn't able to replicate it) with instances of the Button widget added to Max Mega menu and the `<br>` element not working.