### PR TITLE
Social Media Buttons: Resovle Warning

### DIFF
--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -255,12 +255,12 @@ class SiteOrigin_Widget_SocialMediaButtons_Widget extends SiteOrigin_Widget {
 					// If the color wasn't adjusted, use the X colours.
 					if (
 						$network['icon_color'] == '#ffffff' &&
-						$network['icon_color_hover'] == '#ffffff' &&
 						$network['button_color'] == '#78bdf1' &&
+						! empty( $network['icon_color_hover'] ) &&
+						$network['icon_color_hover'] == '#ffffff' &&
+						! empty( $network['button_color_hover'] ) &&
 						$network['button_color_hover'] == '#78bdf1'
 					) {
-						$network['icon_color'] = '#fff';
-						$network['icon_color_hover'] = '#fff';
 						$network['button_color'] = '#000';
 						$network['button_color_hover'] = '#000';
 					}


### PR DESCRIPTION
`PHP message: PHP Warning: Undefined array key “icon_color_hover” in widgets/social-media-buttons/social-media-buttons.php on line 258`

I also removed the `icon_color` and `icon_color_hover` value changes because they're redundent - they're already `#ffffff`.