### PR TITLE
Checkboxes: Force `appearance: auto` in WB Form

### DIFF
--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -1088,6 +1088,7 @@ div.siteorigin-widget-form {
 				line-height: 2;
 
 				&[type=checkbox] {
+					appearance: auto !important;
 					background-color: #ffffff;
 				}
 			}


### PR DESCRIPTION
Certain themes, including Snapshot, clear appearance for checkboxes to allow for custom styling. To prevent conflicts, `!important` is often used. This commit will ensure checkboxes work as expected in WB Forms still.