### PR TITLE
Widget Form Backup: Improve Backup Notice Handling

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1367,13 +1367,14 @@ var sowbForms = window.sowbForms || {};
 	 *
 	 * @param {Object} current - Current field values.
 	 * @param {Object} stored - Stored field values.
+	 * @param {string} formId - The ID of the form being compared.
 	 *
 	 * @returns {boolean} - Returns `true` if the current values are different from the stored values, otherwise `false`.
 	 */
-	const fieldBackupCompare = ( current, stored ) => {
+	const fieldBackupCompare = ( current, stored, formId ) => {
 		// Check if the old data is relevant.
 		if ( current['_sow_form_timestamp'] > stored['_sow_form_timestamp'] ) {
-			sessionStorage.removeItem( _sow_form_id );
+			sessionStorage.removeItem( formId );
 			return false;
 		}
 
@@ -1437,7 +1438,11 @@ var sowbForms = window.sowbForms || {};
 		// Update the stored timestamp to match the current form's timestamp.
 		currentFieldValues['_sow_form_timestamp'] = parseInt( $timestampField.val() || 0 );
 
-		if ( fieldBackupCompare( currentFieldValues, storedFieldValues ) ) {
+		if ( fieldBackupCompare(
+			currentFieldValues,
+			storedFieldValues,
+			_sow_form_id
+		) ) {
 			sowbForms.displayNotice(
 				$el,
 				soWidgets.backup.newerVersion,


### PR DESCRIPTION
The SOWB Form Field Backups will now directly compare fields before showing the notice. This should ensure that the notice only appears when it's needed. As this is a shift from how the previous notice was handled, it's entirely possible for issues to arise due to the more complex communication.

Test prep:
- Open a Classic Editor Page Builder powered page.
- Add a SiteOrigin Editor widget with a title and some basic placeholder editor content.
- Add a SiteOrigin Accordion widget with at least two panels added and an icon set for both.
- Save.

SiteOrigin Editor test steps:
- Open the SiteOrigin Editor widget. No notice should be present.
- Change the title field and click Done.
- Reload the page (don't save), and open the SiteOrigin Editor widget. You should see a notice.
- Insert the backup, and the changed data should be present.
- Change the title again, click done, and reload.
- Open the Editor widget, and this time click dismiss.
- Reload the page, and then open the Editor again. 
- The notice should not be present.

SiteOrigin Accordion test steps:
- Open the Accordion, and adjust a value in the second panel.
- Reload the editor, and then open the Accordion widget.
- The notice should appear.
- Click restore, and then save.
- Open the Accordion again, and no notice should appear.
- Make another change to a panel, and then save.
- Open the Accordion again, and no notice should appear.