### PR TITLE
Add Missing Author for SO Widgets

### DIFF
--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -2,6 +2,7 @@
 /*
 Widget Name: Editor
 Description: Insert and customize content with a rich text editor offering extensive formatting options.
+Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/editor-widget/
 */

--- a/widgets/social-media-buttons/social-media-buttons.php
+++ b/widgets/social-media-buttons/social-media-buttons.php
@@ -2,6 +2,7 @@
 /*
 Widget Name: Social Media Buttons
 Description: Add social media buttons to your site with personalized icons, colors, and design settings.
+Author: SiteOrigin
 Author URI: https://siteorigin.com
 Documentation: https://siteorigin.com/widgets-bundle/social-media-buttons-widget/
 */


### PR DESCRIPTION
This will resolve a display issue in the SiteOrigin Widgets Block where the widget will be listed as "SiteOrigin Editor By" rather than SiteOrigin Editor.