### PR TITLE
Post Carousel: Update continuous mode defaults

### DIFF
--- a/widgets/post-carousel/post-carousel.php
+++ b/widgets/post-carousel/post-carousel.php
@@ -337,7 +337,8 @@ class SiteOrigin_Widget_PostCarousel_Widget extends SiteOrigin_Widget_Base_Carou
 					'label' => __( 'Continuous', 'so-widgets-bundle' ),
 					'values' => array(
 						'carousel_settings' => array(
-							'animation_speed' => 4000,
+							'animation' => 'linear',
+							'animation_speed' => 8000,
 							'timeout' => 400,
 							'autoplay_pause_hover' => true,
 						),


### PR DESCRIPTION
- Set animation to 'linear' for continuous mode
- Increase animation_speed from 4000ms to 8000ms for continuous mode

These changes provide smoother continuous scrolling behavior by using linear animation timing and longer animation duration.

🤖 Generated with [Claude Code](https://claude.ai/code)