### PR TITLE
Simple Masonry: Fix Potential TypeError

### DIFF
--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -327,7 +327,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 	}
 
 	public function get_template_variables( $instance, $args ) {
-		$items = isset( $instance['items'] ) ? (array) $instance['items'] : array();
+		$items = ! empty( $instance['items'] ) && is_array( $instance['items'] ) ? (array) $instance['items'] : array();
 
 		foreach ( $items as &$item ) {
 			$item['link_attributes'] = array();


### PR DESCRIPTION
`PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in simple-masonry\simple-masonry.php:333`

To replicate this error, add a Simple Masonry widget and try to view it without adding any items.