### PR TITLE
Add Filter to Show Cover Image When Self-Hosted Video Ends

### DIFF
--- a/widgets/video/js/so-video-widget.js
+++ b/widgets/video/js/so-video-widget.js
@@ -4,9 +4,11 @@ var sowb = window.sowb || {};
 
 jQuery( function ( $ ) {
 	sowb.setupVideoPlayers = () => {
-		const $video = $( 'video.sow-video-widget' );
+		const $video = $( 'video.sow-video-widget' ).filter( function () {
+			return ! $( this ).data( 'initialized' );
+		} );
 
-		if ( $video.data( 'initialized' ) ) {
+		if ( ! $video.length ) {
 			return $video;
 		}
 
@@ -26,6 +28,7 @@ jQuery( function ( $ ) {
 				$this.attr( 'controls' )
 			) {
 				$this.mediaelementplayer();
+				$this.data( 'initialized', true );
 				return;
 			}
 
@@ -38,13 +41,13 @@ jQuery( function ( $ ) {
 				const video = e.target;
 				video.paused ? video.play() : video.pause();
 			} );
+
+			$this.data( 'initialized', true );
 		} );
 
 		if ( typeof $.fn.fitVids === 'function' ) {
 			$( '.sow-video-wrapper.use-fitvids' ).fitVids();
 		}
-
-		$video.data( 'initialized', true );
 	};
 	sowb.setupVideoPlayers();
 

--- a/widgets/video/js/so-video-widget.js
+++ b/widgets/video/js/so-video-widget.js
@@ -14,22 +14,25 @@ jQuery( function ( $ ) {
 
 		$video.each( function () {
 			const $this = $( this );
-
-			// Reset to poster image when video ends.
-			if ( $this.data( 'show-cover-on-end' ) ) {
-				this.addEventListener( 'ended', function () {
-					this.load();
-				} );
-			}
+			const showCoverOnEnd = Boolean( $this.data( 'show-cover-on-end' ) );
 
 			// Do we need to set up Media Elements?
 			if (
 				typeof $.fn.mediaelementplayer === 'function' &&
 				$this.attr( 'controls' )
 			) {
-				$this.mediaelementplayer();
+				$this.mediaelementplayer( {
+					showPosterWhenEnded: showCoverOnEnd,
+				} );
 				$this.data( 'initialized', true );
 				return;
+			}
+
+			// Reset to the native poster image when MediaElement isn't in use.
+			if ( showCoverOnEnd ) {
+				this.addEventListener( 'ended', function () {
+					this.load();
+				} );
 			}
 
 			// Controls are hidden. Add click event to play/pause video.

--- a/widgets/video/js/so-video-widget.js
+++ b/widgets/video/js/so-video-widget.js
@@ -13,6 +13,13 @@ jQuery( function ( $ ) {
 		$video.each( function () {
 			const $this = $( this );
 
+			// Reset to poster image when video ends.
+			if ( $this.data( 'show-cover-on-end' ) ) {
+				this.addEventListener( 'ended', function () {
+					this.load();
+				} );
+			}
+
 			// Do we need to set up Media Elements?
 			if (
 				typeof $.fn.mediaelementplayer === 'function' &&

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -48,6 +48,10 @@ if ( ! $hide_controls ) {
 	$video_args['controls'] = '';
 }
 
+if ( apply_filters( 'sow_video_show_cover_on_end', false, $instance ) ) {
+	$video_args['data-show-cover-on-end'] = 'true';
+}
+
 $so_video = new SiteOrigin_Video();
 
 do_action( 'siteorigin_widgets_sow-video_before_video', $instance );

--- a/widgets/video/tpl/default.php
+++ b/widgets/video/tpl/default.php
@@ -11,6 +11,7 @@
  * @var $video_type
  * @var $fitvids
  * @var $hide_controls
+ * @var $show_cover_on_end
  */
 if ( ! empty( $instance['title'] ) ) {
 	echo $args['before_title'] . wp_kses_post( $instance['title'] ) . $args['after_title'];
@@ -48,7 +49,7 @@ if ( ! $hide_controls ) {
 	$video_args['controls'] = '';
 }
 
-if ( apply_filters( 'sow_video_show_cover_on_end', false, $instance ) ) {
+if ( $show_cover_on_end ) {
 	$video_args['data-show-cover-on-end'] = 'true';
 }
 

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -142,12 +142,10 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 
 	public function enqueue_frontend_scripts( $instance ) {
 		$video_host = empty( $instance['host_type'] ) ? '' : $instance['host_type'];
-		$show_cover_on_end = false;
+		$show_cover_on_end = $this->show_cover_on_end( $instance );
 
 		if ( $video_host == 'external' ) {
 			$video_host = ! empty( $instance['video']['external_video'] ) ? $this->get_host_from_url( $instance['video']['external_video'] ) : '';
-		} elseif ( $video_host === 'self' ) {
-			$show_cover_on_end = apply_filters( 'sow_video_show_cover_on_end', false, $instance );
 		}
 
 		$load_video_js = false;
@@ -291,6 +289,7 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 			'skin_class'              => 'default',
 			'fitvids'                 => ! empty( $instance['playback']['fitvids'] ),
 			'hide_controls'           => $hide_controls,
+			'show_cover_on_end'       => $this->show_cover_on_end( $instance ),
 		);
 
 		if ( $instance['host_type'] == 'external' && $instance['playback']['oembed'] ) {
@@ -319,6 +318,21 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 	 */
 	private function is_skinnable_video_host( $video_host ) {
 		return isset( $this->skinnable_hosts[ $video_host ] );
+	}
+
+	/**
+	 * Determine if the cover image should be restored when a self-hosted video ends.
+	 *
+	 * @param array $instance The widget instance settings.
+	 *
+	 * @return bool
+	 */
+	private function show_cover_on_end( $instance ) {
+		if ( empty( $instance['host_type'] ) || $instance['host_type'] !== 'self' ) {
+			return false;
+		}
+
+		return (bool) apply_filters( 'sow_video_show_cover_on_end', false, $instance );
 	}
 
 	public function get_less_variables( $instance ) {

--- a/widgets/video/video.php
+++ b/widgets/video/video.php
@@ -142,9 +142,12 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 
 	public function enqueue_frontend_scripts( $instance ) {
 		$video_host = empty( $instance['host_type'] ) ? '' : $instance['host_type'];
+		$show_cover_on_end = false;
 
 		if ( $video_host == 'external' ) {
 			$video_host = ! empty( $instance['video']['external_video'] ) ? $this->get_host_from_url( $instance['video']['external_video'] ) : '';
+		} elseif ( $video_host === 'self' ) {
+			$show_cover_on_end = apply_filters( 'sow_video_show_cover_on_end', false, $instance );
 		}
 
 		$load_video_js = false;
@@ -165,7 +168,8 @@ class SiteOrigin_Widget_Video_Widget extends SiteOrigin_Widget {
 
 			if (
 				$video_host !== 'self' ||
-				! empty( $instance['playback']['hide_controls'] )
+				! empty( $instance['playback']['hide_controls'] ) ||
+				$show_cover_on_end
 			) {
 				$load_video_js = true;
 			}


### PR DESCRIPTION
## Summary
- Adds a `sow_video_show_cover_on_end` filter (defaults to `false`) that, when enabled, resets a self-hosted video back to its poster/cover image after playback ends instead of freezing on the last frame.
- Users can enable it with `add_filter( 'sow_video_show_cover_on_end', '__return_true' );`

## How it works
- The filter adds a `data-show-cover-on-end` attribute to the `<video>` element via the existing `$video_args` array.
- The JS listens for the `ended` event and calls `video.load()` to reset the player to its initial state, re-displaying the poster image.

## Test plan
- [x] Add a self-hosted video with a cover image, confirm default behavior is unchanged (freezes on last frame)
- [x] Enable the filter and confirm the video resets to the cover image after playback ends
- [x] Confirm it works with both MediaElement.js controls and hidden controls
- [x] Confirm loop still takes priority (looped videos don't fire `ended`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)