### PR TITLE
Prevent Multiple Blog Widgets from "stacking" pagination.

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1369,6 +1369,8 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 				$show_all_prev_next = false;
 			}
 
+			wp_reset_query();
+
 			$pagination_markup = paginate_links( array(
 				'format' => '?sow-' . $instance['paged_id'] . '=%#%',
 				'total' => $posts->max_num_pages,
@@ -1377,6 +1379,8 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 				'prev_next' => ! $show_all_prev_next,
 				'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
 				'next_text' => is_rtl() ? '&larr;' : '&rarr;',
+				// Prevent Multiple Blog Widgets from "stacking" pagination.
+				'base' => get_the_permalink() . '%_%',
 			) );
 		}
 


### PR DESCRIPTION
This PR will prevent a situation where multiple Blog widgets on a page will stack their unique paginations.

This would end up looking like this:

> https://so.test/?sow-3ec9bf21a7c7=2&sow-bad24c91a795=2&sow-fcc59ee223ae=3

This PR will restrict it to one pagination instance at a time.