### PR TITLE
Anything Carousel: add bottom-right arrows layout

### DIFF
--- a/widgets/anything-carousel/anything-carousel.php
+++ b/widgets/anything-carousel/anything-carousel.php
@@ -147,6 +147,15 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 						'label' => __( 'Navigation', 'so-widgets-bundle' ),
 						'hide' => true,
 						'fields' => array(
+							'arrows_location' => array(
+								'type' => 'radio',
+								'label' => __( 'Arrows Location', 'so-widgets-bundle' ),
+								'default' => 'left_right',
+								'options' => array(
+									'left_right' => __( 'Left and Right', 'so-widgets-bundle' ),
+									'bottom_right' => __( 'Bottom Right', 'so-widgets-bundle' ),
+								),
+							),
 							'arrow_color' => array(
 								'type' => 'color',
 								'label' => __( 'Arrows Color', 'so-widgets-bundle' ),
@@ -296,19 +305,23 @@ class SiteOrigin_Widget_Anything_Carousel_Widget extends SiteOrigin_Widget_Base_
 
 	public function get_template_variables( $instance, $args ) {
 		$carousel_settings = $this->carousel_settings_template_variables( $instance['carousel_settings'], false );
+		$arrows_location = ! empty( $instance['design']['navigation']['arrows_location'] ) ? $instance['design']['navigation']['arrows_location'] : 'left_right';
 		$carousel_settings['adaptive_height'] = $instance['carousel_settings']['adaptive_height'];
+		$carousel_settings['appendDots'] = $arrows_location === 'bottom_right';
 
 		return array(
 			'settings' => array(
 				'title' => $instance['title'],
 				'item_template' => plugin_dir_path( __FILE__ ) . 'tpl/item.php',
-				'navigation' => 'side',
+				'navigation' => $arrows_location === 'bottom_right' ? 'container' : 'side',
 				'navigation_arrows' => isset( $instance['carousel_settings']['arrows'] ) ? ! empty( $instance['carousel_settings']['arrows'] ) : true,
+				'navigation_dots' => isset( $instance['carousel_settings']['dots'] ) ? ! empty( $instance['carousel_settings']['dots'] ) : true,
 				'item_title_tag' => siteorigin_widget_valid_tag(
 					$instance['design']['item_title']['tag'],
 					'h4'
 				),
 				'items' => ! empty( $instance['items'] ) ? $instance['items'] : array(),
+				'container_classes' => $arrows_location === 'bottom_right' ? array( 'sow-anything-carousel-nav-bottom-right' ) : array(),
 				'attributes' => array(
 					'widget' => 'anything',
 					'item_count' => ! empty( $instance['items'] ) ? count( $instance['items'] ) : 0,

--- a/widgets/anything-carousel/css/style.less
+++ b/widgets/anything-carousel/css/style.less
@@ -63,6 +63,59 @@
 			}
 		}
 
+		&.sow-anything-carousel-nav-bottom-right {
+
+			.sow-carousel-nav {
+				align-items: center;
+				display: flex;
+				gap: 24px;
+				width: 100%;
+
+				body.rtl & {
+					flex-direction: row-reverse;
+				}
+
+				.slick-dots {
+					flex: 1 1 auto;
+					order: 1;
+					text-align: left;
+					width: auto;
+
+					body.rtl & {
+						order: 2;
+						text-align: right;
+					}
+				}
+
+				.sow-carousel-nav-arrows {
+					display: flex;
+					flex-shrink: 0;
+					gap: 12px;
+					margin-left: auto;
+					order: 2;
+
+					body.rtl & {
+						margin-left: 0;
+						margin-right: auto;
+						order: 1;
+					}
+
+					a.sow-carousel-next,
+					a.sow-carousel-previous {
+						-moz-osx-font-smoothing: grayscale;
+						-webkit-font-smoothing: antialiased;
+						font-family: 'anything-carousel-arrows';
+						font-style: normal;
+						font-variant: normal;
+						font-weight: normal;
+						text-align: center;
+						text-decoration: none;
+						text-transform: none;
+					}
+				}
+			}
+		}
+
 
 		.sow-carousel-wrapper {
 			left: 0;

--- a/widgets/anything-carousel/styles/base.less
+++ b/widgets/anything-carousel/styles/base.less
@@ -108,8 +108,79 @@
 		display: none !important;
 	}
 
-	.sow-carousel-wrapper {
+	&.sow-anything-carousel-nav-bottom-right {
 
+		.sow-carousel-nav {
+			align-items: center;
+			display: flex;
+			gap: 24px;
+			margin-top: @navigation_arrow_margin;
+			width: 100%;
+
+			body.rtl & {
+				flex-direction: row-reverse;
+			}
+
+			.slick-dots {
+				flex: 1 1 auto;
+				order: 1;
+				text-align: left;
+				width: auto;
+
+				body.rtl & {
+					order: 2;
+					text-align: right;
+				}
+			}
+
+			.sow-carousel-nav-arrows {
+				display: flex;
+				flex-shrink: 0;
+				gap: 12px;
+				margin-left: auto;
+				order: 2;
+
+				body.rtl & {
+					margin-left: 0;
+					margin-right: auto;
+					order: 1;
+				}
+
+				a.sow-carousel-next,
+				a.sow-carousel-previous {
+					-moz-osx-font-smoothing: grayscale;
+					-webkit-font-smoothing: antialiased;
+					font-family: 'anything-carousel-arrows';
+					font-style: normal;
+					font-variant: normal;
+					font-weight: normal;
+					text-align: center;
+					text-decoration: none;
+					text-transform: none;
+				}
+			}
+
+			a.sow-carousel-previous {
+				margin-right: 0;
+				order: 1;
+
+				body.rtl & {
+					order: 2;
+				}
+			}
+
+			a.sow-carousel-next {
+				margin-left: 0;
+				order: 2;
+
+				body.rtl & {
+					order: 1;
+				}
+			}
+		}
+	}
+
+	.sow-carousel-wrapper {
 		.sow-carousel-items {
 
 			.sow-carousel-item {


### PR DESCRIPTION
## Summary
- add an `Arrows Location` control to Anything Carousel with `Left and Right` and `Bottom Right`
- render the bottom-right mode using the shared bottom navigation container with dots on the left and arrows on the right
- keep `Arrows Margin` active for both layouts, using it as the spacing above the bottom navigation row in bottom-right mode

## Testing
- php -l widgets/anything-carousel/anything-carousel.php
- git diff --check