### PR TITLE
Widget blocks: Fix 3rd SVG Icons, & Add Central Function to Add Icons

### DIFF
--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -50,7 +50,7 @@
 	 */
 	const sowbSetupIcon = ( widget ) => {
 		return widget.icon ?
-			icon.trim().startsWith( '<svg' ) ?
+			widget.icon.trim().startsWith( '<svg' ) ?
 				el(
 					'span',
 					{


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-premium/issues/1197

This PR:

- Fixes 3rd party SVG icons not displaying correctly.
- Adds a central method of generating SiteOrigin Widget Block Icons.
