### PR TITLE
Fix bottom-align spacing in Features widget

### DIFF
--- a/widgets/features/styles/default.less
+++ b/widgets/features/styles/default.less
@@ -184,10 +184,6 @@
 			width: @container_size;
 			flex: 0 0 @container_size;
 
-			& when ( @more_text_bottom_align = true ) {
-				/* handled per-position to avoid collapsing horizontal spacing */
-			}
-
 			&:not(.sow-container-none) [class^="sow-icon-"],
 			.sow-icon-image {
 				align-items: center;


### PR DESCRIPTION
## Summary
- keep icon/title/text anchored to the top while only `.sow-more-text` drops to the bottom when Bottom Align is enabled
- restore spacing/flex behaviour for right/left icon layouts so icons retain margin and headings stay aligned
- CSS-only changes in `widgets/features/styles/default.less`

## Testing
- manual: visit `http://localhost/siteorigin/features-block-test/`. find the file included below.
  - verify rows: **Top / bottom-align on / more yes**, **Right / bottom-align off / more yes**, **Right / bottom-align on / more yes**, **Right / bottom-align on / more no**, **Bottom / bottom-align on / more yes**
  - confirm only the More paragraph sits at the bottom, icons have consistent spacing, and taller columns stay top-aligned

[features-block-test.html](https://github.com/user-attachments/files/22967963/features-block-test.html)
