### PR TITLE
Sliders: Remove % Height Unit

### DIFF
--- a/widgets/hero/hero.php
+++ b/widgets/hero/hero.php
@@ -45,6 +45,9 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	public function get_widget_form() {
+		$units = siteorigin_widgets_get_measurements_list();
+		unset( $units[1] ); // Remove %;
+
 		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
@@ -211,6 +214,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 							'height' => array(
 								'type' => 'measurement',
 								'label' => __( 'Height', 'so-widgets-bundle' ),
+								'units' => $units,
 							),
 
 							'padding' => array(
@@ -246,6 +250,7 @@ class SiteOrigin_Widget_Hero_Widget extends SiteOrigin_Widget_Base_Slider {
 							'height_responsive' => array(
 								'type' => 'measurement',
 								'label' => __( 'Height', 'so-widgets-bundle' ),
+								'units' => $units,
 							),
 
 							'padding' => array(

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -34,6 +34,9 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 	public function get_widget_form() {
 		$show_heading_fields = apply_filters( 'sow_layout_slider_show_heading_fields', false );
 
+		$units = siteorigin_widgets_get_measurements_list();
+		unset( $units[1] ); // Remove %;
+
 		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
@@ -154,6 +157,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 							'height' => array(
 								'type' => 'measurement',
 								'label' => __( 'Height', 'so-widgets-bundle' ),
+								'units' => $units,
 							),
 
 							'padding' => array(
@@ -189,6 +193,7 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 							'height_responsive' => array(
 								'type' => 'measurement',
 								'label' => __( 'Height', 'so-widgets-bundle' ),
+								'units' => $units,
 							),
 
 							'padding' => array(

--- a/widgets/slider/slider.php
+++ b/widgets/slider/slider.php
@@ -29,6 +29,9 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 	}
 
 	public function get_widget_form() {
+		$units = siteorigin_widgets_get_measurements_list();
+		unset( $units[1] ); // Remove %;
+
 		return parent::widget_form( array(
 			'frames' => array(
 				'type' => 'repeater',
@@ -130,11 +133,13 @@ class SiteOrigin_Widget_Slider_Widget extends SiteOrigin_Widget_Base_Slider {
 					'height' => array(
 						'type' => 'measurement',
 						'label' => __( 'Height', 'so-widgets-bundle' ),
+						'units' => $units,
 					),
 
 					'height_responsive' => array(
 						'type' => 'measurement',
 						'label' => __( 'Responsive Height', 'so-widgets-bundle' ),
+						'units' => $units,
 					),
 				),
 			),


### PR DESCRIPTION
% doesn't work in the way people think it does, so most usage of this isn't doing anything. Best to suggest viewport based units (which does work in the way people think % does) or px.