### PR TITLE
Beaver Builder: Prevent BB UI Not Loading

### DIFF
--- a/compat/beaver-builder/beaver-builder.php
+++ b/compat/beaver-builder/beaver-builder.php
@@ -59,11 +59,10 @@ class SiteOrigin_Widgets_Bundle_Beaver_Builder {
 			plugin_dir_url( __FILE__ ) . 'styles.css'
 		);
 
-		$deps = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? array( 'jquery', 'fl-builder', 'siteorigin-widget-admin' ) : array( 'fl-builder-min', 'siteorigin-widget-admin' );
 		wp_enqueue_script(
 			'sowb-js-for-beaver',
 			plugin_dir_url( __FILE__ ) . 'sowb-beaver-builder' . SOW_BUNDLE_JS_SUFFIX . '.js',
-			$deps
+			array( 'jquery', 'siteorigin-widget-admin' )
 		);
 
 		wp_enqueue_style(


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/so-widgets-bundle/issues/1839. 

This issue is resolved by removing Core BB JS as a dependency.