### PR TITLE
Prevent Legacy Block From Being Added Manually

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -634,6 +634,9 @@
 				type: 'boolean',
 			}
 		},
+		supports: {
+			inserter: false,
+		},
 		icon: function() {
 			return el(
 				'span',


### PR DESCRIPTION
This will prevent the SiteOrigin Widgets Block ([which is now a legacy block](https://siteorigin.com/smarter-blocks-smoother-workflow-individual-siteorigin-widget-blocks-arrive/)) from showing up in searches and block insert screens.