### PR TITLE
Block Editor Select: Prevent Text From Touching Chevron

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -1037,7 +1037,11 @@ div.siteorigin-widget-form {
 			box-shadow: none;
 			color: #2c3338;
 			font-size: 14px;
-			padding: 0 8px;
+			padding: 0 24px 0 8px;
+
+			&[multiple] {
+				padding: 0 8px;
+			}
 
 			/* 5.7.2 .wp-core-ui select styling */
 			-webkit-appearance: none;


### PR DESCRIPTION
This PR prevents the following result, and brings the spacing of the select field (when not multiple) in line with the Classic Editor.

![image](https://github.com/user-attachments/assets/d393567a-e494-4a80-a449-82eebaef9841)
