### PR TITLE
Contact: Remove Unused Form ID Field

### DIFF
--- a/widgets/contact/tpl/default.php
+++ b/widgets/contact/tpl/default.php
@@ -108,11 +108,6 @@ if ( is_array( $result ) && $result['status'] == 'success' ) {
 			value="<?php echo esc_attr( $this->instance_hash ); ?>"
 		/>
 
-		<input
-			type="hidden"
-			name="form_id"
-			value="<?php echo esc_attr( $form_id ); ?>"
-		/>
 		<?php wp_nonce_field( '_contact_form_submit' ); ?>
 	</form>
 	<?php


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/2158

This PR removes the no longer used form_id field (dropped in https://github.com/siteorigin/so-widgets-bundle/pull/2089). This will resolve the following potential notice:

`Undefined variable $form_id widgets/contact/tpl/default.php`