### PR TITLE
Blog: Fix Default Post Content Font Size

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -386,7 +386,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 								'font_size' => array(
 									'type' => 'measurement',
 									'label' => __( 'Font Size', 'so-widgets-bundle' ),
-									'default' => '15',
+									'default' => '15px',
 								),
 								'color' => array(
 									'type' => 'color',


### PR DESCRIPTION
This PR fixes the default content font size. Previously it would be output as an invalid property value so the content font size wouldn't change.