### PR TITLE
Widgets Block: Prevent Empty Needle

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -66,9 +66,14 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				// The last class will always be from the widget file we just loaded.
 				$classes = get_declared_classes();
 				$widget_class = end( $classes );
-				// For SiteOrigin widgets, just display the widget's name. For third party widgets, display the Author
-				// to try avoid confusion when the widgets have the same name.
-				if ( $widget['Author'] != 'SiteOrigin' && strpos( $widget['Name'], $widget['Author'] ) === false ) {
+
+				// Append author's name to third-party widget names, if not already
+				// present, to help distinguish widgets with similar names.
+				if (
+					! empty( $widget['Author'] ) &&
+					$widget['Author'] != 'SiteOrigin' &&
+					strpos( $widget['Name'], $widget['Author'] ) === false
+				) {
 					$widget_name = sprintf( __( '%s by %s', 'so-widgets-bundle' ), $widget['Name'], $widget['Author'] );
 				} else {
 					$widget_name = $widget['Name'];


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/empty-needle-message-because-of-updated-site-origin-widgets-bundle-plug-in/)