### PR TITLE
Price Table: Add `siteorigin_widgets_price_table_button_attributes` Filter

### DIFF
--- a/widgets/price-table/price-table.php
+++ b/widgets/price-table/price-table.php
@@ -304,12 +304,23 @@ class SiteOrigin_Widget_PriceTable_Widget extends SiteOrigin_Widget {
 			}
 		}
 
+		$button_attrs = array(
+			'class' => 'ow-pt-link',
+		);
+
+
+
+		if ( ! empty( $instance['button_new_window'] ) ) {
+			$button_attrs['target'] = '_blank';
+			$button_attrs['rel'] = 'noopener noreferrer';
+		}
+
 		return array(
 			'title'                => $instance['title'],
 			'columns'              => $columns,
 			'before_title'         => $args['before_title'],
 			'after_title'          => $args['after_title'],
-			'button_new_window'    => $instance['button_new_window'],
+			'button_attrs'         => $button_attrs,
 			'equalize_row_heights' => ! empty( $instance['equalize_row_heights'] ),
 			'any_column_has_image' => $any_column_has_image,
 		);

--- a/widgets/price-table/tpl/atom.php
+++ b/widgets/price-table/tpl/atom.php
@@ -4,10 +4,12 @@
  * @var $columns array
  * @var $before_title string
  * @var $after_title string
- * @var $button_new_window boolean
+ * @var $button_attrs boolean
  * @var $equalize_row_heights boolean
  * @var $any_column_has_image boolean
  */
+
+$initial_button_attrs = $button_attrs;
 ?>
 
 <?php if ( ! empty( $title ) ) {
@@ -74,10 +76,20 @@
 
 			<?php if ( ! empty( $column['button'] ) ) { ?>
 				<div class="ow-pt-button">
-					<a href='<?php echo sow_esc_url( $column['url'] ); ?>'
-					   class="ow-pt-link" <?php if ( ! empty( $button_new_window ) ) {
-						echo 'target="_blank" rel="noopener noreferrer"';
-					   } ?>><?php echo esc_html( $column['button'] ); ?></a>
+					<a
+						href="<?php echo sow_esc_url( $column['url'] ); ?>"
+						<?php
+						$button_attrs = apply_filters(
+							'siteorigin_widgets_price_table_button_attributes',
+							$initial_button_attrs,
+							$column
+						);
+
+						foreach ( $button_attrs as $attr => $val ) {
+							echo siteorigin_sanitize_attribute_key( $attr ) . '="' . esc_attr( $val ) . '" ';
+						}
+						?>
+					><?php echo esc_html( $column['button'] ); ?></a>
 				</div>
 			<?php } ?>
 		</div>


### PR DESCRIPTION
This PR adds the `siteorigin_widgets_price_table_button_attributes` filter to the Price Table widget, allowing users to modify the button attributes. 

Test snippet that will set links to `nofollow`.

```
add_filter( 'siteorigin_widgets_price_table_button_attributes', function( $button_attrs, $column ) {
	if ( empty( $button_attrs['rel'] ) ) {
		$button_attrs['rel'] = 'nofollow';
	} else {
		$button_attrs['rel'] .= ' nofollow';
	}

	return $button_attrs;
}, 10, 2 );
```