### PR TITLE
Ensure image widget hash reflects filtered LESS vars

### DIFF
--- a/widgets/image/image.php
+++ b/widgets/image/image.php
@@ -219,7 +219,15 @@ class SiteOrigin_Widget_Image_Widget extends SiteOrigin_Widget {
 	}
 
 	public function get_style_hash( $instance ) {
-		return substr( md5( serialize( $this->get_less_variables( $instance ) ) ), 0, 12 );
+		$less_variables = $this->get_less_variables( $instance );
+		$less_variables = apply_filters(
+			'siteorigin_widgets_less_variables_' . $this->id_base,
+			$less_variables,
+			$instance,
+			$this
+		);
+
+		return substr( md5( serialize( $less_variables ) ), 0, 12 );
 	}
 
 	public function get_template_variables( $instance, $args ) {


### PR DESCRIPTION
Resolved the issue reported [here](https://secure.helpscout.net/conversation/3126265562/93542?viewId=472475). When adding a custom image shape to two pages or more, the last shape added reflects in all instances that are using a custom shape.

--

**Image Shape Hash Fix**

- Updated widgets/image/image.php:219 so get_style_hash() runs the same filtered LESS-variable hook that eventually injects the custom mask URL.  This makes each widget instance include its own shape URL in the hash and therefore in the generated CSS filename.
- Verified via wp eval … that two different custom shapes now produce distinct hashes after the change (previously identical).
 - Branch fix/image-shape-custom-hash created from develop, commit Ensure image widget hash reflects filtered LESS vars pushed and tracking origin/fix/image-shape-custom-hash.

