### PR TITLE
Color Form Field: Resolve `Deprecated`

### DIFF
--- a/base/inc/fields/color.class.php
+++ b/base/inc/fields/color.class.php
@@ -61,6 +61,10 @@ class SiteOrigin_Widget_Field_Color extends SiteOrigin_Widget_Field_Text_Input_B
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		if ( empty( $value ) ) {
+			return false;
+		}
+
 		$sanitized_value = $value;
 		if ( ! empty( $this->alpha ) && strpos( $sanitized_value, 'rgba' ) !== false ) {
 			sscanf( $sanitized_value, 'rgba(%d,%d,%d,%f)', $r, $g, $b, $a );


### PR DESCRIPTION
`[28-Feb-2024 12:38:02 UTC] PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in base\inc\fields\color.class.php on line 76`