### PR TITLE
Blog: Reset `Filter Categories` Setting if Template Doesn't Support it

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -204,7 +204,6 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 						'filter_categories' => array(
 							'type' => 'checkbox',
 							'label' => __( 'Filter Categories ', 'so-widgets-bundle' ),
-							'default' => true,
 							'state_emitter' => array(
 								'callback' => 'conditional',
 								'args' => array(
@@ -1158,6 +1157,15 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		}
 
 		$instance['paged_id'] = $this->get_style_hash( $instance );
+
+		// Ensure Filter Categories is disabled for templates that
+		// don't support it.
+		if (
+			$instance['template'] !== 'portfolio' &&
+			$instance['template'] !== 'masonry'
+		) {
+			$instance['settings']['filter_categories'] = false;
+		}
 
 		return $instance;
 	}

--- a/widgets/blog/data/templates.json
+++ b/widgets/blog/data/templates.json
@@ -12,7 +12,8 @@
 				"categories": true,
 				"tags": false,
 				"comment_count": true,
-				"featured_image_size": "full"
+				"featured_image_size": "full",
+				"filter_categories": false
 			},
 			"design": {
 				"post":{
@@ -72,7 +73,8 @@
 				"categories": true,
 				"tags": false,
 				"comment_count": true,
-				"featured_image_size": "sow-blog-grid"
+				"featured_image_size": "sow-blog-grid",
+				"filter_categories": false
 			},
 			"design": {
 				"post":{
@@ -131,7 +133,8 @@
 				"categories": true,
 				"tags": false,
 				"comment_count": true,
-				"featured_image_size": "full"
+				"featured_image_size": "full",
+				"filter_categories": false
 			},
 			"design": {
 				"post":{
@@ -157,7 +160,7 @@
 					"link_color": "#2d2d2d",
 					"link_color_hover": "#f14e4e",
 					"link_font_size": "14"
-				},				
+				},
 				"content":{
 					"color": "#626262",
 					"color_hover": "",
@@ -198,7 +201,8 @@
 				"categories": true,
 				"tags": false,
 				"comment_count": true,
-				"featured_image_size": "sow-blog-alternate"
+				"featured_image_size": "sow-blog-alternate",
+				"filter_categories": false
 			},
 			"design": {
 				"post":{
@@ -258,7 +262,8 @@
 				"categories": true,
 				"tags": false,
 				"comment_count": true,
-				"featured_image_size": "full"
+				"featured_image_size": "full",
+				"filter_categories": false
 			},
 			"design": {
 				"post":{
@@ -317,7 +322,7 @@
 			"settings": {
 				"content": "full",
 				"columns": 3,
-				"filter_categories": "true",
+				"filter_categories": true,
 				"categories": true,
 				"featured_image_size": "sow-blog-portfolio"
 			},


### PR DESCRIPTION
This PR will prevent a potential situation where the filter categories design section may appear for templates that don't support filter categories .