### PR TITLE
Sliders: Add Lazy Load Support

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -503,7 +503,11 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 		}
 
 		if ( ! empty( $background['image'] ) && $background['opacity'] >= 1 && empty( $frame['no_output'] ) ) {
-			$wrapper_attributes['style'][] = 'background-image: url(' . esc_url( $background['image'] ) . ')';
+			if ( $i == 0 ) {
+				$wrapper_attributes['style'][] = 'background-image: url(' . esc_url( $background['image'] ) . ')';
+			} else {
+				$wrapper_attributes['data-background'] = 'url(' . esc_url( $background['image'] ) . ')';
+			}
 		}
 
 		if ( ! empty( $background['url'] ) ) {
@@ -567,13 +571,23 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			}
 
 			if ( $background['opacity'] < 1 && ! empty( $background['image'] ) ) {
+				$attrs_array = array(
+					'opacity: ' . (float) $background['opacity'],
+				);
+
+				if ( $i === 0 ) {
+					$attrs_array[] = 'background-image: url(' . esc_url( $background['image'] ) . ')';
+				}
+
 				$overlay_attributes = array(
 					'class' => array( 'sow-slider-image-overlay', 'sow-slider-image-' . $background['image-sizing'] ),
-					'style' => array(
-						'background-image: url(' . $background['image'] . ')',
-						'opacity: ' . (float) $background['opacity'],
-					),
+					'style' => $attrs_array,
 				);
+
+				if ( $i !== 0 ) {
+					$overlay_attributes['data-background'] = 'url(' . esc_url( $background['image'] ) . ')';
+				}
+
 				$overlay_attributes = apply_filters( 'siteorigin_widgets_slider_overlay_attributes', $overlay_attributes, $frame, $background );
 
 				$overlay_attributes['class'] = empty( $overlay_attributes['class'] ) ? '' : implode( ' ', $overlay_attributes['class'] );

--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -33,7 +33,12 @@ sowb.SiteOriginSlider = function( $ ) {
 				embed[0].contentWindow.postMessage( '{"method":"pause"}', "*" );
 				// YouTube
 				embed[0].contentWindow.postMessage( '{"event":"command","func":"pauseVideo","args":""}', '*' )
-			}	
+			}
+		},
+
+		enableBackground: function( el, background ) {
+			el.css( 'background-image', background );
+			el.removeAttr( 'data-background' );
 		},
 
 		setupActiveSlide: function( slider, newActive, speed ) {
@@ -42,6 +47,21 @@ sowb.SiteOriginSlider = function( $ ) {
 				active = $( newActive ),
 				video = active.find( 'video.sow-background-element' ),
 				$unmuteButton = $( slider ).prev();
+
+			// If this slide hasn't loaded its background, add it.
+			var background = active.attr( 'data-background' );
+			if ( background !== undefined ) {
+				this.enableBackground( active, background );
+			}
+
+			// If the slider overlay hasn't loaded, set it up.
+			var overlay = active.find( '.sow-slider-image-overlay' );
+			if ( overlay ) {
+				var overlayBackground = overlay.attr( 'data-background' );
+				if ( overlayBackground !== undefined ) {
+					this.enableBackground( overlay, overlayBackground );
+				}
+			}
 
 			if ( speed === undefined ) {
 				sentinel.css( 'height', active.outerHeight() + 'px' );
@@ -119,12 +139,12 @@ jQuery( function( $ ) {
 
 		$( '.sow-slider-images' ).each( function() {
 			var $$ = $( this );
-			
-			
+
+
 			if ( $$.data( 'initialized' ) ) {
 				return $$;
 			}
-			
+
 			var $p = $$.siblings( '.sow-slider-pagination' );
 			var $base = $$.closest( '.sow-slider-base' );
 			var $n = $base.find( '.sow-slide-nav' );
@@ -193,7 +213,7 @@ jQuery( function( $ ) {
 
 				// Show everything for this slider
 				$base.show();
-				
+
 				var resizeFrames = function() {
 					$$.find( '.sow-slider-image' ).each( function() {
 						var $i = $( this );
@@ -218,7 +238,7 @@ jQuery( function( $ ) {
 						}, 425 );
 					}
 				}
-				
+
 				$$.trigger( 'slider_setup_before' );
 
 				// Set up the Cycle with videos
@@ -376,45 +396,15 @@ jQuery( function( $ ) {
 					} );
 				}
 			};
-			
+
 			$$.trigger( 'slider_setup_after' );
 
-			var images = $$.find( 'img.sow-slider-background-image, img.sow-slider-foreground-image' );
-			var imagesLoaded = 0;
-			var sliderLoaded = false;
-
-			// Preload all of the slide images, when they're loaded, then display the slider.
-			images.each( function() {
-				var $i = $( this );
-				if ( this.complete ) {
-					imagesLoaded++;
-				} else {
-					$( this ).one('load', function() {
-						imagesLoaded++;
-
-						if ( imagesLoaded === images.length && ! sliderLoaded ) {
-							setupSlider();
-							sliderLoaded = true;
-						}
-					} )
-					// Reset src attribute to force 'load' event for cached images in IE9 and IE10.
-						.attr( 'src', $( this ).attr( 'src' ) );
-				}
-
-				if ( imagesLoaded === images.length && ! sliderLoaded ) {
-					setupSlider();
-					sliderLoaded = true;
-				}
-			} );
-
-			if ( images.length === 0 ) {
-				setupSlider();
-			}
+			setupSlider();
 
 			if ( $.isFunction( $.fn.fitVids ) ) {
 				$$.find( '.sow-slide-video-oembed' ).fitVids();
 			}
-			
+
 			$$.data( 'initialized', true );
 		} );
 	};

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -203,17 +203,21 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 					<div class="sow-slider-image-foreground-wrapper">
 						<?php
 						echo siteorigin_widgets_get_attachment_image(
-						$frame['foreground_image'],
-						'full',
-						! empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
-						apply_filters(
+							$frame['foreground_image'],
+							'full',
+							! empty( $frame['foreground_image_fallback'] ) ? $frame['foreground_image_fallback'] : '',
+							siteorigin_loading_optimization_attributes(
+								apply_filters(
 									'siteorigin_widgets_slider_attr',
 									array(
-										'class' => 'sow-slider-foreground-image skip-lazy',
-										'loading' => apply_filters( 'siteorigin_widgets_slider_loading_attr', 'eager' ),
+										'class' => 'sow-slider-foreground-image',
 										'style' => ! empty( $foreground_style_attr ) ? $foreground_style_attr : '',
 									)
-								)
+								),
+								'sliders',
+								new stdClass(),
+								$this
+							)
 						);
 						?>
 					</div>


### PR DESCRIPTION
This PR will enable Lazy Load for all of our sliders. For some of our widgets, this will mean that the `loading` tag will be used*, or the slide image will be added as needed using JavaScript. Sliders will no longer pre-load all slide images before displaying.

\* (tag handled by WordPress so the image may not actually be lazy loaded)