### PR TITLE
Fix array type check for corrupted active widgets option

### DIFF
--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -250,6 +250,11 @@ class SiteOrigin_Widgets_Bundle {
 
 		if ( empty( $active_widgets ) ) {
 			$active_widgets = get_option( 'siteorigin_widgets_active', array() );
+			
+			if ( ! is_array( $active_widgets ) ) {
+				$active_widgets = array();
+			}
+			
 			$active_widgets = wp_parse_args( $active_widgets, apply_filters( 'siteorigin_widgets_default_active', self::$default_active_widgets ) );
 
 			// Migrate any old names.


### PR DESCRIPTION
## Summary
- Adds array type validation to the `get_active_widgets()` method
- Prevents fatal error when `get_option('siteorigin_widgets_active')` returns a non-array value
- Ensures the foreach loop always receives an array

## Context
User reported a fatal error where the `siteorigin_widgets_active` option returned a string instead of an array, causing foreach() to fail. This can occur when the database option becomes corrupted or is manually edited.

## Test plan
- [x] Tested with corrupted `siteorigin_widgets_active` option (forced string value)
- [x] Verified no PHP errors occur with the fix in place
- [x] Verify widget activation/deactivation works correctly
- [x] Confirm existing sites with valid array data continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)