### PR TITLE
Block Editor: Prevent Editor Scripts From Being Loaded on Frontend

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -252,8 +252,21 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		$this->so_widgets = array_merge( $so_widgets, $third_party_widgets );
 	}
 
+	/**
+	 * Enqueue block editor assets for SiteOrigin Widget Blocks.
+	 *
+	 * This method enqueues the necessary scripts and styles for the block editor.
+	 * It also localizes widget data for use in the editor.
+	 */
 	public function enqueue_widget_block_editor_assets() {
 		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
+
+		if (
+			empty( $current_screen ) ||
+			! in_array( $current_screen->base, array( 'post', 'site-editor', 'widgets' ) )
+		) {
+			return;
+		}
 
 		wp_enqueue_script(
 			'sowb-register-widget-blocks',

--- a/tests/e2e/wb-form-field-site-editor.test.js
+++ b/tests/e2e/wb-form-field-site-editor.test.js
@@ -652,3 +652,22 @@ test(
 		}
 	}
 );
+
+/**
+ * Validates that editor scripts aren't being loaded on the frontend.
+ *
+ * @param {Object} page The Playwright page object.
+ */
+test(
+	'Test that editor scripts are not loaded on the frontend.',
+	async ( { page } ) => {
+		await page.goto( '/' );
+
+		const hasBlockCss = await page.$( '#sowb-widget-block-css' ) !== null;
+		const hasBlockJs = await page.$( '#sowb-widget-block-js' ) !== null;
+
+		expect( hasBlockCss ).toBe( false );
+		expect( hasBlockJs ).toBe( false );
+
+	}
+);


### PR DESCRIPTION
The 'enqueue_block_assets' action is used instead of 'enqueue_block_editor_assets' due to compatibility issues with the Site Editor. Using 'enqueue_block_editor_assets' would prevent the required assets from loading correctly in the Site Editor context.

Includes test to validate fix, and to catch any breaks due to `enqueue_block_assets` having to be used.