### PR TITLE
Fix undefined array key warnings in add_defaults method

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -409,7 +409,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		foreach ( $form as $id => $field ) {
 			if ( $field['type'] == 'repeater' ) {
-				if ( is_array( $instance[ $id ] ) ) {
+				if ( isset( $instance[ $id ] ) && is_array( $instance[ $id ] ) ) {
 					foreach ( array_keys( $instance[ $id ] ) as $i ) {
 						$instance[ $id ][ $i ] = $this->add_defaults( $field['fields'], $instance[ $id ][ $i ], $level + 1 );
 					}


### PR DESCRIPTION
Add isset() check before accessing array keys in repeater field processing to prevent PHP warnings when keys like 'networks' or 'custom_networks' are not present in the instance array.

Resolves: Warning: Undefined array key "networks" in wp-content/plugins/so-widgets-bundle/base/siteorigin-widget.class.php on line 412

Warning: Undefined array key "custom_networks" in wp-content/plugins/so-widgets-bundle/base/siteorigin-widget.class.php on line 412

🤖 Generated with [Claude Code](https://claude.ai/code)