### PR TITLE
Video oEmbed: Ensure Video is Able to be Fullscreen

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -90,9 +90,8 @@ class SiteOrigin_Video {
 				), $html );
 			}
 
-
 			// Ensure the embed is able to go fullscreen.
-			$html = preg_replace('/<iframe(.*?)>/', '<iframe$1 allowfullscreen mozallowfullscreen webkitallowfullscreen>', $html);
+			$html = preg_replace( '/<iframe(.*?)>/', '<iframe$1 allowfullscreen mozallowfullscreen webkitallowfullscreen>', $html );
 
 			if ( ! empty( $html ) ) {
 				set_transient( 'sow-vid-embed[' . $hash . ']', $html, 30 * 86400 );


### PR DESCRIPTION
[Related](https://help.vimeo.com/hc/en-us/articles/12425790245777-Troubleshoot-Fullscreen-button-missing-from-the-player)