### PR TITLE
Fix: Blog Alternate Template Mobile Spacing Issue

### DIFF
--- a/widgets/blog/styles/alternate.less
+++ b/widgets/blog/styles/alternate.less
@@ -64,7 +64,6 @@
 			& > img,
 			.sow-entry-thumbnail,
 			.sow-entry-thumbnail .wp-post-image {
-				flex: 1;
 				height: auto;
 				width: 100%;
 			}
@@ -101,6 +100,7 @@
 			width: 58.4994%;
 
 			@media (max-width: @responsive_breakpoint) {
+				flex: none;
 				width: auto;
 			}
 


### PR DESCRIPTION
Resolves https://github.com/siteorigin/so-widgets-bundle/issues/2198. Please see the issue link for notes and a question.

Removed flex: 1 from entry thumbnails and added flex: none to the content wrapper for mobile screens to eliminate unwanted vertical space in the Blog Alternate template on mobile devices.