### PR TITLE
Widget Block: Ensure Widget Widget has Block Name Before Attempting to Register It

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -509,6 +509,11 @@
 			return;
 		}
 
+		// Don't register any blocks that don't have a blockName.
+		if ( ! widget.blockName ) {
+			return;
+		}
+
 		registerBlockType( 'sowb/' + widget.blockName, {
 			title: widget.name,
 			description: widget.description,


### PR DESCRIPTION
This PR will prevent the following potential console notice:

![image](https://github.com/user-attachments/assets/b4bb264d-b7f7-458e-baf4-22dc452165ed)
