### PR TITLE
Beaver Builder: Resolve Saving Issue

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -730,7 +730,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 	 *
 	 * @return array|void
 	 */
-	public function update( $new_instance, $old_instance = array(), $form_type = 'widget' ) {
+	public function update( $new_instance, $old_instance, $form_type = 'widget' ) {
 		if ( ! class_exists( 'SiteOrigin_Widgets_Color_Object' ) ) {
 			require plugin_dir_path( __FILE__ ) . 'inc/color.php';
 		}


### PR DESCRIPTION
This PR will resolve a saving issue affecting recent versions of Beaver Builder. To test this PR, add any SiteOrigin Widget and try to make a change. Upon clicking save the change won't be visible in the preview and the settings form will be reset to default.