### PR TITLE
Move SiteOrigin_Widget_GoogleMap_Widget configuration from siteorigin-panels

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,4 +1,10 @@
 <wpml-config>
+  <admin-texts>
+    <key name="so_widget_settings[SiteOrigin_Widget_GoogleMap_Widget]">
+      <key name="map_consent_btn_text" />
+      <key name="map_consent_notice" />
+    </key>
+  </admin-texts>
   <gutenberg-blocks>
     <gutenberg-block type="sowb/widget-block" translate="1">
       <key name="widgetData">
@@ -432,11 +438,6 @@
       <fields-in-item items_of="columns>features">
         <field type="Feature text">text</field>
         <field type="Feature hover text">hover</field>
-      </fields-in-item>
-    </widget>
-    <widget name="SiteOrigin_Widget_GoogleMap_Widget">
-      <fields-in-item items_of="markers>marker_positions">
-        <field type="Map marker info" editor_type="VISUAL">info</field>
       </fields-in-item>
     </widget>
   </siteorigin-widgets>


### PR DESCRIPTION
This commit removes duplicate configuration for the SiteOrigin_Widget_GoogleMap_Widget widget.

It also sets a couple of admin texts for translation.