### PR TITLE
Fix/simple masonry gutter cascading

### DIFF
--- a/widgets/simple-masonry/simple-masonry.php
+++ b/widgets/simple-masonry/simple-masonry.php
@@ -381,10 +381,10 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 	 * @return int The gutter value.
 	 */
 	private function get_responsive_gutter( $instance, $breakpoint ) {
-		$gutter_value = $instance['layout'][$breakpoint]['gutter'] ?? '';
+		$gutter_value = isset( $instance['layout'][ $breakpoint ]['gutter'] ) ? $instance['layout'][ $breakpoint ]['gutter'] : '';
 		
 		// If gutter is explicitly set and not empty string, use it.
-		if ( isset( $instance['layout'][$breakpoint]['gutter'] ) && $gutter_value !== '' ) {
+		if ( isset( $instance['layout'][ $breakpoint ]['gutter'] ) && $gutter_value !== '' ) {
 			return (int) $gutter_value;
 		}
 		
@@ -394,7 +394,7 @@ class SiteOrigin_Widget_Simple_Masonry_Widget extends SiteOrigin_Widget {
 		}
 		
 		if ( $breakpoint === 'mobile' ) {
-			$tablet_gutter = $instance['layout']['tablet']['gutter'] ?? '';
+			$tablet_gutter = isset( $instance['layout']['tablet']['gutter'] ) ? $instance['layout']['tablet']['gutter'] : '';
 			if ( isset( $instance['layout']['tablet']['gutter'] ) && $tablet_gutter !== '' ) {
 				return (int) $tablet_gutter;
 			}


### PR DESCRIPTION
At the moment the Simple Masonry treats the Tablet and Mobile gutter fields as zero values when empty and they are empty by default. Ideally Tablet and Mobile should use the Desktop gutter unless they have their own values. This PR sets out to achieve that. If Table gutter is applied and Mobile gutter is empty, Mobile gutter will use Tablet so we're cascading sequentially. 