### PR TITLE
Fix hero FitText refresh on mobile

### DIFF
--- a/js/slider/jquery.slider.js
+++ b/js/slider/jquery.slider.js
@@ -274,6 +274,10 @@ jQuery( function( $ ) {
 				// Show everything for this slider
 				$base.show();
 
+				if ( typeof sowb.runFitText === 'function' ) {
+					sowb.runFitText();
+				}
+
 				var resizeFrames = function() {
 					$$.find( '.sow-slider-image' ).each( function() {
 						var $i = $( this );
@@ -308,6 +312,9 @@ jQuery( function( $ ) {
 							var $$ = $( this );
 							siteoriginSlider.playSlideVideo( incomingSlideEl );
 							siteoriginSlider.setupActiveSlide( $$, incomingSlideEl );
+							if ( typeof sowb.runFitText === 'function' ) {
+								sowb.runFitText();
+							}
 							$( incomingSlideEl ).trigger( 'sowSlideCycleAfter' );
 						},
 
@@ -322,6 +329,9 @@ jQuery( function( $ ) {
 						'cycle-initialized' : function( event, optionHash ) {
 							siteoriginSlider.playSlideVideo( $( this ).find( '.cycle-slide-active' ) );
 							siteoriginSlider.setupActiveSlide( $$, optionHash.slides[0] );
+							if ( typeof sowb.runFitText === 'function' ) {
+								sowb.runFitText();
+							}
 
 							$p.find( '>li' ).removeClass( 'sow-active' ).eq( 0 ).addClass( 'sow-active' );
 							$( this ).find( '.cycle-slide-active' ).trigger( 'sowSlideInitial' );

--- a/js/sow.jquery.fittext.js
+++ b/js/sow.jquery.fittext.js
@@ -12,47 +12,70 @@ var sowb = window.sowb || {};
 
 (function ($) {
 
-    $.fn.fitText = function (kompressor, options) {
+	$.fn.fitText = function (kompressor, options) {
 
-        // Setup options
-        var compressor = kompressor || 1,
-            settings = $.extend({
-                'minFontSize': Number.NEGATIVE_INFINITY,
-                'maxFontSize': Number.POSITIVE_INFINITY
-            }, options);
+		// Setup options
+		var compressor = kompressor || 1,
+			settings = $.extend({
+				'minFontSize': Number.NEGATIVE_INFINITY,
+				'maxFontSize': Number.POSITIVE_INFINITY
+			}, options);
 
-        return this.each(function () {
+		return this.each(function () {
 
-            // Store the object
-            var $this = $(this);
+			// Store the object
+			var $this = $(this);
+			var fitTextData = $this.data( 'fitTextData' ) || {};
 
-            // Resizer() resizes items based on the object width divided by the compressor * 10
-            var resizer = function () {
-                $this.css('font-size', Math.max(Math.min($this.width() / (compressor * 10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
-            };
+			if ( fitTextData.initialized ) {
+				fitTextData.resizer();
+				return;
+			}
 
-            // Call once to set.
-            resizer();
+			// Resizer() resizes items based on the object width divided by the compressor * 10
+			var resizer = function () {
+				var width = $this.width();
 
-            // Call on resize. Opera debounces their resize by default.
-            $(window).on('resize.fittext orientationchange.fittext', resizer);
+				if ( ! width ) {
+					return;
+				}
+
+				$this.css(
+					'font-size',
+					Math.max(
+						Math.min( width / ( compressor * 10 ), parseFloat( settings.maxFontSize ) ),
+						parseFloat( settings.minFontSize )
+					)
+				);
+			};
+
+			fitTextData.initialized = true;
+			fitTextData.resizer = resizer;
+			$this.data( 'fitTextData', fitTextData );
+
+			// Call once to set.
+			resizer();
+
+			// Call on resize. Opera debounces their resize by default.
+			$( window ).on( 'resize.fittext orientationchange.fittext', resizer );
 			$( sowb ).on( 'setup_widgets', resizer );
 
-        });
-    };
+		});
+	};
 })(jQuery);
 
 jQuery( function( $ ){
 
-    // Apply FitText to all Widgets Bundle FitText wrappers
+	// Apply FitText to all Widgets Bundle FitText wrappers
 	sowb.runFitText = function () {
 		$( '.so-widget-fittext-wrapper' ).each( function() {
 			var fitTextWrapper = $( this );
-			if ( ! fitTextWrapper.is( ':visible' ) || fitTextWrapper.data( 'fitTextDone' ) ) {
+			if ( ! fitTextWrapper.is( ':visible' ) ) {
 				return fitTextWrapper;
 			}
 
 			var compressor = fitTextWrapper.data( 'fitTextCompressor' ) || 0.85;
+			var fitTextDone = fitTextWrapper.data( 'fitTextDone' );
 			fitTextWrapper.find( 'h1,h2,h3,h4,h5,h6' ).each( function () {
 				var $$ = $( this );
 				$$.fitText( compressor, {
@@ -60,13 +83,21 @@ jQuery( function( $ ){
 					maxFontSize: $$.css( 'font-size' )
 				} );
 			} );
-			fitTextWrapper.data( 'fitTextDone', true );
-			fitTextWrapper.trigger( 'fitTextDone' );
+
+			if ( ! fitTextDone ) {
+				fitTextWrapper.data( 'fitTextDone', true );
+				fitTextWrapper.trigger( 'fitTextDone' );
+			}
 		});
 	};
 
 	$( window ).on( 'resize', sowb.runFitText );
+	$( window ).on( 'load', sowb.runFitText );
 	$( sowb ).on( 'setup_widgets', sowb.runFitText );
+
+	if ( document.fonts && document.fonts.ready ) {
+		document.fonts.ready.then( sowb.runFitText );
+	}
 
 	sowb.runFitText();
 } );


### PR DESCRIPTION
## Summary
- allow FitText headings to be remeasured after initial setup instead of locking after the first pass
- rerun FitText when hidden sliders are revealed and when the active slide initializes or changes
- refresh FitText after page load and webfont readiness to avoid stale first-slide measurements on mobile

## Testing
- node -e "const fs=require('fs'); new Function(fs.readFileSync('js/sow.jquery.fittext.js','utf8')); new Function(fs.readFileSync('js/slider/jquery.slider.js','utf8')); console.log('syntax ok');"
- git diff --check
- node /Users/misplon/.codex/skills/wp-project-triage/scripts/detect_wp_project.mjs
- node /Users/misplon/.codex/skills/wp-plugin-development/scripts/detect_plugins.mjs