### PR TITLE
Fix double border on TinyMCE editor in Panels dialog

### DIFF
--- a/base/inc/fields/css/tinymce-field.less
+++ b/base/inc/fields/css/tinymce-field.less
@@ -6,3 +6,7 @@
 #mceu_44-body {
 	z-index: 1000000 !important;
 }
+
+.siteorigin-widget-tinymce-container .wp-editor-container textarea.wp-editor-area {
+	border: none;
+}

--- a/base/inc/fields/css/tinymce-field.less
+++ b/base/inc/fields/css/tinymce-field.less
@@ -7,6 +7,20 @@
 	z-index: 1000000 !important;
 }
 
+.siteorigin-widget-tinymce-container .wp-editor-container {
+	border-color: #c3c4c7;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.siteorigin-widget-tinymce-container .wp-switch-editor {
+	border-color: #c3c4c7;
+}
+
+.siteorigin-widget-tinymce-container .tmce-active .switch-tmce,
+.siteorigin-widget-tinymce-container .html-active .switch-html {
+	border-bottom-color: #f6f7f7;
+}
+
 .siteorigin-widget-tinymce-container .wp-editor-container textarea.wp-editor-area {
 	border: none;
 }


### PR DESCRIPTION
## Summary
- Fixes a double border around the TinyMCE editor textarea in the Panels widget dialog.
- The textarea was getting a border from Panels' admin CSS (`.so-panels-dialog .so-content textarea`), while `.wp-editor-container` already has its own border from WordPress core's `editor.min.css`. Both were visible as nested borders.
- Removes the textarea border when inside a `wp-editor-container`, letting the container border serve as the single border.

Fixes #2302

## Test plan
- [ ] Open a widget with a TinyMCE field (e.g., Hero Widget) in the Panels dialog
- [ ] Confirm only a single border appears around the editor in Code/Text mode
- [ ] Switch to Visual mode and confirm no double border
- [ ] Test in the block editor widget form to ensure no regression