### PR TITLE
Include Accessibility CSS in Release Builds

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -56,6 +56,7 @@ module.exports = {
             'icons/**/!(*.js|*.less|*.css)',
             'js/**/!(*.js|*.less|*.css)',
             'widgets/**/!(*.js|*.less|*.css)',
+            'css/*.css',                                          // Copy static root CSS assets.
             'icons/**/*css',                                      // Copy CSS for icon packs.
             'js/lib/**/*css',                                     // Copy CSS for JS libs.
             'css/lib/**/*css',                                    // Copy CSS for JS libs.


### PR DESCRIPTION
## Summary
- Include Root-Level CSS Files in the Release Copy Patterns.
- Ensure `css/accessibility.css` Is Included in the Built Plugin.

## Verification
- Confirmed `css/accessibility.css` Matches the Resolved Copy Globs.
- Ran `npm run copy` in `build/`.
- Verified `tmp/css/accessibility.css` Is Present After the Copy Step.