### PR TITLE
Post Carousel: Prevent Potential `loop_posts` Migration Fatal

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -338,6 +338,10 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 
 		// Migrate settings to the Settings section.
 		if ( isset( $instance['loop_posts'] ) ) {
+			if ( ! is_array( $instance['carousel_settings'] ) ) {
+				$instance['carousel_settings'] = array();
+			}
+
 			$instance['carousel_settings']['loop'] = $instance['loop_posts'];
 			unset( $instance['loop_posts'] );
 		}


### PR DESCRIPTION
`Fatal error: Uncaught TypeError: Cannot access offset of type string on string in so-widgets-bundle/widgets/post-carousel/post-carousel.php:341`