### PR TITLE
Features: Link Title When Column Link Overlay Is Enabled

### DIFF
--- a/widgets/features/tpl/default.php
+++ b/widgets/features/tpl/default.php
@@ -119,8 +119,7 @@ if ( empty( $instance['features'] ) ) {
 						<?php
 						if (
 							! empty( $feature['more_url'] ) &&
-							$instance['title_link'] &&
-							! $link_overlay
+							( $instance['title_link'] || $link_overlay )
 						) {
 						?>
 							<a
@@ -136,8 +135,7 @@ if ( empty( $instance['features'] ) ) {
 
 						if (
 							! empty( $feature['more_url'] ) &&
-							$instance['title_link'] &&
-							! $link_overlay
+							( $instance['title_link'] || $link_overlay )
 						) {
 								?>
 							</a>


### PR DESCRIPTION
## Summary
- When "Link feature column to more URL" is enabled, the title was not being linked. The condition explicitly excluded the title link when the overlay was active (`! $link_overlay`), but the overlay's z-index approach means content sits above the link — so the title needs its own `<a>` tag to be clickable.
- Changed the condition so the title is linked when either `title_link` or `link_overlay` is true.

## Test plan
- [x] Enable "Link feature column to more URL" with a more URL set — confirm the title is now a clickable link
- [x] Disable "Link feature column to more URL", enable "Link feature title to more URL" — confirm title link still works independently
- [x] Disable both settings — confirm no title link is rendered
- [x] Test with "Link icon to more URL" enabled alongside column overlay — confirm both icon and title are linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)