### PR TITLE
Features Widget: Fix Icon Disappearing When Link Overlay Enabled

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -272,11 +272,6 @@
 				position: relative;
 				z-index: 1;
 			}
-
-			.sow-icon-container {
-				position: relative;
-				z-index: -1;
-			}
 		}
 	}
 


### PR DESCRIPTION
Removed duplicate z-index: -1 rule that was causing icons to disappear when "Link feature column to more URL" was checked. Icons now properly display with z-index: 1 alongside other content elements.

🤖 Generated with [Claude Code](https://claude.ai/code)