### PR TITLE
Add filter to disable blog pagination

### DIFF
--- a/widgets/blog/blog.php
+++ b/widgets/blog/blog.php
@@ -1592,6 +1592,16 @@ class SiteOrigin_Widget_Blog_Widget extends SiteOrigin_Widget {
 			$pagination_markup = apply_filters( 'siteorigin_widgets_blog_pagination_markup', false, $settings, $posts, $instance );
 		}
 
+		if (
+			! $addon_active &&
+			( ! isset( $settings['pagination'] ) || $settings['pagination'] !== 'disabled' )
+		) {
+			$pagination_enabled = apply_filters( 'siteorigin_widgets_blog_pagination_enabled', true, $settings, $posts, $instance );
+			if ( ! $pagination_enabled ) {
+				return;
+			}
+		}
+
 		if ( empty( $pagination_markup ) ) {
 			if ( $addon_active && isset( $settings['pagination_reload'] ) && $settings['pagination_reload'] == 'ajax' ) {
 				$current = 99999;


### PR DESCRIPTION
## Summary
- add a filter hook that lets free users disable blog pagination output
- keep premium add-on behavior unchanged by skipping the filter when premium pagination markup is active
- preserve existing pagination settings checks so "disabled" remains authoritative

## Rationale
Free users needed a non-UI way to disable pagination. The filter short-circuits output only for the free widget and leaves the premium add-on's markup and JS flow untouched, minimizing regressions.