### PR TITLE
Post Carousel: Fix Navigation Arrows Outputting When `Autoplay Continuous Scroll` enabled.

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -441,7 +441,7 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 
 		$carousel_settings = $this->carousel_settings_template_variables( $instance['carousel_settings'], false );
 		$carousel_settings['autoplay_continuous_scroll'] = ! empty( $instance['carousel_settings']['autoplay_continuous_scroll'] ) ? $instance['carousel_settings']['autoplay_continuous_scroll'] : false;
-		// The base theme doesn't support dot noviation so let's remove it.
+		// The base theme doesn't support dot navigation so let's remove it.
 		if ( $theme == 'base' ) {
 			unset( $carousel_settings['dots'] );
 		}


### PR DESCRIPTION
This PR fixes the output of the navigation arrows and prevents the Navigation Arrows setting from being shown when the `Autoplay Continuous Scroll` setting is enabled. This setting completely controls navigation so the arrows are intended to be hidden.