### PR TITLE
Onclick: Add `Calendly` to Allowlist

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -506,6 +506,17 @@ function siteorigin_widget_onclick( $onclick = null, $recursive = true ) {
 
 		// Remove anything not inside of an allowed function.
 		foreach ( $onclick_parts as $part ) {
+			$part = trim( $part );
+
+			// Allow Buttons to prevent the default action.
+			if (
+				$part === 'return false;' ||
+				$part === 'return;'
+			) {
+				$adjusted_onclick .= $part;
+				continue;
+			}
+
 			$function_name = substr( $part, 0, strpos( $part, '(' ) );
 			$function_name = strtolower( trim( $function_name ) );
 			if ( ! isset( $allowed_functions[ $function_name ] ) ) {


### PR DESCRIPTION
This required introducing a case-sensitive disallow for `url` key used Calendly to be allowed. We don't want to allow `URL` due to it potentially being abused. I also added some additional things to the disallow.