### PR TITLE
 Slider Widget: Don't Add Double Up On Backgrounds

### DIFF
--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -142,11 +142,13 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	public function get_frame_background( $i, $frame ) {
-		$background_image = siteorigin_widgets_get_attachment_image_src(
-			$frame['background_image'],
-			'full',
-			! empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : ''
-		);
+		if ( ! empty( $frame['foreground_image'] ) ) {
+			$background_image = siteorigin_widgets_get_attachment_image_src(
+				$frame['background_image'],
+				'full',
+				! empty( $frame['background_image_fallback'] ) ? $frame['background_image_fallback'] : ''
+			);
+		}
 
 		return array(
 			'color' => ! empty( $frame['background_color'] ) ? $frame['background_color'] : false,


### PR DESCRIPTION
This PR will prevent the Slider widget from adding the background image as both a HTML Image (which is correct) and a CSS Background Image (which isn't) when there's not a foreground image present. 

You can test this by adding a background image without a foreground and checking the list item for that slide on the frontend.