### PR TITLE
Cards/Post Carousel: Trigger Resize after New Posts are Loaded and Dot Navigation

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -483,8 +483,8 @@ jQuery( function ( $ ) {
 				} );
 
 				// Setup Slick Dot Navigation again when new posts are added.
-				$( sowb ).on( 'carousel_posts_added', function() {
-					const $$ = $( this );
+				$( sowb ).on( 'carousel_posts_added', function( e, carousel) {
+					const $$ = $( carousel );
 					const $dots = $$.find( '.slick-dots li' );
 
 					if ( $dots ) {

--- a/widgets/post-carousel/js/script.js
+++ b/widgets/post-carousel/js/script.js
@@ -44,7 +44,7 @@ jQuery( function ( $ ) {
 					$items.find( '.sow-carousel-item[tabindex="0"]' ).trigger( 'focus' );
 				}
 
-				$( sowb ).trigger( 'carousel_posts_added' );
+				$( sowb ).trigger( 'carousel_posts_added', carousel );
 			}
 		);
 	} );


### PR DESCRIPTION
This PR will ensure carousel items are resized after new posts are loaded, and after navigating using the dot navigation.

While testing, please also run some responsive tests by resizing the window. A small delay before the resize occurs is expected during resize.