### PR TITLE
Editor: Resolve Potential Noreferrer Empty Text Deprecated Notice

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -152,7 +152,10 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 	}
 
 	public function add_noreferrer_to_link_targets( $instance ) {
-		if ( function_exists( 'wp_targeted_link_rel' ) ) {
+		if (
+			function_exists( 'wp_targeted_link_rel' ) &&
+			! empty( $instance['text'] )
+		) {
 			$instance['text'] = wp_targeted_link_rel( $instance['text'] );
 		}
 


### PR DESCRIPTION
This PR will resolve a deprecated notice when the SiteOrigin Editor widget has a null value.