### PR TITLE
Slider: Resolve Potential FitVids Fatal Error

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -411,6 +411,10 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 			}
 		}
 
+		if ( empty( $instance['controls'] ) ) {
+			$instance['controls'] = array();
+		}
+
 		if ( ! isset( $instance['controls']['fitvids'] ) ) {
 			$instance['controls']['fitvids'] = true;
 		}


### PR DESCRIPTION
`PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in so-widgets-bundle\base\inc\widgets\base-slider.class.php:415`

Triggered while attempting to save a Hero widget in Beaver Builder.