### PR TITLE
Fix slider cover background tiling

### DIFF
--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -36,7 +36,8 @@
 			}
 
 			&.sow-slider-image-cover {
-				background-repeat: repeat;
+				// "cover" should never tile; tiling is only appropriate for explicit "tile" sizing modes.
+				background-repeat: no-repeat;
 			}
 
 			.sow-slider-image-container {
@@ -74,7 +75,7 @@
 				}
 
 				&.sow-slider-image-cover {
-					background-repeat: repeat;
+					background-repeat: no-repeat;
 				}
 			}
 

--- a/css/slider/slider.less
+++ b/css/slider/slider.less
@@ -36,7 +36,6 @@
 			}
 
 			&.sow-slider-image-cover {
-				// "cover" should never tile; tiling is only appropriate for explicit "tile" sizing modes.
 				background-repeat: no-repeat;
 			}
 


### PR DESCRIPTION
## Problem
On iOS Safari, when background videos fail to render/autoplay, the slider/hero falls back to the frame background image. The cover sizing mode currently sets `background-repeat: repeat`, which causes the fallback background to tile and appear like repeated video stills.

## Fix
Set `background-repeat: no-repeat` for `sow-slider-image-cover` and the corresponding overlay cover class in `css/slider/slider.less`.

## Notes
`css/slider/slider.css` is a built artifact in this working copy and is not tracked in git, so this change is limited to the LESS source.