### PR TITLE
WP 7: Restore widgets search sizing

### DIFF
--- a/admin/admin.less
+++ b/admin/admin.less
@@ -75,6 +75,9 @@
 			input{
 				box-sizing: border-box;
 				width: 200px;
+				padding: 0 8px;
+				line-height: 2;
+				min-height: 30px;
 			}
 
 			.results {


### PR DESCRIPTION
## Summary
- restore WP 6-sized Widgets Bundle admin search field sizing under WP 7

## Root Cause
The earlier WP 7 styling rollback covered the main widget form and admin-button surfaces, but the top-level Widgets Bundle admin search field still relied on newer core input sizing and appeared taller than it did in WP 6.

## Changes
- apply WP 6 input sizing to the Widgets Bundle admin page search field

## Testing
- verified the Widgets Bundle admin page search field sizing
