### PR TITLE
Section Form Field: Set Font Size To Prevent Override in Twenty Twenty

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -634,10 +634,11 @@ div.siteorigin-widget-form {
 			> label {
 				background: #f0f0f0;
 				border: 1px solid #d0d0d0;
-				line-height: 1.4;
-				padding: 10px;
 				display: block;
+				font-size: 13px;
+				line-height: 1.4;
 				margin-bottom: 0;
+				padding: 10px;
 
 				&:focus {
 					background: #f5f5f5;


### PR DESCRIPTION
This PR will require a build to test.

![A screenshot of the a form with incorrect section font size](https://github.com/user-attachments/assets/e673bc5e-7209-44d9-a8e9-03152dc930b8)
