### PR TITLE
Carousel: Increase Animation Speed Default

### DIFF
--- a/base/inc/widgets/base-carousel.class.php
+++ b/base/inc/widgets/base-carousel.class.php
@@ -299,7 +299,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 				'animation_speed' => array(
 					'type' => 'number',
 					'label' => __( 'Animation speed', 'so-widgets-bundle' ),
-					'default' => 300,
+					'default' => 400,
 				),
 				'autoplay' => array(
 					'type' => 'checkbox',
@@ -454,7 +454,7 @@ abstract class SiteOrigin_Widget_Base_Carousel extends SiteOrigin_Widget {
 			'loop' => isset( $settings['loop'] ) ? $settings['loop'] : true,
 			'dots' => isset( $settings['dots'] ) ? $settings['dots'] : true,
 			'animation' => isset( $settings['animation'] ) ? $settings['animation'] : 'ease',
-			'animation_speed' => ! empty( $settings['animation_speed'] ) ? $settings['animation_speed'] : 300,
+			'animation_speed' => ! empty( $settings['animation_speed'] ) ? $settings['animation_speed'] : 400,
 			'autoplay' => isset( $settings['autoplay'] ) ? $settings['autoplay'] : false,
 			'pauseOnHover' => isset( $settings['autoplay_pause_hover'] ) ? $settings['autoplay_pause_hover'] : false,
 			'autoplaySpeed' => ! empty( $settings['timeout'] ) ? $settings['timeout'] : 8000,


### PR DESCRIPTION
This will help transitions feel snapper/smooth. This change will only affect new Carousels.