### PR TITLE
Fields: Ensure `$value` isn't null before processing it

### DIFF
--- a/base/inc/fields/base.class.php
+++ b/base/inc/fields/base.class.php
@@ -348,13 +348,13 @@ abstract class SiteOrigin_Widget_Field_Base {
 	 * @return mixed|string
 	 */
 	public function sanitize( $value, $instance = array(), $old_value = null ) {
-		$value = $this->sanitize_field_input( $value, $instance );
-
 		if ( empty( $value ) ) {
 			return '';
 		}
 
-		if ( isset( $this->sanitize ) ) {
+		$value = $this->sanitize_field_input( $value, $instance );
+
+		if ( isset( $this->sanitize ) && ! empty( $value ) ) {
 			// This field also needs some custom sanitization
 			switch( $this->sanitize ) {
 				case 'text':


### PR DESCRIPTION
`PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in wp-includes\kses.php on line 1745`

Unsure of the specific setting combination required to trigger this. I suspect it's related to the Text field. Hard to be sure though.