### PR TITLE
Cards Carousel: Scope overflow hidden to panel instead of cell

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -251,11 +251,11 @@ jQuery( function ( $ ) {
 			} );
 
 			if ( carouselSettings.theme === 'cards' ) {
-				// To prevent a sizing issue, we need to check if the Cards Carousel
-				// is inside of a Layout Builder, and if so, set the parent container
-				// to overflow hidden.
+				// To prevent card shadows from visually overflowing,
+				// set overflow hidden on the panel rather than the
+				// cell to avoid affecting sibling cell sizing.
 				if ( $$.closest( '.widget_siteorigin-panels-builder' ).length ) {
-					const $cell = $$.closest( '.so-panel' ).parent().css( 'overflow', 'hidden' );
+					$$.closest( '.so-panel' ).css( 'overflow', 'hidden' );
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Fixes an issue where multiple Post Carousel Cards widgets in the same Layout Builder row rendered the last widget's featured image at a slightly smaller size
- The `overflow: hidden` added in 5158f041 was being set on the cell parent, affecting flex layout calculations for sibling cells
- Scopes `overflow: hidden` to `.so-panel` instead of `.so-panel.parent()` to preserve shadow clipping without impacting cell sizing

## Test plan
- [ ] Add three Post Carousel Cards widgets in a single Layout Builder row with spacer cells on each side
- [ ] Verify all featured images render at the same size
- [ ] Verify card shadows are still properly clipped and don't overflow the cell