### PR TITLE
Post/Card Carousel: Fix Second Dot Not Working

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -430,7 +430,7 @@ jQuery( function ( $ ) {
 					} else {
 						if ( $$.data( 'widget' ) == 'post' ) {
 							// We need to account for an empty item.
-							targetItem = Math.ceil( $( this ).index() * slidesToScroll );
+							targetItem = Math.ceil( targetItem + 1 * slidesToScroll );
 						}
 						$items.navigateToSlide( targetItem );
 					}


### PR DESCRIPTION
This fixes the Card Carousel and Post Carousel set to Overlay theme second dot navigation item not working.