### PR TITLE
Fix Hero repeater media field after duplicate

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1179,6 +1179,11 @@ var sowbForms = window.sowbForms || {};
 						var $nextIndex = $items.children().length;
 						var newIds = {};
 
+						// Reset initialization flags so field setup runs for the cloned item.
+						$copyItem
+							.find( '.siteorigin-widget-field[data-initialized]' )
+							.removeAttr( 'data-initialized' );
+
 						$copyItem.find( '*[name]' ).each(function () {
 							var $inputElement = $( this );
 							var id = $inputElement.attr( 'id' );


### PR DESCRIPTION
## Summary
- ensure cloned repeater items re-run field setup by clearing data-initialized flags
- fixes media field in duplicated Hero frames not opening background picker

## Testing
- not run (admin JS only)