### PR TITLE
Anything Carousel: Prevent Potential Design Warning

### DIFF
--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -251,7 +251,7 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 	}
 
 	public function get_less_variables( $instance ) {
-		if ( empty( $instance ) ) {
+		if ( empty( $instance ) || empty( $instance['design'] ) ) {
 			return array();
 		}
 


### PR DESCRIPTION
`PHP Warning: Undefined array key "design" in widgets\anything-carousel\anything-carousel.php on line 259`

Unclear how this was triggered.