### PR TITLE
Fix undefined widgetClass array key warning in widget-block.php

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -338,7 +338,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				'</div>';
 		}
 
-		$widget_class = $block_content['widgetClass'];
+		$widget_class = isset( $block_content['widgetClass'] ) ? $block_content['widgetClass'] : '';
 		global $wp_widget_factory;
 
 		$widget = ! empty( $wp_widget_factory->widgets[ $widget_class ] ) ? $wp_widget_factory->widgets[ $widget_class ] : false;


### PR DESCRIPTION
Add isset() check to prevent PHP warning when widgetClass key doesn't exist in block_content array.

🤖 Generated with [Claude Code](https://claude.ai/code)