### PR TITLE
Video: Add Sandbox Attribute

### DIFF
--- a/base/inc/video.php
+++ b/base/inc/video.php
@@ -91,7 +91,7 @@ class SiteOrigin_Video {
 			}
 
 			// Ensure the embed is able to go fullscreen.
-			$html = preg_replace( '/<iframe(.*?)>/', '<iframe$1 allowfullscreen mozallowfullscreen webkitallowfullscreen>', $html );
+			$html = preg_replace( '/<iframe(.*?)>/', '<iframe$1 allowfullscreen mozallowfullscreen webkitallowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation">', $html );
 
 			if ( ! empty( $html ) ) {
 				set_transient( 'sow-vid-embed[' . $hash . ']', $html, 30 * 86400 );


### PR DESCRIPTION
[Requested here](https://siteorigin.com/thread/insecure-frame/)

To test this PR you'll need to clear the transient cache. The easiest way to do that (without something like WP CLI) is just to change the SO Video widget settings. Please confirm a YouTube and Vimeo video works as expected (you can play it, make it full screen, etc).