### PR TITLE
Fields: Prevent Potential Error When Saving & Only Filter During Save

### DIFF
--- a/base/inc/fields/base.class.php
+++ b/base/inc/fields/base.class.php
@@ -378,6 +378,10 @@ abstract class SiteOrigin_Widget_Field_Base {
 
 		if (
 			! empty( $value ) &&
+			// Fields can be sanitized for setup purposes during display.
+			// As the data is sanitized during the saving purpose, we can
+			// safely skip this. Not doing so could result in an error.
+			is_user_logged_in() &&
 			! current_user_can( 'unfiltered_html' ) &&
 			! apply_filters( 'siteorigin_widgets_field_allow_unfiltered_html', false )
 		) {


### PR DESCRIPTION
This PR will resolve the following error:

`PHP Fatal error:  Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in wp-includes/blocks.php:1188`