### PR TITLE
Multiple Media: Refresh Library After Uploading a New File

### DIFF
--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -145,7 +145,7 @@
 				frame.close();
 			} );
 
-			// Store the frame
+			// Store the frame.
 			$$.data( 'frame', frame );
 
 			// Finally, open the modal.


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-premium/issues/1212

The difference between the regular field here and the Multiple Media field is that the upload functionality appears to function slightly differently when multiple is enabled. Unclear why - I suspect it might be a core bug.

Two instances of `wp.media.frame.content.get().collection._requery( true );` were required to prevent a timing issue. The workaround isn't ideal, but that flash looks really bad, so it's required until the underlying core issue is resolved.