### PR TITLE
WC Shop: If There are any WB Blocks present, re-render the page.

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -180,7 +180,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 
 		$blocks = parse_blocks( $shop_page->post_content );
 		// Check if any SiteOrigin Widgets Bundle blocks exist.
-		$blocks = array_filter( $blocks, function ( $block ) {
+		$blocks = array_filter( $blocks, function( $block ) {
 			return strpos( $block['blockName'], 'sowb/' ) === 0;
 		} );
 


### PR DESCRIPTION
This PR will resolve display issues with WB blocks being added to the WC Shop Page via the Block Editor. WC applies `wp_kses` to the shop content and that will break some of our widgets - such as the Accordion. 