### PR TITLE
Section Defaults: Resolve TypeError

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -410,9 +410,14 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 					}
 				}
 			} elseif ( $field['type'] == 'section' ) {
+				if ( empty( $instance ) ) {
+					$instance = array();
+				}
+
 				if ( empty( $instance[ $id ] ) ) {
 					$instance[ $id ] = array();
 				}
+
 				$instance[ $id ] = $this->add_defaults( $field['fields'], $instance[ $id ], $level + 1 );
 			} elseif ( $field['type'] == 'measurement' ) {
 				if ( ! isset( $instance[ $id ] ) ) {


### PR DESCRIPTION
`PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in base\siteorigin-widget.class.php:418`

I got this error when viewing [this layout](https://drive.google.com/uc?id=1gX0vdZNxYwGcYJwYMp6mUHWX1jSa0hON) on the frontend.