### PR TITLE
Fix Widget Form and Admin Styling for WP 7

### DIFF
--- a/admin/admin.less
+++ b/admin/admin.less
@@ -273,7 +273,15 @@
 					margin-right: 1em;
 					margin-top: .5em;
 				}
-				
+
+				.so-widget-toggle-active button,
+				.so-widget-settings {
+					font-size: 13px;
+					line-height: 2.15384615;
+					min-height: 30px;
+					padding: 0 10px;
+				}
+
 				.so-widget-toggle-active button:focus {
 					outline: none;
 				}

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -907,6 +907,13 @@ div.siteorigin-widget-form {
 
 .siteorigin-widget-preview {
 	display: block !important;
+
+	.siteorigin-widget-preview-button.button-secondary {
+		min-height: 30px;
+		line-height: 2.15384615;
+		font-size: 13px;
+		padding: 0 10px;
+	}
 }
 
 .siteorigin-widget-help-link {

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -1101,6 +1101,9 @@ div.siteorigin-widget-form {
 				&[type=checkbox] {
 					appearance: auto !important;
 					background-color: #ffffff;
+					width: 16px;
+					height: 16px;
+					min-height: 16px;
 				}
 			}
 

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -1102,11 +1102,26 @@ div.siteorigin-widget-form {
 					width: 16px;
 					height: 16px;
 					min-height: 16px;
+					border: 1px solid #8c8f94;
+					border-radius: 3px;
+					background: #fff;
+
+					&:checked {
+						background: #fff;
+						border-color: #8c8f94;
+					}
 
 					&:checked::before {
-						margin: 0;
-						width: 16px;
-						height: 16px;
+						content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E");
+						margin: -3px 0 0 -4px;
+						width: 1.3125rem;
+						height: 1.3125rem;
+					}
+
+					&:focus {
+						border-color: #2271b1;
+						box-shadow: 0 0 0 1px #2271b1;
+						outline: 2px solid transparent;
 					}
 				}
 			}

--- a/base/css/admin.less
+++ b/base/css/admin.less
@@ -1099,11 +1099,15 @@ div.siteorigin-widget-form {
 				line-height: 2;
 
 				&[type=checkbox] {
-					appearance: auto !important;
-					background-color: #ffffff;
 					width: 16px;
 					height: 16px;
 					min-height: 16px;
+
+					&:checked::before {
+						margin: 0;
+						width: 16px;
+						height: 16px;
+					}
 				}
 			}
 

--- a/base/inc/fields/css/measurement-field.less
+++ b/base/inc/fields/css/measurement-field.less
@@ -10,8 +10,17 @@ div.siteorigin-widget-form div.siteorigin-widget-field.siteorigin-widget-field {
 
 	select.sow-measurement-select-unit {
 		min-width: inherit;
-		padding: 0 24px 0;
+		padding: 0 24px 0 8px;
 		width: auto;
+		-webkit-appearance: none;
+		background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
+		background-size: 16px 16px;
+		border: 1px solid #8c8f94;
+		border-radius: 3px;
+		cursor: pointer;
+		font-size: 14px;
+		line-height: 2;
+		min-height: 30px;
 	}
 
 	input[type="text"].siteorigin-widget-input-measurement,

--- a/base/inc/fields/css/multi-measurement-field.less
+++ b/base/inc/fields/css/multi-measurement-field.less
@@ -19,9 +19,17 @@ div.siteorigin-widget-form div.siteorigin-widget-field.siteorigin-widget-field {
 			}
 
 			select.sow-multi-measurement-select-unit {
-				border: 1px solid #646970;
-				line-height: 24px;
+				border: 1px solid #8c8f94;
+				line-height: 2;
 				min-width: inherit;
+				padding: 0 24px 0 8px;
+				-webkit-appearance: none;
+				background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
+				background-size: 16px 16px;
+				border-radius: 3px;
+				cursor: pointer;
+				font-size: 14px;
+				min-height: 30px;
 
 				&:focus,
 				&:hover {


### PR DESCRIPTION
## Summary

- Fix measurement field select dropdowns losing their chevron when WP 7 block CSS strips native appearance
- Restore WP 6-style checkbox appearance (white background, blue checkmark, simple focus border) to counter WP 7's filled-background checkbox styling
- Normalize widget admin page button and Preview button sizing against WP 7's inflated `min-height: 40px`

## Changes

- **Measurement selects:** Add custom SVG chevron, `-webkit-appearance: none`, and WP 5.7.2 select styling to `sow-measurement-select-unit` and `sow-multi-measurement-select-unit`
- **Checkboxes:** Override WP 7's checked state (filled theme-color background, white checkmark, glow focus ring) with WP 6 values (white background, blue `#3582c4` checkmark, simple border focus)
- **Admin page buttons:** Pin WP 5.7.2 button dimensions on Deactivate/Settings buttons in `.so-action-links`
- **Preview button:** Pin `min-height: 30px` and WP 5.7.2 line-height on `.siteorigin-widget-preview-button`

## Test Plan

- [ ] WP 7 Block Editor: Insert a widget with measurement fields (e.g., Features), verify px/em/% dropdown shows a proper chevron
- [ ] WP 7 Block Editor: Verify checkboxes are 16px, white background, blue checkmark when checked, simple border on focus
- [ ] WP 7 Plugins > SiteOrigin Widgets: Verify Deactivate/Settings buttons match WP 6 sizing
- [ ] WP 7 Panels dialog: Verify Preview button is not inflated
- [ ] WP 6 / Classic Editor: Verify no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)