### PR TITLE
Font Field Saving: Ensure Font is Valid, otherwise use default or clear

### DIFF
--- a/base/inc/fields/font.class.php
+++ b/base/inc/fields/font.class.php
@@ -5,13 +5,6 @@
  */
 class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 
-	/**
-	 * Whether to default to $this->default when saving the field if the value is empty.
-	 *
-	 * @var int
-	 */
-	protected $use_default_if_empty = false;
-
 	protected function render_field( $value, $instance ) {
 		static $widget_font_families;
 
@@ -37,6 +30,7 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 		}
 
 		$sanitized_value = trim( $value );
+
 		// Any alphanumeric character followed by alphanumeric or whitespace characters (except newline),
 		// with optional colon followed by optional variant.
 		if ( preg_match( '/[\w\d]+[\w\d\t\r ]*(:\w+)?/', $sanitized_value, $sanitized_matches ) ) {
@@ -50,9 +44,12 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 		if ( empty( $widget_font_families ) ) {
 			$widget_font_families = siteorigin_widgets_font_families();
 		}
-		$keys = array_keys( $widget_font_families );
 
-		if ( ! in_array( $sanitized_value, $keys ) && $this->use_default_if_empty ) {
+		// If selected font isn't set to default, ensure the font is valid.
+		if (
+			$sanitized_value !== 'default' &&
+			! isset( $widget_font_families[ $sanitized_value ] )
+		) {
 			$sanitized_value = isset( $this->default ) ? $this->default : 'default';
 		}
 


### PR DESCRIPTION
This PR will allow for font fields that have a default to be cleared (previously would change the value to default when selecting theme default), and it'll add additional validation to ensure a valid font when saving.