### PR TITLE
Link Field: Resolve Deprecated

### DIFF
--- a/base/inc/fields/link.class.php
+++ b/base/inc/fields/link.class.php
@@ -51,6 +51,10 @@ class SiteOrigin_Widget_Field_Link extends SiteOrigin_Widget_Field_Text_Input_Ba
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		if ( empty( $value ) ) {
+			return '';
+		}
+
 		$sanitized_value = trim( $value );
 
 		if ( preg_match( '/^post\: *([0-9]+)/', $sanitized_value, $matches ) ) {


### PR DESCRIPTION
`PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in wp-content/plugins/so-widgets-bundle/base/inc/fields/link.class.php on line 54`