### PR TITLE
Improve Page Builder Detection For Layout Slider & Builder Form Field

### DIFF
--- a/base/base.php
+++ b/base/base.php
@@ -350,6 +350,36 @@ function siteorigin_widgets_url( $path = '' ) {
 	return plugins_url( 'so-widgets-bundle/' . $path );
 }
 
+/**
+ * Check if the Page Builder can render.
+ *
+ * This method checks if the necessary conditions are met for Page Builder to
+ * render. It first verifies that Page Builder is active. It then checks
+ * if either:
+ * - The request is in the admin area, OR
+ * - If this is a REST request and the block editor is active.
+ *
+ * If none of these conditions are met, Page Builder can't render.
+ *
+ * @return bool True if Page Builder builder can render, false otherwise.
+ */
+function siteorigin_widgets_can_render_builder_field() {
+	if ( ! defined( 'SITEORIGIN_PANELS_VERSION' ) ) {
+		return false;
+	}
+
+	if ( is_admin() ) {
+		return true;
+	}
+
+	// Is this field being rendered inside one of our blocks?
+	if ( defined( 'REST_REQUEST' ) && function_exists( 'register_block_type' ) ) {
+		return true;
+	}
+
+	return false;
+}
+
 function siteorigin_loading_optimization_attributes( $attr, $widget, $instance, $class ) {
 	// Allow other plugins to override whether this widget is lazy loaded or not.
 	if (

--- a/base/inc/fields/builder.class.php
+++ b/base/inc/fields/builder.class.php
@@ -6,45 +6,47 @@
  * Class SiteOrigin_Widget_Field_Builder
  */
 class SiteOrigin_Widget_Field_Builder extends SiteOrigin_Widget_Field_Base {
-	protected function render_field( $value, $instance ) {
-		if ( defined( 'SITEORIGIN_PANELS_VERSION' ) ) {
-			// Normal rendering code
-			// In some contexts this is already encoded, e.g. accordion widget using a layout field for content,
-			// inside a PB block in the block editor.
-			$valid_string = is_string( $value ); // Required for PHP <5.4
 
-			if ( empty( $valid_string ) ) {
-				$value = json_encode( $value );
-			}
-			?>
-			<div
-				class="siteorigin-page-builder-field"
-				data-mode="dialog"
-				data-type="<?php echo isset( $this->field_options['builder_type'] ) ? esc_attr( $this->field_options['builder_type'] ) : 'sow-builder-field'; ?>"
-				>
-				<p>
-					<button class="button-secondary siteorigin-panels-display-builder">
-						<?php esc_html_e( 'Open Builder', 'so-widgets-bundle' ); ?>
-					</button>
-				</p>
-				<input
-					type="hidden"
-					class="siteorigin-widget-input panels-data"
-					value="<?php echo sow_esc_attr( $value, ENT_QUOTES, false, true ); ?>"
-					name="<?php echo esc_attr( $this->element_name ); ?>"
-					id="<?php echo esc_attr( $this->element_id ); ?>"
-					/>
-			</div>
-			<?php
-		} else {
-			// Let the user know that they need Page Builder installed
+	protected function render_field( $value, $instance ) {
+		if ( ! siteorigin_widgets_can_render_builder_field() ) {
 			?>
 			<p>
-				<?php _e( 'This field requires: ', 'so-widgets-bundle' ); ?>
-				<a href="https://siteorigin.com/page-builder/" target="_blank" rel="noopener noreferrer"><?php _e( 'SiteOrigin Page Builder', 'so-widgets-bundle' ); ?></a>
+				<?php
+				printf(
+					esc_html__( 'This field requires %sSiteOrigin Page Builder%s to be installed and activated.', 'so-widgets-bundle' ),
+					'<a href="https://siteorigin.com/page-builder/" target="_blank" rel="noopener noreferrer">',
+					'</a>'
+				);
+				?>
 			</p>
 			<?php
+			return;
 		}
+
+		// Encode builder data if necessary.
+		if ( ! empty( $value ) && is_array( $value ) ) {
+			$value = json_encode( $value );
+		}
+		?>
+		<div
+			class="siteorigin-page-builder-field"
+			data-mode="dialog"
+			data-type="<?php echo isset( $this->field_options['builder_type'] ) ? esc_attr( $this->field_options['builder_type'] ) : 'sow-builder-field'; ?>"
+			>
+			<p>
+				<button class="button-secondary siteorigin-panels-display-builder">
+					<?php esc_html_e( 'Open Builder', 'so-widgets-bundle' ); ?>
+				</button>
+			</p>
+			<input
+				type="hidden"
+				class="siteorigin-widget-input panels-data"
+				value="<?php echo sow_esc_attr( (string) $value, ENT_QUOTES, false, true ); ?>"
+				name="<?php echo esc_attr( $this->element_name ); ?>"
+				id="<?php echo esc_attr( $this->element_id ); ?>"
+				/>
+		</div>
+		<?php
 	}
 
 	/**

--- a/widgets/layout-slider/layout-slider.php
+++ b/widgets/layout-slider/layout-slider.php
@@ -260,17 +260,41 @@ class SiteOrigin_Widget_LayoutSlider_Widget extends SiteOrigin_Widget_Base_Slide
 		) );
 	}
 
-	public function form( $instance, $form_type = 'widget' ) {
-		if ( ( is_admin() || ( defined( 'REST_REQUEST' ) && function_exists( 'register_block_type' ) ) ) && defined( 'SITEORIGIN_PANELS_VERSION' ) ) {
-			parent::form( $instance, $form_type );
-		} else {
-			?>
-			<p>
-				<?php _e( 'This widget requires: ', 'so-widgets-bundle' ); ?>
-				<a href="https://siteorigin.com/page-builder/" target="_blank" rel="noopener noreferrer"><?php _e( 'SiteOrigin Page Builder', 'so-widgets-bundle' ); ?></a>
-			</p>
-			<?php
+
+	private static function can_render() {
+		if ( ! defined( 'SITEORIGIN_PANELS_VERSION' ) ) {
+			return false;
 		}
+
+		if ( is_admin() ) {
+			return true;
+		}
+
+		// Is this field being rendered inside one of our blocks?
+		if ( defined( 'REST_REQUEST' ) && function_exists( 'register_block_type' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public function form( $instance, $form_type = 'widget' ) {
+		if ( siteorigin_widgets_can_render_builder_field() ) {
+			parent::form( $instance, $form_type );
+			return;
+		}
+		?>
+
+		<p>
+			<?php
+			printf(
+				esc_html__( 'This widget requires %sSiteOrigin Page Builder%s to be installed and activated.', 'so-widgets-bundle' ),
+				'<a href="https://siteorigin.com/page-builder/" target="_blank" rel="noopener noreferrer">',
+				'</a>'
+			);
+			?>
+		</p>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
This PR also resolves the `UnsafePrintingFunction` report in the widget and form field files.

To test this PR:
- Deactivate Page Builder.
- Open the Block Editor, and add a SiteOrigin Widgets Block.
- Set the widget to Layout Slider, and then inspect the error.

If the message appears, the change worked as expected.