### PR TITLE
Blog: Prevent Any Markup From Outtpung if Pagination is Disabled

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1343,7 +1343,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 			}
 			?>
 			<nav class="sow-post-navigation">
-				<h2 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'so-widgets-bundle' ); ?></h2>
+				<h3 class="screen-reader-text"><?php esc_html_e( 'Pagination', 'so-widgets-bundle' ); ?></h3>
 				<div class="sow-nav-links<?php if ( ! empty( $settings['pagination'] ) ) {
 					echo ' sow-post-pagination-' . esc_attr( $settings['pagination'] );
 				} ?>">


### PR DESCRIPTION
This will prevent a potential accessibility issue with screen readers.