### PR TITLE
sowFieldBackups Builder Changes

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1411,12 +1411,43 @@ var sowbForms = window.sowbForms || {};
 				return;
 			}
 
+			const $target = $( e.target );
+
 			// Don't trigger a backup if the user clicked on a section.
-			if ( $( e.target ).parent().is( '.siteorigin-widget-field-type-section' ) ) {
+			if ( $target.is( 'label' ) ) {
+				const $parent = $target.parent();
+				// Check if the label is part of a section/widget field.
+				if (
+					$parent.hasClass( 'siteorigin-widget-field-type-section' ) ||
+					$parent.hasClass( 'siteorigin-widget-field-type-widget' )
+				) {
+					return false;
+				}
+			}
+
+			// Don't trigger if user opens Builder field.
+			if ( $target.is( '.siteorigin-panels-display-builder' ) ) {
 				return false;
 			}
 
-			isUserChange = true;
+			const validElementClasses = [
+				'input',
+				'select',
+				'textarea',
+				'iframe',
+				'label',
+				'.ui-slider-handle',
+				'.ui-slider',
+				'.siteorigin-widget-icon-icons-icon',
+				'.so-panels-dialog-add-builder .so-close',
+				'a.media-upload-button',
+				'a.media-remove-button',
+			];
+
+			if ( validElementClasses.some( ( selector ) => $target.is( selector ) ) ) {
+				isUserChange = true;
+			}
+
 		} );
 
 		// Debounce backups to prevent potential performance issues.


### PR DESCRIPTION
This PR contains two changes that are intended to work alongside https://github.com/siteorigin/siteorigin-panels/pull/1289 to help prevent the backup notice from showing when using a widget with a Builder widget.

[fieldBackupCompareLoop: Exclude builder_id](https://github.com/siteorigin/so-widgets-bundle/commit/788e4a2b29ce6de389507320d0ad1bf7a37da329)

[sowFieldBackups: Stop Checking After the First User Change](https://github.com/siteorigin/so-widgets-bundle/commit/63c0e33c09058431018ce677a34dfd520428f0c2)