### PR TITLE
Features: Prevent Misculation With Feature Width

### DIFF
--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -460,7 +460,9 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 			// If two, return the second value. Otherwise, return the first.
 			$feature_gap = explode( ' ', $instance['feature_spacing'] );
 			$feature_gap = count( $feature_gap ) > 1 ? $feature_gap[1] : $feature_gap[0];
-		} else {
+		}
+
+		if ( empty( $feature_gap ) ) {
 			$feature_gap = '25px';
 		}
 


### PR DESCRIPTION
This PR will resolve a situation where the inline Feature item width is miscalculated.

<img width="527" alt="Screenshot 2024-02-28 at 10 59 45" src="https://github.com/siteorigin/so-widgets-bundle/assets/17275120/5d554891-cfca-40dc-afb2-f967a47c188d">
