### PR TITLE
Restore Portfolio-only filter control with extension hook

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -76,6 +76,29 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 	public function get_widget_form() {
 		$templates = apply_filters( 'siteorigin_widgets_blog_templates', json_decode( file_get_contents( plugin_dir_path( __FILE__ ) . 'data/templates.json' ), true ) );
 
+		$filter_categories_templates = apply_filters(
+			'siteorigin_widgets_blog_filter_categories_templates',
+			array( 'portfolio' )
+		);
+		$filter_categories_templates = array_unique(
+			array_filter(
+				array_map(
+					'sanitize_key',
+					(array) $filter_categories_templates
+				)
+			)
+		);
+
+		$filter_categories_state_handler = array();
+		if ( ! empty( $filter_categories_templates ) ) {
+			$filter_categories_state_handler[ 'active_template[' . implode( ',', $filter_categories_templates ) . ']' ] = array( 'slideDown' );
+		}
+		$filter_categories_state_handler['_else[active_template]'] = array( 'slideUp' );
+
+		$filter_categories_design_state_handler = $filter_categories_state_handler;
+		$filter_categories_design_state_handler['filter_categories[show]'] = array( 'slideDown' );
+		$filter_categories_design_state_handler['filter_categories[hide]'] = array( 'slideUp' );
+
 		return $this->dynamic_preset_state_handler(
 			'active_template',
 			$templates,
@@ -212,6 +235,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 									'filter_categories[hide]: ! val',
 								),
 							),
+							'state_handler' => $filter_categories_state_handler,
 						),
 						'categories' => array(
 							'type' => 'checkbox',
@@ -419,6 +443,7 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 							'type' => 'section',
 							'label' => __( 'Filter Categories', 'so-widgets-bundle' ),
 							'hide' => true,
+							'state_handler' => $filter_categories_design_state_handler,
 							'fields' => array(
 								'font' => array(
 									'type' => 'font',


### PR DESCRIPTION
Part of https://github.com/siteorigin/siteorigin-premium/pull/1261.

## Summary
- default the Blog widget’s filter toggle to Portfolio only
- add a filter so extensions can register additional templates without replacing the field
- reuse the filtered template list for the settings and design state handlers

## Testing
- Add a Blog widget without Premium active; confirm only Portfolio exposes the Filter Categories checkbox
- Activate Premium’s Blog Addon and ensure the toggle appears when Masonry is selected and filtering works