### PR TITLE
Fix Notice: Function _load_textdomain_just_in_time

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -13,6 +13,10 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 	}
 
 	public function __construct() {
+		add_action( 'init' , array( $this, 'init' ) );
+	}
+
+	public function init() {
 		$builder = $this->get_active_builder();
 
 		if ( ! empty( $builder ) ) {
@@ -30,6 +34,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			add_action( 'siteorigin_widgets_stylesheet_cleared', array( $this, 'clear_all_cache' ) );
 		}
 
+		// Compatibility with AMP plugin.
 		if (
 			function_exists( 'amp_is_enabled' ) &&
 			amp_is_enabled()
@@ -45,10 +50,7 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 			} );
 		}
 
-		add_action( 'init' , array( $this, 'init' ) );
-	}
-
-	public function init() {
+		// Compatibility with WooCommerce.
 		if ( function_exists( 'WC' ) ) {
 			add_filter( 'woocommerce_format_content', array( $this, 'woocommerce_shop_page_content' ), 10, 2 );
 		}

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -59,7 +59,7 @@ class SiteOrigin_Widgets_Bundle {
 		add_action( 'wp_ajax_so_widgets_setting_save', array( $this, 'admin_ajax_settings_save' ) );
 
 		// Initialize the widgets, but do it fairly late.
-		add_action( 'plugins_loaded', array( $this, 'set_plugin_textdomain' ), 1 );
+		add_action( 'init', array( $this, 'set_plugin_textdomain' ), 10, 0 );
 		add_action( 'after_setup_theme', array( $this, 'get_widget_folders' ), 11 );
 		add_action( 'after_setup_theme', array( $this, 'load_widget_plugins' ), 11 );
 
@@ -1042,6 +1042,14 @@ class SiteOrigin_Widgets_Bundle {
 // Create the initial single.
 SiteOrigin_Widgets_Bundle::single();
 
-// Initialize the Meta Box Manager.
-global $sow_meta_box_manager;
-$sow_meta_box_manager = SiteOrigin_Widget_Meta_Box_Manager::single();
+// Initialize the Meta Box Manager. This is required to prevent a WP 6.7 notice.
+$sow_meta_box_manager = null;
+function siteorigin_widgets_load_meta_box_manager() {
+	global $sow_meta_box_manager;
+
+	// Confirm we haven't already set up the Meta Box Manager.
+	if ( ! is_a( $sow_meta_box_manager, 'SiteOrigin_Widget_Meta_Box_Manager' ) ) {
+		$sow_meta_box_manager = SiteOrigin_Widget_Meta_Box_Manager::single();
+	}
+}
+add_action( 'init', 'siteorigin_widgets_load_meta_box_manager' );


### PR DESCRIPTION
This notice occurred when logging in for me. Strangely, it didn't happen during RC1 testing.

`Notice: Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>so-widgets-bundle</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in C:\laragon\www\snapshot\wp-includes\functions.php on line 6114`