### PR TITLE
🐛 Removes warning for namespaced widget classes when trying to register block

### DIFF
--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -212,7 +212,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				$description = __( 'No description available.', 'so-widgets-bundle' );
 			}
 
-			$block_name = strtolower( str_replace( '_', '-', $class ) );
+			$block_name = strtolower( str_replace( ['_', '\\'], '-', $class ) );
 
 			// For SiteOrigin authored widgets, display the widget's name directly. For third-party widgets, append the author's name to the widget name to avoid confusion when multiple widgets have the same name.
 			if (


### PR DESCRIPTION
This pull request makes a minor update to the way block names are generated for widgets in the block editor. The change ensures that both underscores and backslashes in widget class names are replaced with hyphens, improving consistency and avoiding potential naming conflicts.

* Updated block name generation in `prepare_widget_data()` to replace both underscores and backslashes with hyphens in the widget class name.