### PR TITLE
Number Field: Account for potential null `abs` value

### DIFF
--- a/base/inc/fields/number.class.php
+++ b/base/inc/fields/number.class.php
@@ -79,11 +79,11 @@ class SiteOrigin_Widget_Field_Number extends SiteOrigin_Widget_Field_Text_Input_
 			$value = max( $value, $this->min );
 		}
 
-		if ( ! empty( $this->max ) ) {
+		if ( ! empty( $this->max ) && ! empty( $value ) ) {
 			$value = min( $value, $this->max );
 		}
 
-		if ( ! empty( $this->abs ) ) {
+		if ( ! empty( $this->abs ) && ! empty( $value ) ) {
 			$value = abs( $value );
 		}
 


### PR DESCRIPTION
`PHP Deprecated:  abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in base/inc/widgets/base-carousel.class.php on line 443`