### PR TITLE
Fix/Undefined Array Key Warnings

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -746,7 +746,7 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 			$field = $field_factory->create_field( $field_name, $field_options, $this );
 			$field->enqueue_scripts();
 
-			if ( ! empty( $field_options['fields'] ) ) {
+			if ( is_array( $field_options ) && ! empty( $field_options['fields'] ) ) {
 				$this->enqueue_field_scripts( $field_options['fields'] );
 			}
 		}


### PR DESCRIPTION
 This PR addresses PHP warnings detected by Query Monitor when processing widget fields with incomplete or malformed configurations. The warnings were occurring across different websites using the SiteOrigin Widget Bundle.

## Problem
  Query Monitor was reporting undefined array key warnings in the following locations:
  - `siteorigin-widget.class.php:411` - Accessing `$field['type']` without validation
  - `siteorigin-widget.class.php:452` - Accessing `$field['class']` without validation
  - `siteorigin-widget.class.php:749` - Accessing `$field_options['fields']` without validation

These warnings occurred when widget field configurations were missing expected keys or when non-array values were passed where arrays were expected.

  ## Solution
  Added defensive checks before accessing array keys:
  1. **`add_defaults()` method**: Validate that `$field` is an array and contains a 'type' key before processing
  2. **Widget field instantiation**: Check for 'class' key existence before creating widget instances
  3. **`enqueue_field_scripts()` method**: Verify `$field_options` is an array before accessing 'fields' key
  
    ## Commits
  - 787644c5: Fix undefined array key 'type' warning in add_defaults()
  - ca754e91: Fix undefined array key 'class' warning for widget fields
  - be5972d6: Fix undefined array key 'fields' warning in enqueue_field_scripts()