### PR TITLE
Image: Prevent Empty `img`

### DIFF
--- a/widgets/image/tpl/default.php
+++ b/widgets/image/tpl/default.php
@@ -9,9 +9,12 @@
  * @var $attributes
  * @var $classes
  */
-?>
 
-<?php
+// Don't output an empty image.
+if ( empty( $attributes['src'] ) ) {
+	return;
+}
+
 if ( $title_position == 'above' ) {
 	echo $args['before_title'];
 


### PR DESCRIPTION
To test this PR, compare the result of a SiteOrigin Image widget with and without an image set. Prior to this PR, the `img` would still be output.