### PR TITLE
Post Carousel: Load Carousel Theme CSS when using Block Themes

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -180,10 +180,8 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 	public function get_style_name( $instance ) {
 		$theme = self::get_theme( $instance );
 
-		// If this theme has a dedicated stylesheet load it.
-		if ( wp_style_is( 'sow-post-carousel-' . $theme, 'registered' ) ) {
-			wp_enqueue_style( 'sow-post-carousel-' . $theme );
-		}
+		// Try to load carousel theme stylesheet.
+		wp_enqueue_style( 'sow-post-carousel-' . $theme );
 
 		return $theme;
 	}


### PR DESCRIPTION
This will resolve the display issues with the Post Carousel when added to a website using a Block Theme. For example, it'll allow for the Post Featured Image to appear correctly.