### PR TITLE
Rename Accessibility Stylesheet to `siteorigin-accessibility`

### DIFF
--- a/base/inc/widgets/base-slider.class.php
+++ b/base/inc/widgets/base-slider.class.php
@@ -597,7 +597,7 @@ abstract class SiteOrigin_Widget_Base_Slider extends SiteOrigin_Widget {
 				! empty( $background['image'] ) &&
 				! empty( $background['image-alt'] )
 			) {
-				wp_enqueue_style( 'sow-accessibility' );
+				wp_enqueue_style( 'siteorigin-accessibility' );
 				?>
 				<div class="sowb-slider-background-alt so-sr-only">
 					<?php echo esc_html( $background['image-alt'] ); ?>

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -851,12 +851,12 @@ class SiteOrigin_Widgets_Bundle {
 
 	public function register_general_scripts() {
 		wp_register_style(
-			'sow-accessibility',
+			'siteorigin-accessibility',
 			plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'css/accessibility.css',
 			array(),
 			SOW_BUNDLE_VERSION
 		);
-		
+
 		wp_register_script(
 			'sowb-fittext',
 			plugin_dir_url( SOW_BUNDLE_BASE_FILE ) . 'js/sow.jquery.fittext' . SOW_BUNDLE_JS_SUFFIX . '.js',

--- a/widgets/features/features.php
+++ b/widgets/features/features.php
@@ -385,7 +385,7 @@ class SiteOrigin_Widget_Features_Widget extends SiteOrigin_Widget {
 		);
 
 		if ( ! empty( $instance ) && ! empty( $instance['link_feature'] ) ) {
-			wp_enqueue_style( 'sow-accessibility' );
+			wp_enqueue_style( 'siteorigin-accessibility' );
 		}
 
 		return array(


### PR DESCRIPTION
Renaming this so it makes more sense as a central thing for all of our plugins, rather than specifically for the Widgets Bundle.