### PR TITLE
Widget Blocks: Fix Icons Not Saving Correctly

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -137,7 +137,7 @@
 
 			props.setAttributes( {
 				widgetMarkup: widgetPreview.html,
-				widgetIcons: widgetPreview.icons
+				widgetIcons: widgetPreview.widgetIcons,
 			} );
 		} )
 		.fail( ( response ) => {


### PR DESCRIPTION
This PR will fix the Icon form field not showing correctly in the rendered Block Editor layout. This PR will require the page containing the Block to be opened and then saved (no changes necessary).