### PR TITLE
Widget Block: Improve `WidgetClass` Redundancy

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -231,7 +231,6 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			);
 
 			if ( $is_so_widget ) {
-				// str starts with
 				if ( strpos( $class, 'SiteOrigin_Widget' ) === 0 ) {
 					$widget_data['manuallyRegister'] = true;
 				}


### PR DESCRIPTION
Replaces https://github.com/siteorigin/so-widgets-bundle/pull/2214

This PR improves the Widget Block `WidgetClass` redundancy. Due to the nature of the Block Editor, it's entirely possible for the user to unintentionally break things or for data to become malformed.  This PR adds additional checks and fallbacks to ensure that if that happens, we'll try and fix it automatically, and handle it gracefully if we can't.

The general flow is:
- If the widget class is empty, try to find it using the Block name. (uses the `find_widget_class_by_block_name` method).
- Adds `get_block_widget`, which improves widget instance loading. If we're unable to find the widget, we attempt to load it using the block name.
- If all of the above attempts fail, we return an error message using `return_invalid_widget_class_notice`. (this should basically never happen now)

This PR also implements [prepare_widget_data](https://github.com/siteorigin/so-widgets-bundle/commit/c11b981c7daa5ccc6f1dfb2fcb14f0f435c7bcdf), which replaces the `get_all_widgets` method.

To test this PR:
1. Confirm any SO Widget Block is working (confirms https://github.com/siteorigin/so-widgets-bundle/commit/c11b981c7daa5ccc6f1dfb2fcb14f0f435c7bcdf).
2. With the newly added SO Widget Block, open the Code Editor and change the WidgetClass to anything else. For example:

`widgetClass":"SiteOrigin_Widget_Hero_Widget"`

To:

`widgetClass":"test"`

3. Confirm it previews, save, and confirm it displays correctly on the frontend.
4. Open the editor again, open Code View, and then empty the contents of widgetClass. For example:
`widgetClass":"test"`

To:

`widgetClass":""`

5. The Block should appear as expected.