### PR TITLE
Video: Resolve Potential FitVids Warning During Migration

### DIFF
--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -315,7 +315,7 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 		}
 
 
-		// Check if 'playback' is not set or not an array
+		// Check if 'playback' is not set or not an array.
 		if ( ! isset( $instance['playback'] ) || ! is_array( $instance['playback'] ) ) {
 			$instance['playback'] = array(
 				'fitvids' => false,


### PR DESCRIPTION
`PHP message: PHP Warning: Illegal string offset 'fitvids' in /wp-content/plugins/so-widgets-bundle/widgets/video/video.php on line 314`

`PHP message: PHP Warning: Cannot assign an empty string to a string offset in /wp-content/plugins/so-widgets-bundle/widgets/video/video.php on line 314`