### PR TITLE
Fix TypeError when widget instance is JSON string in REST API context

### DIFF
--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -528,6 +528,14 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 		$form_id = 'siteorigin_widget_form_' . md5( $id );
 		$class_name = str_replace( '_', '-', strtolower( $this->widget_class ) );
 
+		// Handle cases where instance is a JSON string (e.g., from WooCommerce REST API updates).
+		if ( is_string( $instance ) ) {
+			$instance = json_decode( $instance, true );
+			if ( ! is_array( $instance ) ) {
+				$instance = array();
+			}
+		}
+
 		if ( empty( $instance['_sow_form_id'] ) ) {
 			$instance['_sow_form_id'] = $id;
 		}


### PR DESCRIPTION
## Summary
This PR fixes a fatal TypeError that occurs when updating WooCommerce products through the REST API or mobile app. The error happens because widget instance data is passed as a JSON string instead of an array in REST API contexts.

## Problem
When users update WooCommerce products via the mobile app or REST API, they encounter this fatal error:
```
Uncaught TypeError: Cannot access offset of type string on string in 
.../so-widgets-bundle/base/siteorigin-widget.class.php:532
```

The issue occurs because `$instance` is a JSON string like `'{"toggle_visibility": true}'` instead of an array, but the code tries to access it as an array with `$instance['_sow_form_id']`.

## Solution
Added JSON string detection and decoding before attempting array access. The fix:
1. Checks if `$instance` is a string
2. Attempts to decode it as JSON
3. Falls back to an empty array if decoding fails
4. Proceeds with normal array operations

## Technical Analysis (from code review)
The root cause is that WordPress Core's widget REST API sometimes passes widget instance data as JSON strings instead of arrays, particularly when triggered by WooCommerce REST operations. The current fix addresses the symptom correctly, but could be enhanced by:

1. Moving the JSON check earlier in the method (before line 515)
2. Adding similar protection to the `update()` method
3. Fixing it at the REST API handler level in `siteorigin-widgets-resource.class.php`
4. Adding WordPress filter hooks for centralized handling
5. Reporting the issue to WordPress Core

The multi-layered approach would provide the most robust solution without waiting for WordPress Core to address the underlying architectural inconsistency.

## Testing
- [ ] Test normal widget operations continue to work
- [ ] Test updating WooCommerce products via REST API no longer causes fatal error
- [ ] Test with SiteOrigin Premium metaboxes active
- [ ] Verify no regressions in widget form rendering

## References
- User report described the error occurring when updating stock through WooCommerce app
- Stack trace showed the error path through SiteOrigin Premium's metabox to the widget form method
- Fix handles both SiteOrigin Widgets Bundle and Premium since Premium's Metabox class extends SiteOrigin_Widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)