### PR TITLE
Beaver Builder: Switch Color Fields to a Color Input

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -264,9 +264,18 @@ var sowbForms = window.sowbForms || {};
 			// For any repeater items currently in existence
 			$el.find('.siteorigin-widget-field-repeater-item').sowSetupRepeaterItems();
 
-			// Set up any color fields
+			var canSetupColorPicker = typeof jQuery.fn.wpColorPicker !== 'undefined';
+			// Set up any color fields.
 			$fields.find( '> .siteorigin-widget-input-color' ).each( function() {
 				var $colorField = $( this );
+
+				if ( ! canSetupColorPicker ) {
+					// We can't load the color picker, so let's convert the field to a color input.
+					$colorField.attr( 'type' , 'color' );
+
+					return;
+				}
+
 				var colorResult = ''
 				var alphaImage = '';
 

--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -41,7 +41,20 @@
 		}
 
 		input.siteorigin-widget-input-color {
-			height: inherit !important;
+			border: none;
+			height: 20px;
+			padding: 0;
+			width: 40px;
+
+			&::-moz-color-swatch-wrapper,
+			&::-webkit-color-swatch-wrapper {
+			    padding: 0;
+			}
+
+			&::-moz-color-swatch,
+			&::-webkit-color-swatch {
+			    border: none;
+			}
 		}
 
 		input.siteorigin-widget-input-measurement {


### PR DESCRIPTION
This PR will switch WB Color Form Fields to the [color input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color). This will allow for those fields to be more useable overall.