### PR TITLE
Carousel: Disable Slide Transitions if Motion is set to be Reduced

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -3,6 +3,8 @@
 var sowb = window.sowb || {};
 
 jQuery( function ( $ ) {
+	// We remove animations if the user has motion disabled.
+	const reduceMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 	sowb.setupCarousel = function () {
 		$.fn.setSlideTo = function( slide ) {
@@ -28,6 +30,11 @@ jQuery( function ( $ ) {
 				$items = $$.find( '.sow-carousel-items' ),
 				responsiveSettings = $$.data( 'responsive' ),
 				carouselSettings = $$.data( 'carousel_settings' );
+
+			// Remove animations if needed.
+			if ( reduceMotion ) {
+				carouselSettings.animation_speed = 0;
+			}
 
 			$items.not( '.slick-initialized' ).slick( {
 				arrows: false,


### PR DESCRIPTION


This PR will improve the accessibility of our carousel widgets by removing item transitions if the user has motion set to be reduced. Reduced in this context means: remove any that are not necessary. They're nice to have, but they're not necessary.
