### PR TITLE
Prevent Admin Aside area From Being Stuck

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -381,16 +381,19 @@ var sowbForms = window.sowbForms || {};
 				if ( e.type == 'keyup' && ! sowbForms.isEnter( e ) ) {
 					return;
 				}
-				$(this).toggleClass('siteorigin-widget-section-visible');
-				$(this).parent().find('> .siteorigin-widget-section, > .siteorigin-widget-widget > .siteorigin-widget-section')
-					.slideToggle( 'fast', function() {
-						$( this ).find( '> .siteorigin-widget-field-container-state' ).val( $( this ).is( ':visible' ) ? 'open' : 'closed');
 
-						if ( $( this ).is( ':visible' ) ) {
-							var $fields = $( this ).find( '> .siteorigin-widget-field' );
-							$fields.trigger( 'sowsetupformfield' );
-						}
-					} );
+				const $this = $( this );
+				$this.toggleClass( 'siteorigin-widget-section-visible' );
+				const $section = $this.parent().find( '> .siteorigin-widget-section, > .siteorigin-widget-widget > .siteorigin-widget-section' );
+
+				$section.slideToggle( 'fast', function() {
+					const $thisSection = $( this );
+					$thisSection.find( '> .siteorigin-widget-field-container-state' ).val( $thisSection.is( ':visible' ) ? 'open' : 'closed' );
+
+					if ( $thisSection.is( ':visible' ) ) {
+						$thisSection.find( '> .siteorigin-widget-field' ).trigger( 'sowsetupformfield' );
+					}
+				} );
 			};
 			$fields.filter( '.siteorigin-widget-field-type-widget, .siteorigin-widget-field-type-section' ).find( '> label' )
 			.on( 'click keyup', expandContainer )


### PR DESCRIPTION
This PR resolves [this Page Builder issue](https://github.com/siteorigin/siteorigin-panels/issues/845). This issue occurs when a resize event is triggered on the window, and Sortable (what's used to re-order metaboxes) sets the aside sidebar to `position: fixed;` with `bottom` set to `0`. Why it does that isn't clear, but it can be avoided by simply not triggering a resize. I can't see any immediate downsides to not doing this, but I'll keep an eye out for any.