### PR TITLE
Post Carousel: Prevent Thumbnail From Exceeding Width On Mobile

### DIFF
--- a/widgets/post-carousel/styles/base.less
+++ b/widgets/post-carousel/styles/base.less
@@ -93,7 +93,6 @@
 			@media (max-width: @breakpoint_mobile) {
 				.sow-carousel-thumbnail a {
 					background-size: cover;
-
 				}
 
 				&,


### PR DESCRIPTION
This PR will prevent slides from exceeding the width of the browser on mobile. It does this by setting the maximum slide width to 100vw. This isn't a perfect solution but it's about as good as we can get with the post carousel without a major recode and without setting a custom static item height on mobile.

To test this PR, set the ` Featured Image size` to an image size that's bigger than a typical mobile device (400px plus) and then save. Open the page on a mobile device and you'll see that images look strange - they're being displayed off the side of the screen. Now apply this PR, and you'll notice that they're better than before.