### PR TITLE
Measurement Units: Adjust `line-height` to verticaly align better

### DIFF
--- a/base/inc/fields/css/measurement-field.less
+++ b/base/inc/fields/css/measurement-field.less
@@ -16,7 +16,7 @@ div.siteorigin-widget-form div.siteorigin-widget-field.siteorigin-widget-field {
 
 	input[type="text"].siteorigin-widget-input-measurement,
 	select.sow-measurement-select-unit {
-		line-height: 2em;
+		line-height: 24px;
 	}
 
 	@media (max-width: 680px) {

--- a/base/inc/fields/css/multi-measurement-field.less
+++ b/base/inc/fields/css/multi-measurement-field.less
@@ -18,6 +18,7 @@ div.siteorigin-widget-form div.siteorigin-widget-field.siteorigin-widget-field {
 
 			select.sow-multi-measurement-select-unit {
 				border: 1px solid #646970;
+				line-height: 24px;
 				min-width: inherit;
 
 				&:focus,


### PR DESCRIPTION
This PR will better vertically align the measurement unit text better than it currently is.