### PR TITLE
Blog: Resolve Potential Date Output Format Fatal Error

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1295,7 +1295,14 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 		}
 
 		if ( $settings['date'] ) {
-			$date_output_format = isset( $settings['date_output_format'] ) ? $settings['date_output_format'] : null;
+			if (
+				isset( $settings['date_output_format'] ) &&
+				is_string( $settings['date_output_format'] )
+			) {
+				$date_output_format = $settings['date_output_format'];
+			} else {
+				$date_output_format = null;
+			}
 			?>
 			<span class="sow-entry-date">
 				<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">


### PR DESCRIPTION
I was able to trigger this by adding a new SiteOrigin Blog widget to a Classic Editor Page Builder layout and then saving without opening it. I was able to replicate this issue 2 times in 5 attempts, and I suspect that might be because of timing.

```
PHP Fatal error:  Uncaught TypeError: strlen(): Argument #1 ($string) must be of type string, array given in wp-includes\functions.php:267 Stack trace:
#0 wp-includes\general-template.php(2895): wp_date(Array, 1744332330, Object(DateTimeZone)) #1 wp-includes\general-template.php(2720): get_post_time(Array, false, Object(WP_Post), true) #2 wp-content\plugins\so-widgets-bundle\widgets\blog\blog.php(1303): get_the_date(Array)
```