### PR TITLE
Post Selector: Resolve deprecated

### DIFF
--- a/base/inc/post-selector.php
+++ b/base/inc/post-selector.php
@@ -32,6 +32,15 @@ function siteorigin_widget_post_selector_process_query( $query, $exclude_current
 		$query['post__in'] = array_map( 'intval', $query['post__in'] );
 	}
 
+	if ( ! empty( $query['post__in'] ) ) {
+		$query['post__in'] = explode( ',', $query['post__in'] );
+		// Filter out empty values to prevent deprecated warnings.
+		$query['post__in'] = array_filter( $query['post__in'], function( $value ) {
+			return ! empty( $value );
+		} );
+		$query['post__in'] = array_map( 'intval', $query['post__in'] );
+	}
+
 	if ( ! empty( $query['tax_query'] ) ) {
 		$tax_queries = explode( ',', $query['tax_query'] );
 


### PR DESCRIPTION
`PHP Deprecated:  intval(): Passing null to parameter #2 ($base) of type int is deprecated in \base\inc\fields\base.class.php on line 383`