### PR TITLE
Block: Resolve Map Consent Preview Issue After Initial Load

### DIFF
--- a/js/sow.google-map.js
+++ b/js/sow.google-map.js
@@ -228,7 +228,7 @@ sowb.SiteOriginGoogleMap = function($) {
 			}
 
 			markerOptions.content = this.drawMarkerEl( icon );
-			return 	new window.google.maps.marker.AdvancedMarkerElement( markerOptions )
+			return new window.google.maps.marker.AdvancedMarkerElement( markerOptions )
 		},
 
 		showMarkers: function(markerPositions, map, options) {


### PR DESCRIPTION
Previously, the consent prompt would work as expected on load and then after making a change it would be impossible to consent again.