### PR TITLE
Trigger PB Row Stretch on Tab/Accordion Open

### DIFF
--- a/widgets/accordion/js/accordion.js
+++ b/widgets/accordion/js/accordion.js
@@ -52,6 +52,7 @@ jQuery( function ( $ ) {
 								scrollToPanel( $panel, true );
 							}
 							$( this ).trigger( 'show' );
+							$( window ).trigger( 'panelsStretchRows' );
 						}
 					});
 					$panel.find(  '> .sow-accordion-panel-header-container > .sow-accordion-panel-header' ).attr( 'aria-expanded', true );

--- a/widgets/tabs/js/tabs.js
+++ b/widgets/tabs/js/tabs.js
@@ -91,6 +91,8 @@ jQuery( function ( $ ) {
 									if ( preventHashChange || shouldScroll( $tab ) ) {
 										scrollToTab( true );
 									}
+
+									$( window ).trigger( 'panelsStretchRows' );
 								}
 							});
 						}


### PR DESCRIPTION
This will prevent a situation where a Full Width Stretched row won't be stretched correctly.