### PR TITLE
Features Widget: Prevent Theme Margin on List Items

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -48,6 +48,7 @@
 
 	.sow-features-feature {
 		.box-sizing(border-box);
+		margin: 0;
 		position: relative;
 		& when ( @more_text_bottom_align = true ) {
 			display: flex;


### PR DESCRIPTION
Added margin: 0 to .sow-features-feature to prevent theme styles like .entry-content ul li from adding unwanted margins to widget list items.

Resolves theme list styling as seen with Vantage causing what should be three features per row output as two.

🤖 Generated with [Claude Code](https://claude.ai/code)
