### PR TITLE
Fix/Block Editor Toolbar Opacity Line

### DIFF
--- a/compat/block-editor/widget-block.less
+++ b/compat/block-editor/widget-block.less
@@ -66,7 +66,7 @@
 	stroke: transparent !important;
 }
 
-// Hide the WordPress core pseudo-element border when SiteOrigin widget icons are active
+// Hide the WordPress core pseudo-element border when SiteOrigin widget icons are active.
 .components-toolbar-group:has(.so-widget-icon.so-block-editor-icon):after {
 	display: none;
 }


### PR DESCRIPTION
  - Fixes unwanted opacity line appearing in WordPress block editor toolbar when SiteOrigin widget icons are displayed.
  - Adds CSS rule to hide WordPress core pseudo-element border specifically when SiteOrigin widget icons are active.

The issue being fixed is visible below:
<img width="662" height="191" alt="Screenshot 2025-07-11 at 18 03 08" src="https://github.com/user-attachments/assets/dae5ddb5-136a-466c-8507-40c1d473ace9" />
