### PR TITLE
Icon: Prevent Pottential `TypeError`

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -120,7 +120,7 @@ function siteorigin_widget_get_icon( $icon_value, $icon_styles = false, $title =
 		}
 
 		return '<span class="' . esc_attr( $family_style ) . '" data-sow-icon="' . $unicode . '"
-		' . ( ! empty( $icon_styles ) ? 'style="' . implode( '; ', $icon_styles ) . '"' : '' ) . ' ' .
+		' . ( is_array( $icon_styles ) ? 'style="' . implode( '; ', $icon_styles ) . '"' : '' ) . ' ' .
 		( ! empty( $title ) ? 'title="' . esc_attr( $title ) . '"' : '' ) . '
 		aria-hidden="true"></span>';
 	} else {


### PR DESCRIPTION
`wp-content/plugins/so-widgets-bundle/base/base.php on line 123 [24-Jan-2024 20:33:24 UTC] PHP Fatal error:  Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, bool given in /Users/amisplon/Sites/demo/wp-content/plugins/so-widgets-bundle/base/base.php:123`