### PR TITLE
TinyMCE Form Field: Prevent Potential TypeError

### DIFF
--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -137,6 +137,8 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 				'redo',
 				'wp_help',
 			),
+			'mce_buttons_3' => array(),
+			'mce_buttons_4' => array(),
 			'quicktags_buttons' => array(
 				'strong',
 				'em',


### PR DESCRIPTION
If this isn't an array, we run the risk of triggering a TypeError for other developers who rightly assume the mce_buttons_X filters will pass an array.