### PR TITLE
Blog: Resolve undefined `post_type`

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -954,8 +954,9 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	public static function get_query_terms( $instance, $query, $post_id = 0 ) {
 		$terms = array();
 
+		$query['post_type'] = ! empty( $query['post_type'] ) ? $query['post_type'] : array( 'post' );
+
 		if ( ! empty( $post_id ) ) {
-			$query['post_type'] = ! empty( $query['post_type'] ) ? $query['post_type'] : array( 'post' );
 
 			// Check if a developer has set terms for this post type.
 			$taxonomy = apply_filters(


### PR DESCRIPTION
This PR adds a fallback (post) if no post type is selected.

`[11-Jan-2025 13:44:37 UTC] PHP Warning:  Undefined array key "post_type" in widgets\blog\blog.php on line 1009`