### PR TITLE
Anything Carousel: Reset Dots Font Family & Weight

### DIFF
--- a/widgets/anything-carousel/css/style.less
+++ b/widgets/anything-carousel/css/style.less
@@ -97,8 +97,10 @@
 						color: transparent;
 						cursor: pointer;
 						display: block;
+						font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
 						font-size: 0;
 						font-style: normal;
+						font-weight: 400;
 						letter-spacing: normal;
 						line-height: 0;
 						margin: 0;


### PR DESCRIPTION
This PR resets the `font-family` and `font-weight` of the Dot buttons. This will allow them to be more consistently sized in different environments.

A build is required to test this PR as this LESS is complied during the build.