### PR TITLE
Contact: Resolve Multibyte Issue Causing Form Not to Submit

### DIFF
--- a/widgets/contact/contact.php
+++ b/widgets/contact/contact.php
@@ -1167,7 +1167,7 @@ class SiteOrigin_Widgets_ContactForm_Widget extends SiteOrigin_Widget {
 		$it = 0;
 
 		$label = str_replace( ' ', '-', strtolower( $label ) );
-		$label = sanitize_html_class( $label );
+		$label = sanitize_title( $label );
 
 		do {
 			$id = $label . ( $it > 0 ? '-' . $it : '' );


### PR DESCRIPTION
Resolved by https://siteorigin.com/thread/issue-with-contact-form-widget/

When giving fields the label `מייל`(Email), the contact form would previously be unable to output a label so the form wouldn't be able to submit correctly. This PR corrects that.