### PR TITLE
Fields Sanitize: Keep `0`

### DIFF
--- a/base/inc/fields/base.class.php
+++ b/base/inc/fields/base.class.php
@@ -348,7 +348,7 @@ abstract class SiteOrigin_Widget_Field_Base {
 	 * @return mixed|string
 	 */
 	public function sanitize( $value, $instance = array(), $old_value = null ) {
-		if ( empty( $value ) ) {
+		if ( $value === '' || is_null( $value ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/form-building-slider-does-not-save-zero-value-an-more/)

To test this PR, add the following to [the previous line](https://github.com/siteorigin/so-widgets-bundle/blob/develop/widgets/editor/editor.php#L30):

```
'test' => array(
	'name' => __( 'Test', 'so-widgets-bundle' ),
	'type' => 'slider',
	'max' => 6,
	'min' => 0,
	'default' => 0,
),
```
