### PR TITLE
Add `siteorigin_widgets_backup` To Allow Widget Backups To Be Disabled

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -233,7 +233,10 @@ var sowbForms = window.sowbForms || {};
 					});
 				});
 
-				if ( ! $el.data( 'backupDisabled' ) ) {
+				if (
+					soWidgets.backup.enabled &&
+					! $el.data( 'backupDisabled' )
+				) {
 					var _sow_form_id = $el.find( '> .siteorigin-widgets-form-id' ).val();
 					var $timestampField = $el.find( '> .siteorigin-widgets-form-timestamp' );
 					var _sow_form_timestamp = parseInt( $timestampField.val() || 0 );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -681,6 +681,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 					'actions' => __( 'Actions', 'so-widgets-bundle' ),
 				),
 				'backup' => array(
+					'enabled' => apply_filters( 'siteorigin_widgets_backup', true ),
 					'newerVersion' => __( "There is a newer version of this widget's content available.", 'so-widgets-bundle' ),
 					'restore' => __( 'Restore', 'so-widgets-bundle' ),
 					'dismiss' => __( 'Dismiss', 'so-widgets-bundle' ),


### PR DESCRIPTION
`add_filter( 'siteorigin_widgets_backup', '__return_false' );` can be used to disable it.