### PR TITLE
Feature/sowb block editor iframe asset clone no polling

### DIFF
--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -1,12 +1,19 @@
 /* global jQuery, soWidgets */
 
 ( function( $ ) {
+	const isRepeaterTemplateField = function( $field ) {
+		return $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+	};
 
 	const setupMediaField = function( e ) {
 		const $field = $( this );
 		const $media = $field.find( '> .media-field-wrapper' );
 		const $inputField = $field.find( '.siteorigin-widget-input' ).not( '.media-fallback-external' );
 		const $externalField = $field.find( '.media-fallback-external' );
+
+		if ( isRepeaterTemplateField( $field ) ) {
+			return;
+		}
 
 		if ( $field.attr( 'data-initialized' ) ) {
 			return;
@@ -487,7 +494,12 @@
 	window.addEventListener( 'message', function( e ) {
 		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
 			$( '.siteorigin-widget-field-type-media' ).each( function() {
-				if ( $( this ).attr( 'data-initialized' ) ) {
+				const $field = $( this );
+
+				if (
+					isRepeaterTemplateField( $field ) ||
+					$field.attr( 'data-initialized' )
+				) {
 					return;
 				}
 

--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -471,9 +471,10 @@
 		} );
 	};
 
-	// If the current page isn't the site editor, set up the Media field now.
+	// In the Site Editor iframe, repeater rows added after the initial block
+	// postMessage still rely on the normal field setup event.
 	if (
-		window.top === window.self &&
+		window.top !== window.self ||
 		(
 			typeof pagenow === 'string' &&
 			pagenow !== 'site-editor'

--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -156,16 +156,17 @@
 		$field.data( 'initialized', true );
 	};
 
-	 // If the current page isn't the site editor, set up the Multiple Media field now.
-	 if (
-		 window.top === window.self &&
-		 (
-			 typeof pagenow === 'string' &&
-			 pagenow !== 'site-editor'
-		 )
-	 ) {
-		 $( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-multiple_media', setupMultipleMediaField );
-	 }
+	// In the Site Editor iframe, repeater rows added after the initial block
+	// postMessage still rely on the normal field setup event.
+	if (
+		window.top !== window.self ||
+		(
+			typeof pagenow === 'string' &&
+			pagenow !== 'site-editor'
+		)
+	) {
+		$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-multiple_media', setupMultipleMediaField );
+	}
 
 	// Add support for the Site Editor.
 	window.addEventListener( 'message', function( e ) {

--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -1,8 +1,16 @@
 /* global jQuery, soWidgets */
 
 ( function( $ ) {
+	const isRepeaterTemplateField = function( $field ) {
+		return $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+	};
+
 	const setupMultipleMediaField = function() {
 		const $field = $( this );
+
+		if ( isRepeaterTemplateField( $field ) ) {
+			return;
+		}
 
 		if ( $field.data( 'initialized' ) ) {
 			return;
@@ -172,6 +180,10 @@
 	window.addEventListener( 'message', function( e ) {
 		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
 			$( '.siteorigin-widget-field-type-multiple_media' ).each( function() {
+				if ( isRepeaterTemplateField( $( this ) ) ) {
+					return;
+				}
+
 				setupMultipleMediaField.call( this );
 			} );
 		}

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -575,16 +575,19 @@
 			.attr( 'data-tinymce-id', id )
 			.attr( 'id', id );
 
-		let _resolveInitPending;
-		_tinymceInitPending[ id ] = {
-			promise: new Promise( function( resolve ) {
-				_resolveInitPending = resolve;
-			} ),
-			resolve: function() {
-				_resolveInitPending();
-				delete _tinymceInitPending[ id ];
-			},
-		};
+		_tinymceInitPending[ id ] = ( function( entryId ) {
+			let storedResolve;
+			const promise = new Promise( function( resolve ) {
+				storedResolve = resolve;
+			} );
+			return {
+				promise: promise,
+				resolve: function() {
+					storedResolve();
+					delete _tinymceInitPending[ entryId ];
+				},
+			};
+		} )( id );
 
 		$field
 			.data( 'sowb-tinymce-initializing', true )

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -206,48 +206,6 @@
 			.replace( /^-+|-+$/g, '' );
 	};
 
-	const sanitizeTinyMCEContent = function( content ) {
-		if (
-			window.sowbForms &&
-			typeof window.sowbForms.sanitizeTinyMCEContent === 'function'
-		) {
-			return window.sowbForms.sanitizeTinyMCEContent( content );
-		}
-
-		if ( typeof content !== 'string' || content.length === 0 ) {
-			return content;
-		}
-
-		if (
-			content.indexOf( 'mce_SELRES_' ) === -1 &&
-			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
-			content.indexOf( '\uFEFF' ) === -1
-		) {
-			return content;
-		}
-
-		const wrapper = document.createElement( 'div' );
-		wrapper.innerHTML = content;
-		wrapper
-			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
-			.forEach( ( marker ) => marker.remove() );
-
-		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
-	};
-
-	const saveTinyMCEEditorContent = function( editor, $textarea ) {
-		if ( ! editor || typeof editor.getContent !== 'function' ) {
-			return '';
-		}
-
-		const content = sanitizeTinyMCEContent( editor.getContent() );
-		if ( $textarea && $textarea.length ) {
-			$textarea.val( content );
-		}
-
-		return content;
-	};
-
 	/**
 	 * Resolves the best available WordPress editor API object.
 	 *
@@ -308,10 +266,7 @@
 
 			if ( editor ) {
 				editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
-				saveTinyMCEEditorContent(
-					editor,
-					$( typeof editor.getElement === 'function' ? editor.getElement() : document.getElementById( editorId ) )
-				);
+				editor.save();
 				editor.fire( 'change' );
 			}
 		} );
@@ -602,16 +557,6 @@
 		let id = $textarea.attr( 'data-tinymce-id' ) || $textarea.data( 'tinymce-id' );
 		const fieldElement = $field.get( 0 );
 		const textareaElement = $textarea.get( 0 );
-		const updateTextTabLabel = function() {
-			const textTab = document.getElementById( id + '-html' );
-			if ( textTab ) {
-				const codeLabel = window.top.wp && window.top.wp.i18n && typeof window.top.wp.i18n.__ === 'function'
-					? window.top.wp.i18n.__( 'Code' )
-					: 'Code';
-				textTab.textContent = codeLabel;
-				textTab.setAttribute( 'aria-label', codeLabel );
-			}
-		};
 
 		if ( id ) {
 			const existingTextarea = document.getElementById( id );
@@ -726,7 +671,7 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
-						saveTinyMCEEditorContent( ed, $textarea );
+						ed.save();
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -751,7 +696,10 @@
 					if ( window.frameElement ) {
 						// Fix code tab label in the Site Editor.
 						editor.on( 'init', () => {
-							updateTextTabLabel();
+							const textTab = document.querySelector( `#${id}-html` );
+							if ( textTab ) {
+								textTab.innerHTML = window.top.wp.i18n.__( 'Code' );
+							}
 						} );
 					}
 
@@ -809,22 +757,15 @@
 				const editor = window.tinymce.get( id );
 				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
 				if ( editor !== null ) {
-					let content = sanitizeTinyMCEContent( $textarea.val() );
+					let content = $textarea.val();
 					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
 						content = content.replace( /</g, '' );
+						$textarea.val( content );
 					}
-					$textarea.val( content );
 					editor.setContent( window.switchEditors.wpautop( content ) );
-				}
-			} else {
-				const editor = window.tinymce.get( id );
-				if ( editor !== null ) {
-					saveTinyMCEEditorContent( editor, $textarea );
 				}
 			}
 			settings.selectedEditor = mode;
-			updateTextTabLabel();
-			setTimeout( updateTextTabLabel, 0 );
 
 			$field.find( 'textarea.wp-editor-area' ).css(
 				'visibility', mode === 'tmce' ? 'hidden' : 'visible'

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -195,16 +195,27 @@
 	/**
 	 * Resolves the best available WordPress editor API object.
 	 *
+	 * Delegates to `window.sowbResolveWpEditor` (defined in widget-block.js) when
+	 * available so the guard logic lives in one place. Falls back to an inline
+	 * implementation for contexts where widget-block.js has not yet been evaluated
+	 * (e.g. classic Page Builder or widgets screen).
+	 *
 	 * Prefers `wp.oldEditor` (present in iframe contexts for legacy compatibility)
-	 * over `wp.editor` so that teardown and initialization use the same object.
+	 * over `wp.editor`, and requires the resolved object to expose `initialize()`.
 	 *
 	 * @returns {Object|null} The resolved editor API, or null if unavailable.
 	 */
 	const resolveWpEditor = function() {
+		if ( typeof window.sowbResolveWpEditor === 'function' ) {
+			return window.sowbResolveWpEditor();
+		}
 		if ( ! window.wp ) {
 			return null;
 		}
-		return window.wp.oldEditor ? window.wp.oldEditor : ( window.wp.editor || null );
+		const candidate = window.wp.oldEditor && typeof window.wp.oldEditor.initialize === 'function'
+			? window.wp.oldEditor
+			: ( window.wp.editor || null );
+		return candidate && typeof candidate.initialize === 'function' ? candidate : null;
 	};
 
 	/**

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -3,6 +3,232 @@
 ( function( $ ) {
 
 	let mediaFrameOpen = false;
+	const sowbTinyMCEEventNamespace = '.sowTinymce';
+
+	/**
+	 * Filters a jQuery collection to only those TinyMCE fields that are eligible
+	 * for editor initialization.
+	 *
+	 * Excludes fields that live inside a repeater item template
+	 * (`.siteorigin-widget-field-repeater-item-html`) and fields whose textarea ID
+	 * contains `_id_`, which indicates a placeholder that has not yet been cloned
+	 * into a real repeater row.
+	 *
+	 * @param {jQuery|Array} $fields - jQuery collection or array of field elements.
+	 *
+	 * @returns {jQuery} Filtered jQuery collection of eligible TinyMCE field elements.
+	 */
+	const getEligibleTinyMCEFields = function( $fields ) {
+		const $collection = $fields && $fields.jquery ?
+			$fields :
+			$( $fields || [] );
+
+		return $collection.filter( function() {
+			const $field = $( this );
+			const $textarea = $field.find( '.siteorigin-widget-tinymce-container textarea' ).first();
+			const textareaId = $textarea.attr( 'id' ) || '';
+
+			if ( $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length ) {
+				return false;
+			}
+
+			if ( textareaId.indexOf( '_id_' ) !== -1 ) {
+				return false;
+			}
+
+			return true;
+		} );
+	};
+
+	/**
+	 * Escapes a string for safe use as a CSS selector value.
+	 *
+	 * Uses the native `CSS.escape` when available and falls back to a manual
+	 * regex replacement that escapes all CSS special characters.
+	 *
+	 * @param {string} value - The raw string to escape.
+	 *
+	 * @returns {string} The escaped string, or an empty string if value is not a string.
+	 */
+	const escapeSelectorValue = function( value ) {
+		if ( typeof value !== 'string' ) {
+			return '';
+		}
+
+		if ( window.CSS && typeof window.CSS.escape === 'function' ) {
+			return window.CSS.escape( value );
+		}
+
+		return value.replace( /([ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1' );
+	};
+
+	/**
+	 * Selects the best matching widget form from a set of candidates.
+	 *
+	 * Scores each form on multiple signals and returns the highest-scoring one.
+	 * Scoring weights (highest to lowest priority):
+	 *   - Connected to the live document       +10000
+	 *   - Visible (not hidden by CSS)          +5000
+	 *   - Hidden by aria-hidden               -2500
+	 *   - Inside a repeater item template     -5000
+	 *   - TinyMCE field count                 ×100 per field
+	 *   - Total field count                   +1 per field
+	 *   - DOM order tie-breaker               -index/1000 (earlier wins)
+	 *
+	 * @param {jQuery} $forms - jQuery collection of candidate form elements.
+	 *
+	 * @returns {jQuery} Single-element jQuery collection containing the best form,
+	 *                   or an empty jQuery object if no forms are provided.
+	 */
+	const selectBestFormInstance = function( $forms ) {
+		if ( ! $forms || ! $forms.length ) {
+			return $( [] );
+		}
+
+		if ( $forms.length === 1 ) {
+			return $forms;
+		}
+
+		let bestScore = Number.NEGATIVE_INFINITY;
+		let bestForm = null;
+
+		$forms.each( function( index ) {
+			const $form = $( this );
+			const fieldCount = $form.find( '.siteorigin-widget-field' ).length;
+			const tinymceFieldCount = $form.find( '.siteorigin-widget-field-type-tinymce' ).length;
+			const visible = $form.is( ':visible' );
+			const hiddenByAria = $form.is( '[aria-hidden="true"]' ) || $form.closest( '[aria-hidden="true"]' ).length > 0;
+			const connected = document.documentElement.contains( this );
+			const inRepeaterTemplate = $form.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+
+			const score =
+				( connected ? 10000 : 0 ) +
+				( visible ? 5000 : 0 ) +
+				( hiddenByAria ? -2500 : 0 ) +
+				( inRepeaterTemplate ? -5000 : 0 ) +
+				( tinymceFieldCount * 100 ) +
+				fieldCount -
+				( index / 1000 );
+
+			if ( score > bestScore ) {
+				bestScore = score;
+				bestForm = this;
+			}
+		} );
+
+		return bestForm ? $( bestForm ) : $forms.first();
+	};
+
+	/**
+	 * Returns all eligible TinyMCE fields within a set of widget forms.
+	 *
+	 * When more than one form is supplied, delegates to `selectBestFormInstance`
+	 * to pick the most appropriate one before searching for fields. Within the
+	 * resolved form, visible forms are preferred over hidden ones.
+	 *
+	 * @param {jQuery} $forms - jQuery collection of widget form elements.
+	 *
+	 * @returns {jQuery} jQuery collection of eligible TinyMCE field elements.
+	 */
+	const getTinyMCEFieldsFromForms = function( $forms ) {
+		if ( ! $forms || ! $forms.length ) {
+			return $( [] );
+		}
+
+		// When multiple forms are present, delegate to selectBestFormInstance which
+		// scores on connected/visible/aria-hidden/repeater-template signals.
+		const $scopedForms = $forms.length > 1 ?
+			selectBestFormInstance( $forms ) :
+			$forms;
+
+		const $visibleForms = $scopedForms.filter( ':visible' );
+		const $activeForms = $visibleForms.length ? $visibleForms : $scopedForms;
+
+		return getEligibleTinyMCEFields(
+			$activeForms.find( '.siteorigin-widget-field-type-tinymce' )
+		);
+	};
+
+	/**
+	 * Resolves the target widget form(s) from a `sowbBlockFormInit` postMessage payload.
+	 *
+	 * Uses the `formSelector` from the message data to find matching forms, then
+	 * narrows the result using the currently-selected block's `is-selected` state
+	 * when more than one form matches. Falls back to `selectBestFormInstance` if
+	 * the selection-based narrowing still leaves multiple candidates.
+	 *
+	 * @param {Object} messageData            - The postMessage data object.
+	 * @param {string} messageData.formSelector - CSS selector targeting the form(s).
+	 * @param {string} [messageData.clientId]   - Block client ID used to narrow matches.
+	 *
+	 * @returns {jQuery} jQuery collection of the resolved form element(s).
+	 */
+	const resolvePostMessageForms = function( messageData ) {
+		if ( ! messageData || ! messageData.formSelector ) {
+			return $( [] );
+		}
+
+		let $forms = $( messageData.formSelector );
+
+		if ( $forms.length > 1 && messageData.clientId ) {
+			const escapedClientId = escapeSelectorValue( messageData.clientId );
+			const $selectedBlockForms = $(
+				'.block-editor-block-list__block.is-selected[data-block="' + escapedClientId + '"] .siteorigin-widget-form.siteorigin-widget-form-main, ' +
+				'.is-selected[data-block="' + escapedClientId + '"] .siteorigin-widget-form.siteorigin-widget-form-main, ' +
+				'[data-block="' + escapedClientId + '"][aria-selected="true"] .siteorigin-widget-form.siteorigin-widget-form-main'
+			);
+
+			if ( $selectedBlockForms.length ) {
+				$forms = selectBestFormInstance( $selectedBlockForms );
+			}
+		}
+
+		if ( $forms.length > 1 ) {
+			$forms = selectBestFormInstance( $forms );
+		}
+
+		return $forms;
+	};
+
+	/**
+	 * Sanitizes a string for use as a segment of a TinyMCE editor DOM ID.
+	 *
+	 * Replaces bracket notation (e.g. `[0]`) with hyphens, strips all characters
+	 * that are not alphanumeric, underscores, or hyphens, collapses consecutive
+	 * hyphens, and trims leading/trailing hyphens.
+	 *
+	 * @param {string} value - The raw string to sanitize.
+	 *
+	 * @returns {string} The sanitized string, or an empty string if the input is
+	 *                   not a non-empty string.
+	 */
+	const sanitizeIdSegment = function( value ) {
+		if ( typeof value !== 'string' || value.length === 0 ) {
+			return '';
+		}
+
+		return value
+			.replace( /\[[^\]]*\]/g, '-' )
+			.replace( /[^A-Za-z0-9_-]+/g, '-' )
+			.replace( /-+/g, '-' )
+			.replace( /^-+|-+$/g, '' );
+	};
+
+	/**
+	 * Resolves the best available WordPress editor API object.
+	 *
+	 * Prefers `wp.oldEditor` (present in iframe contexts for legacy compatibility)
+	 * over `wp.editor` so that teardown and initialization use the same object.
+	 *
+	 * @returns {Object|null} The resolved editor API, or null if unavailable.
+	 */
+	const resolveWpEditor = function() {
+		if ( ! window.wp ) {
+			return null;
+		}
+		return window.wp.oldEditor ? window.wp.oldEditor : ( window.wp.editor || null );
+	};
+
 	/**
 	 * Opens the WordPress media library for TinyMCE editors in an iframe context.
 	 *

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -2,6 +2,13 @@
 
 ( function( $ ) {
 
+	if ( window.sowbTinyMCEFieldScriptLoaded ) {
+		return;
+	}
+
+	window.sowbTinyMCEFieldScriptLoaded = true;
+	window.sowbTinyMCEFieldScriptLoadedAt = Date.now();
+
 	let mediaFrameOpen = false;
 	const sowbTinyMCEEventNamespace = '.sowTinymce';
 	let _tinymceDomIdSeq = 0;
@@ -584,6 +591,10 @@
 			.attr( 'data-tinymce-id', id )
 			.attr( 'id', id );
 
+		if ( textareaElement ) {
+			textareaElement.sowbTinyMCELastSyncedContent = $textarea.val();
+		}
+
 		_tinymceInitPending[ id ] = ( function( entryId ) {
 			let storedResolve;
 			const promise = new Promise( function( resolve ) {
@@ -607,50 +618,50 @@
 		$( window.document )
 			.off( 'wp-before-tinymce-init' + fieldEventNamespace )
 			.on( 'wp-before-tinymce-init' + fieldEventNamespace, function( event, init ) {
-			if ( init.selector !== settings.tinymce.selector ) {
-				return;
-			}
-
-			$( window.document ).off( 'wp-before-tinymce-init' + fieldEventNamespace );
-
-			const mediaButtons = $container.data( 'mediaButtons' );
-			if (
-				typeof mediaButtons != 'undefined' &&
-				$field.find( '.wp-media-buttons' ).length === 0
-			) {
-				$field.find( '.wp-editor-tabs' ).before( mediaButtons.html );
-			}
-
-			const addMediaButton = $field.find( '.add_media' );
-			if ( addMediaButton.length > 0 ) {
-				const $textarea = $container.find( 'textarea' );
-				const editorId = $textarea.data( 'tinymce-id' );
-				addMediaButton.attr( 'data-editor', editorId );
-
-				if ( window.frameElement ) {
-					addMediaButton
-						.removeClass( 'insert-media add_media' )
-						.addClass( 'siteorigin-widget-tinymce-add-media' )
-						.off( 'click.sowbMedia' )
-						.on( 'click.sowbMedia', () => {
-							siteEditorAddMediaOverride( editorId );
-						} );
+				if ( init.selector !== settings.tinymce.selector ) {
+					return;
 				}
-			}
-		} );
+
+				$( window.document ).off( 'wp-before-tinymce-init' + fieldEventNamespace );
+
+				const mediaButtons = $container.data( 'mediaButtons' );
+				if (
+					typeof mediaButtons != 'undefined' &&
+					$field.find( '.wp-media-buttons' ).length === 0
+				) {
+					$field.find( '.wp-editor-tabs' ).before( mediaButtons.html );
+				}
+
+				const addMediaButton = $field.find( '.add_media' );
+				if ( addMediaButton.length > 0 ) {
+					const $textarea = $container.find( 'textarea' );
+					const editorId = $textarea.data( 'tinymce-id' );
+					addMediaButton.attr( 'data-editor', editorId );
+
+					if ( window.frameElement ) {
+						addMediaButton
+							.removeClass( 'insert-media add_media' )
+							.addClass( 'siteorigin-widget-tinymce-add-media' )
+							.off( 'click.sowbMedia' )
+							.on( 'click.sowbMedia', () => {
+								siteEditorAddMediaOverride( editorId );
+							} );
+					}
+				}
+			} );
 
 		$( window.top.document )
 			.off( 'tinymce-editor-setup' + fieldEventNamespace )
 			.on( 'tinymce-editor-setup' + fieldEventNamespace, function() {
-			const $wpEditorWrap = $field.find( '.wp-editor-wrap' );
-			if ( $wpEditorWrap.length > 0 && ! $wpEditorWrap.hasClass( settings.selectedEditor + '-active' ) ) {
-				setTimeout( function() {
-					window.switchEditors.go( id );
-				}, 10 );
-			}
+				const $wpEditorWrap = $field.find( '.wp-editor-wrap' );
+				if ( $wpEditorWrap.length > 0 && ! $wpEditorWrap.hasClass( settings.selectedEditor + '-active' ) ) {
+					setTimeout( function() {
+						window.switchEditors.go( id );
+					}, 10 );
+				}
 
-			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
-		} );
+				$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
+			} );
 
 		if ( settings.tinymce ) {
 			const setupEditor = function( editor ) {
@@ -671,7 +682,20 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
+						const textareaNode = $textarea.get( 0 );
+						const previousContent = textareaNode ?
+							textareaNode.sowbTinyMCELastSyncedContent :
+							undefined;
 						ed.save();
+
+						const currentContent = $textarea.val();
+						if ( textareaNode && previousContent === currentContent ) {
+							return;
+						}
+
+						if ( textareaNode ) {
+							textareaNode.sowbTinyMCELastSyncedContent = currentContent;
+						}
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -713,6 +737,20 @@
 			window.tinymce.EditorManager.overrideDefaults( { base_url: settings.baseURL, suffix: settings.suffix } );
 		}
 
+		const initTimeoutId = setTimeout( function() {
+			if ( _tinymceInitPending[ id ] ) {
+				_tinymceInitPending[ id ].resolve();
+			}
+
+			$field.removeData( 'sowb-tinymce-initializing' );
+			$field.removeData( 'sowb-tinymce-initializing-id' );
+			// If the TinyMCE init event never fired (e.g. field removed from DOM),
+			// clean up the top-document listener so it doesn't accumulate.
+			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
+		}, 5000 );
+
+		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
+
 		// Wait for textarea to be visible before initialization.
 		if ( $textarea.is( ':visible' ) ) {
 			wpEditor.initialize( id, settings );
@@ -731,49 +769,59 @@
 			$field.data( 'sowb-tinymce-visibility-poll', intervalId );
 		}
 
-		const initTimeoutId = setTimeout( function() {
-			if ( _tinymceInitPending[ id ] ) {
-				_tinymceInitPending[ id ].resolve();
-			}
-
-			$field.removeData( 'sowb-tinymce-initializing' );
-			$field.removeData( 'sowb-tinymce-initializing-id' );
-			// If the TinyMCE init event never fired (e.g. field removed from DOM),
-			// clean up the top-document listener so it doesn't accumulate.
-			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
-		}, 5000 );
-
-		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
-
-		$field.on( 'click', function( event ) {
-			const $target = $( event.target );
-			if ( ! $target.is( '.wp-switch-editor' ) ) {
-				return;
-			}
-
-			const mode = $target.hasClass( 'switch-tmce' ) ? 'tmce' : 'html';
-
-			if ( mode === 'tmce' ) {
-				const editor = window.tinymce.get( id );
-				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
-				if ( editor !== null ) {
-					let content = $textarea.val();
-					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
-						content = content.replace( /</g, '' );
-						$textarea.val( content );
-					}
-					editor.setContent( window.switchEditors.wpautop( content ) );
+		$field
+			.off( 'click.sowTinymceSwitchEditor' )
+			.on( 'click.sowTinymceSwitchEditor', function( event ) {
+				const $target = $( event.target );
+				if ( ! $target.is( '.wp-switch-editor' ) ) {
+					return;
 				}
-			}
-			settings.selectedEditor = mode;
 
-			$field.find( 'textarea.wp-editor-area' ).css(
-				'visibility', mode === 'tmce' ? 'hidden' : 'visible'
-			);
+				const mode = $target.hasClass( 'switch-tmce' ) ? 'tmce' : 'html';
+				const $selectedEditor = $field.find( '.siteorigin-widget-tinymce-selected-editor' );
+				if ( $selectedEditor.val() === mode ) {
+					return;
+				}
 
+				const fieldNode = $field.get( 0 );
+				const now = Date.now();
+				const lastSwitchClick = fieldNode && fieldNode.sowbTinyMCELastSwitchClick ?
+					fieldNode.sowbTinyMCELastSwitchClick :
+					null;
+				if (
+					lastSwitchClick &&
+					lastSwitchClick.mode === mode &&
+					now - lastSwitchClick.time < 50
+				) {
+					return;
+				}
+				if ( fieldNode ) {
+					fieldNode.sowbTinyMCELastSwitchClick = {
+						mode,
+						time: now,
+					};
+				}
 
-			$field.find( '.siteorigin-widget-tinymce-selected-editor' ).val( mode );
-		} );
+				if ( mode === 'tmce' ) {
+					const editor = window.tinymce.get( id );
+					// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
+					if ( editor !== null ) {
+						let content = $textarea.val();
+						if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
+							content = content.replace( /</g, '' );
+							$textarea.val( content );
+						}
+						editor.setContent( window.switchEditors.wpautop( content ) );
+					}
+				}
+				settings.selectedEditor = mode;
+
+				$field.find( 'textarea.wp-editor-area' ).css(
+					'visibility', mode === 'tmce' ? 'hidden' : 'visible'
+				);
+
+				$selectedEditor.val( mode );
+			} );
 	};
 
 	/**
@@ -984,12 +1032,18 @@
 		$( document )
 			.off( 'sowsetupform' + sowbTinyMCEEventNamespace )
 			.on( 'sowsetupform' + sowbTinyMCEEventNamespace, function( e, $form ) {
-				if ( ! $form || ! $form.length ) {
+				const $setupTarget = $form && $form.jquery ?
+					$form :
+					$( $form || [] );
+				if ( ! $setupTarget.length ) {
 					return;
 				}
-				// $form is the wrapper element, not a field itself, so .find() is
-				// sufficient — no need to also .filter() the root element.
-				setupSiteEditorTinyMCEFields( $form.find( '.siteorigin-widget-field-type-tinymce' ) );
+
+				setupSiteEditorTinyMCEFields(
+					$setupTarget
+						.filter( '.siteorigin-widget-field-type-tinymce' )
+						.add( $setupTarget.find( '.siteorigin-widget-field-type-tinymce' ) )
+				);
 			} );
 
 		// sowrepeaterfieldsadded is fired by admin.js on the parent document, not the iframe's document,

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -206,6 +206,48 @@
 			.replace( /^-+|-+$/g, '' );
 	};
 
+	const sanitizeTinyMCEContent = function( content ) {
+		if (
+			window.sowbForms &&
+			typeof window.sowbForms.sanitizeTinyMCEContent === 'function'
+		) {
+			return window.sowbForms.sanitizeTinyMCEContent( content );
+		}
+
+		if ( typeof content !== 'string' || content.length === 0 ) {
+			return content;
+		}
+
+		if (
+			content.indexOf( 'mce_SELRES_' ) === -1 &&
+			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
+			content.indexOf( '\uFEFF' ) === -1
+		) {
+			return content;
+		}
+
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = content;
+		wrapper
+			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
+			.forEach( ( marker ) => marker.remove() );
+
+		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+	};
+
+	const saveTinyMCEEditorContent = function( editor, $textarea ) {
+		if ( ! editor || typeof editor.getContent !== 'function' ) {
+			return '';
+		}
+
+		const content = sanitizeTinyMCEContent( editor.getContent() );
+		if ( $textarea && $textarea.length ) {
+			$textarea.val( content );
+		}
+
+		return content;
+	};
+
 	/**
 	 * Resolves the best available WordPress editor API object.
 	 *
@@ -266,7 +308,10 @@
 
 			if ( editor ) {
 				editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
-				editor.save();
+				saveTinyMCEEditorContent(
+					editor,
+					$( typeof editor.getElement === 'function' ? editor.getElement() : document.getElementById( editorId ) )
+				);
 				editor.fire( 'change' );
 			}
 		} );
@@ -557,6 +602,16 @@
 		let id = $textarea.attr( 'data-tinymce-id' ) || $textarea.data( 'tinymce-id' );
 		const fieldElement = $field.get( 0 );
 		const textareaElement = $textarea.get( 0 );
+		const updateTextTabLabel = function() {
+			const textTab = document.getElementById( id + '-html' );
+			if ( textTab ) {
+				const codeLabel = window.top.wp && window.top.wp.i18n && typeof window.top.wp.i18n.__ === 'function'
+					? window.top.wp.i18n.__( 'Code' )
+					: 'Code';
+				textTab.textContent = codeLabel;
+				textTab.setAttribute( 'aria-label', codeLabel );
+			}
+		};
 
 		if ( id ) {
 			const existingTextarea = document.getElementById( id );
@@ -671,7 +726,7 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
-						ed.save();
+						saveTinyMCEEditorContent( ed, $textarea );
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -696,10 +751,7 @@
 					if ( window.frameElement ) {
 						// Fix code tab label in the Site Editor.
 						editor.on( 'init', () => {
-							const textTab = document.querySelector( `#${id}-html` );
-							if ( textTab ) {
-								textTab.innerHTML = window.top.wp.i18n.__( 'Code' );
-							}
+							updateTextTabLabel();
 						} );
 					}
 
@@ -757,15 +809,22 @@
 				const editor = window.tinymce.get( id );
 				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
 				if ( editor !== null ) {
-					let content = $textarea.val();
+					let content = sanitizeTinyMCEContent( $textarea.val() );
 					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
 						content = content.replace( /</g, '' );
-						$textarea.val( content );
 					}
+					$textarea.val( content );
 					editor.setContent( window.switchEditors.wpautop( content ) );
+				}
+			} else {
+				const editor = window.tinymce.get( id );
+				if ( editor !== null ) {
+					saveTinyMCEEditorContent( editor, $textarea );
 				}
 			}
 			settings.selectedEditor = mode;
+			updateTextTabLabel();
+			setTimeout( updateTextTabLabel, 0 );
 
 			$field.find( 'textarea.wp-editor-area' ).css(
 				'visibility', mode === 'tmce' ? 'hidden' : 'visible'

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -314,8 +314,17 @@
 			$field.removeData( 'sowb-tinymce-init-timeout' );
 		}
 
+		// If an init was in flight, resolve (and remove) its pending promise now.
+		// The safety timeout was the only other resolver; cancelling it above without
+		// resolving here would leave sowbGetTinyMCEInitPromise() waiting forever.
+		const pendingId = $field.data( 'sowb-tinymce-initializing-id' );
+
 		$field.removeData( 'sowb-tinymce-initializing' );
 		$field.removeData( 'sowb-tinymce-initializing-id' );
+
+		if ( pendingId && _tinymceInitPending[ pendingId ] ) {
+			_tinymceInitPending[ pendingId ].resolve();
+		}
 		$field.removeData( 'sowb-pre-init-bound' );
 		$field.removeAttr( 'data-pre-init' );
 
@@ -796,6 +805,12 @@
 				$field.removeAttr( 'data-initialized' );
 			} else if ( hasHealthyTinyMCEEditor( $field, initializedEditor.id ) ) {
 				return;
+			} else if ( $field.data( 'sowb-tinymce-initializing' ) ) {
+				// An init is in flight: data-initialized was set when setupTinyMCEField
+				// started but TinyMCE hasn't fired 'init' yet. Clearing the attr here
+				// would leave the field unmarked after the pending init completes,
+				// causing the next setup event to tear down a healthy editor.
+				return;
 			} else {
 				// Stale data-initialized would cause setupTinyMCEField to attempt
 				// teardown of an editor that no longer exists; clear it now.
@@ -938,24 +953,23 @@
 		}
 
 		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
-			let $messageFields = null;
-			if ( e.data.formSelector ) {
-				const $form = resolvePostMessageForms( e.data );
-				if ( $form.length ) {
-					$messageFields = getTinyMCEFieldsFromForms( $form );
-				} else {
-					return;
-				}
-			}
-
-			// Bug fix: null means no formSelector was provided, which would cause
-			// setupSiteEditorTinyMCEFields to fall back to querying ALL TinyMCE
-			// fields. Guard against both null and an empty jQuery set.
-			if ( ! $messageFields || ! $messageFields.length ) {
+			if ( ! e.data.formSelector ) {
 				return;
 			}
 
-			setupSiteEditorTinyMCEFields( $messageFields );
+			const $form = resolvePostMessageForms( e.data );
+			if ( ! $form.length ) {
+				return;
+			}
+
+			// Full form setup (sowSetupForm, setWidgetFormValues) is handled by the
+			// polling interval in sowbSetupWidgetForm (widget-block.js), which waits
+			// for jQuery UI to be ready before calling sowSetupForm. This handler
+			// covers only TinyMCE fields, including those added by repeater items.
+			const $tinymceFields = getTinyMCEFieldsFromForms( $form );
+			if ( $tinymceFields.length ) {
+				setupSiteEditorTinyMCEFields( $tinymceFields );
+			}
 		}
 	};
 	window.addEventListener( 'message', window._sowbTinyMCEMessageHandler );

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -4,6 +4,8 @@
 
 	let mediaFrameOpen = false;
 	const sowbTinyMCEEventNamespace = '.sowTinymce';
+	let _tinymceDomIdSeq = 0;
+	let _tinymcePreInitSeq = 0;
 
 	/**
 	 * Filters a jQuery collection to only those TinyMCE fields that are eligible
@@ -76,7 +78,12 @@
 			const tinymceFieldCount = $form.find( '.siteorigin-widget-field-type-tinymce' ).length;
 			const visible = $form.is( ':visible' );
 			const hiddenByAria = $form.is( '[aria-hidden="true"]' ) || $form.closest( '[aria-hidden="true"]' ).length > 0;
-			const connected = document.documentElement.contains( this );
+			// Use ownerDocument rather than the closure `document` so this signal is
+			// accurate whether selectBestFormInstance is called from the parent window
+			// (resolvePostMessageForms path) or from inside the iframe.
+			const connected = ( this.ownerDocument && this.ownerDocument.documentElement )
+				? this.ownerDocument.documentElement.contains( this )
+				: false;
 			const inRepeaterTemplate = $form.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
 
 			const score =
@@ -258,6 +265,7 @@
 	 *   - `sowb-tinymce-initializing`      — initializing lock flag
 	 *   - `sowb-tinymce-initializing-id`   — ID recorded during initialization
 	 *   - `sowb-pre-init-bound`            — pre-init event listener flag
+	 *   - `sowb-pre-init-namespace`        — namespaced event suffix for the pre-init listener/poll pair
 	 *   - `data-pre-init` attribute
 	 *
 	 * @param {jQuery} $field - jQuery object of the field container element.
@@ -285,6 +293,12 @@
 		$field.removeData( 'sowb-tinymce-initializing-id' );
 		$field.removeData( 'sowb-pre-init-bound' );
 		$field.removeAttr( 'data-pre-init' );
+
+		const preInitNamespace = $field.data( 'sowb-pre-init-namespace' );
+		if ( preInitNamespace ) {
+			$field.off( 'sowsetupformfield' + preInitNamespace );
+			$field.removeData( 'sowb-pre-init-namespace' );
+		}
 	};
 
 	/**
@@ -439,9 +453,8 @@
 				return;
 			}
 
-			// Tear down timers/locks from the previous (unhealthy) initialization
-			// attempt before removing the stale editor markup.
-			clearTinyMCEFieldPendingSetup( $field );
+			// Tear down stale editor markup. Timers/locks are cleared unconditionally
+			// by the clearTinyMCEFieldPendingSetup call below.
 			removeStaleTinyMCEFieldState( $field, initializedEditor.id );
 			$field.removeAttr( 'data-initialized' );
 		}
@@ -529,7 +542,7 @@
 
 		if ( ! id ) {
 			const baseId = sanitizeIdSegment( $textarea.attr( 'id' ) || $textarea.attr( 'name' ) || 'sowb-tinymce' ) || 'sowb-tinymce';
-			id = baseId + '-' + Date.now() + '-' + Math.floor( Math.random() * 1000 );
+			id = baseId + '-' + ( ++_tinymceDomIdSeq );
 		}
 
 		$textarea
@@ -729,12 +742,18 @@
 
 		if ( $field.attr( 'data-initialized' ) ) {
 			const initializedEditor = getTinyMCEFieldEditor( $field );
-			if ( hasHealthyTinyMCEEditor( $field, initializedEditor.id ) ) {
+			// If the textarea ID cannot be resolved the data-initialized attr is stale;
+			// clear it and fall through to re-initialize rather than passing undefined
+			// to hasHealthyTinyMCEEditor (which would call tinymce.get(undefined)).
+			if ( ! initializedEditor.id ) {
+				$field.removeAttr( 'data-initialized' );
+			} else if ( hasHealthyTinyMCEEditor( $field, initializedEditor.id ) ) {
 				return;
+			} else {
+				// Stale data-initialized would cause setupTinyMCEField to attempt
+				// teardown of an editor that no longer exists; clear it now.
+				$field.removeAttr( 'data-initialized' );
 			}
-			// Stale data-initialized would cause setupTinyMCEField to attempt
-			// teardown of an editor that no longer exists; clear it now.
-			$field.removeAttr( 'data-initialized' );
 		}
 
 		// If the field is visible, initialize the TinyMCE editor immediately.
@@ -747,11 +766,20 @@
 			return;
 		}
 
+		// Use a per-field namespace so the poll can cancel the listener if it fires
+		// first, and the listener can cancel the poll if it fires first. This prevents
+		// both paths from racing to call setupTinyMCEField on the same field.
+		const preInitEventNamespace = '.sowbPreInit-' + ( ++_tinymcePreInitSeq );
+		$field.data( 'sowb-pre-init-namespace', preInitEventNamespace );
+
 		const preInitVisibilityPoll = setInterval( function() {
 			if ( $field.is( ':visible' ) ) {
 				clearInterval( preInitVisibilityPoll );
 				$field.removeData( 'sowb-pre-init-visibility-poll' );
 				$field.removeData( 'sowb-pre-init-bound' );
+				// Cancel the sowsetupformfield listener so it doesn't re-trigger
+				// initialization after the poll has already started it.
+				$field.off( 'sowsetupformfield' + preInitEventNamespace );
 				setupTinyMCEField( $field );
 			}
 		}, 250 );
@@ -762,7 +790,8 @@
 		// Once visible, the 'sowsetupformfield' event triggers the editor setup.
 		$field
 			.data( 'sowb-pre-init-bound', true )
-			.one( 'sowsetupformfield', () => {
+			.off( 'sowsetupformfield' + preInitEventNamespace )
+			.one( 'sowsetupformfield' + preInitEventNamespace, () => {
 				const existingPreInitPoll = $field.data( 'sowb-pre-init-visibility-poll' );
 				if ( existingPreInitPoll ) {
 					clearInterval( existingPreInitPoll );
@@ -851,33 +880,38 @@
 		.on( 'sortstop' + sowbTinyMCEEventNamespace, sortStopEvent );
 
 	// Add support for the Site Editor.
-	if ( ! window.sowbTinyMCEMessageListenerBound ) {
-		window.sowbTinyMCEMessageListenerBound = true;
+	// Store the handler reference on window so it can be removed and replaced on
+	// script re-evaluation (e.g. HMR or plugin updates) rather than accumulating.
+	if ( window._sowbTinyMCEMessageHandler ) {
+		window.removeEventListener( 'message', window._sowbTinyMCEMessageHandler );
+	}
+	window._sowbTinyMCEMessageHandler = function( e ) {
+		if ( ! e || e.origin !== window.location.origin ) {
+			return;
+		}
 
-		window.addEventListener( 'message', function( e ) {
-			if ( ! e || e.origin !== window.location.origin ) {
+		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
+			let $messageFields = null;
+			if ( e.data.formSelector ) {
+				const $form = resolvePostMessageForms( e.data );
+				if ( $form.length ) {
+					$messageFields = getTinyMCEFieldsFromForms( $form );
+				} else {
+					return;
+				}
+			}
+
+			// Bug fix: null means no formSelector was provided, which would cause
+			// setupSiteEditorTinyMCEFields to fall back to querying ALL TinyMCE
+			// fields. Guard against both null and an empty jQuery set.
+			if ( ! $messageFields || ! $messageFields.length ) {
 				return;
 			}
 
-			if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
-				let $messageFields = null;
-				if ( e.data.formSelector ) {
-					const $form = resolvePostMessageForms( e.data );
-					if ( $form.length ) {
-						$messageFields = getTinyMCEFieldsFromForms( $form );
-					} else {
-						return;
-					}
-				}
-
-				if ( $messageFields && ! $messageFields.length ) {
-					return;
-				}
-
-				setupSiteEditorTinyMCEFields( $messageFields );
-			}
-		} );
-	}
+			setupSiteEditorTinyMCEFields( $messageFields );
+		}
+	};
+	window.addEventListener( 'message', window._sowbTinyMCEMessageHandler );
 
 	if ( window.frameElement ) {
 		$( document )
@@ -889,12 +923,12 @@
 		$( document )
 			.off( 'sowsetupform' + sowbTinyMCEEventNamespace )
 			.on( 'sowsetupform' + sowbTinyMCEEventNamespace, function( e, $form ) {
+				if ( ! $form || ! $form.length ) {
+					return;
+				}
 				// $form is the wrapper element, not a field itself, so .find() is
 				// sufficient — no need to also .filter() the root element.
-				const $formFields = $form && $form.length ?
-					$form.find( '.siteorigin-widget-field-type-tinymce' ) :
-					null;
-				setupSiteEditorTinyMCEFields( $formFields );
+				setupSiteEditorTinyMCEFields( $form.find( '.siteorigin-widget-field-type-tinymce' ) );
 			} );
 
 		// sowrepeaterfieldsadded is fired by admin.js on the parent document, not the iframe's document,

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -41,28 +41,6 @@
 	};
 
 	/**
-	 * Escapes a string for safe use as a CSS selector value.
-	 *
-	 * Uses the native `CSS.escape` when available and falls back to a manual
-	 * regex replacement that escapes all CSS special characters.
-	 *
-	 * @param {string} value - The raw string to escape.
-	 *
-	 * @returns {string} The escaped string, or an empty string if value is not a string.
-	 */
-	const escapeSelectorValue = function( value ) {
-		if ( typeof value !== 'string' ) {
-			return '';
-		}
-
-		if ( window.CSS && typeof window.CSS.escape === 'function' ) {
-			return window.CSS.escape( value );
-		}
-
-		return value.replace( /([ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1' );
-	};
-
-	/**
 	 * Selects the best matching widget form from a set of candidates.
 	 *
 	 * Scores each form on multiple signals and returns the highest-scoring one.
@@ -152,14 +130,16 @@
 	/**
 	 * Resolves the target widget form(s) from a `sowbBlockFormInit` postMessage payload.
 	 *
-	 * Uses the `formSelector` from the message data to find matching forms, then
-	 * narrows the result using the currently-selected block's `is-selected` state
-	 * when more than one form matches. Falls back to `selectBestFormInstance` if
-	 * the selection-based narrowing still leaves multiple candidates.
+	 * Queries `messageData.formSelector` against this iframe's document and, when
+	 * more than one form matches, delegates to `selectBestFormInstance` to pick the
+	 * best candidate based on visibility, DOM connectivity, and field count.
 	 *
-	 * @param {Object} messageData            - The postMessage data object.
+	 * Note: block-editor selection attributes (`is-selected`, `data-block`) live on
+	 * elements in the parent document and are never present in the iframe DOM, so no
+	 * attempt is made to narrow by clientId here.
+	 *
+	 * @param {Object} messageData              - The postMessage data object.
 	 * @param {string} messageData.formSelector - CSS selector targeting the form(s).
-	 * @param {string} [messageData.clientId]   - Block client ID used to narrow matches.
 	 *
 	 * @returns {jQuery} jQuery collection of the resolved form element(s).
 	 */
@@ -168,20 +148,11 @@
 			return $( [] );
 		}
 
+		// formSelector targets elements in this iframe document. Block-editor
+		// attributes such as `is-selected` and `data-block` belong to the parent
+		// document's block list and are never present here, so we go straight to
+		// selectBestFormInstance when more than one form matches.
 		let $forms = $( messageData.formSelector );
-
-		if ( $forms.length > 1 && messageData.clientId ) {
-			const escapedClientId = escapeSelectorValue( messageData.clientId );
-			const $selectedBlockForms = $(
-				'.block-editor-block-list__block.is-selected[data-block="' + escapedClientId + '"] .siteorigin-widget-form.siteorigin-widget-form-main, ' +
-				'.is-selected[data-block="' + escapedClientId + '"] .siteorigin-widget-form.siteorigin-widget-form-main, ' +
-				'[data-block="' + escapedClientId + '"][aria-selected="true"] .siteorigin-widget-form.siteorigin-widget-form-main'
-			);
-
-			if ( $selectedBlockForms.length ) {
-				$forms = selectBestFormInstance( $selectedBlockForms );
-			}
-		}
 
 		if ( $forms.length > 1 ) {
 			$forms = selectBestFormInstance( $forms );
@@ -314,21 +285,6 @@
 		$field.removeData( 'sowb-tinymce-initializing-id' );
 		$field.removeData( 'sowb-pre-init-bound' );
 		$field.removeAttr( 'data-pre-init' );
-	};
-
-	/**
-	 * Resolves the best available WordPress editor API object.
-	 *
-	 * Prefers `wp.oldEditor` (present in iframe contexts for legacy compatibility)
-	 * over `wp.editor` so that teardown and initialization use the same object.
-	 *
-	 * @returns {Object|null} The resolved editor API, or null if unavailable.
-	 */
-	const resolveWpEditor = function() {
-		if ( ! window.wp ) {
-			return null;
-		}
-		return window.wp.oldEditor ? window.wp.oldEditor : ( window.wp.editor || null );
 	};
 
 	/**
@@ -483,13 +439,16 @@
 				return;
 			}
 
+			// Tear down timers/locks from the previous (unhealthy) initialization
+			// attempt before removing the stale editor markup.
 			clearTinyMCEFieldPendingSetup( $field );
 			removeStaleTinyMCEFieldState( $field, initializedEditor.id );
 			$field.removeAttr( 'data-initialized' );
 		}
 
+		// Always clear any lingering state from a pre-init visibility poll or
+		// a prior partial setup, even when data-initialized was not set.
 		clearTinyMCEFieldPendingSetup( $field );
-		$field.attr( 'data-initialized', true );
 
 		// If this is in an iframe, copy necessary globals from the parent window.
 		if ( frameElement && typeof window.tinyMCEPreInit === 'undefined' ) {
@@ -500,6 +459,10 @@
 		if ( ! wpEditor ) {
 			return;
 		}
+
+		// Mark as initialized only after confirming the editor API is available, so a
+		// transient null wpEditor does not leave the field stranded with the attr set.
+		$field.attr( 'data-initialized', true );
 
 		// In iframe contexts wp.oldEditor is the authoritative API. Copy its text-processing
 		// methods onto wp.editor so both references stay in sync.
@@ -607,7 +570,8 @@
 					addMediaButton
 						.removeClass( 'insert-media add_media' )
 						.addClass( 'siteorigin-widget-tinymce-add-media' )
-						.on( 'click', () => {
+						.off( 'click.sowbMedia' )
+						.on( 'click.sowbMedia', () => {
 							siteEditorAddMediaOverride( editorId );
 						} );
 				}
@@ -648,8 +612,8 @@
 				} );
 
 				if ( $wpautopToggleField ) {
-					$wpautopToggleField.off( 'change' );
-					$wpautopToggleField.on( 'change', function() {
+					$wpautopToggleField.off( 'change' + fieldEventNamespace );
+					$wpautopToggleField.on( 'change' + fieldEventNamespace, function() {
 						const currentEditor = resolveWpEditor();
 						if ( ! currentEditor ) {
 							return;
@@ -705,6 +669,9 @@
 		const initTimeoutId = setTimeout( function() {
 			$field.removeData( 'sowb-tinymce-initializing' );
 			$field.removeData( 'sowb-tinymce-initializing-id' );
+			// If the TinyMCE init event never fired (e.g. field removed from DOM),
+			// clean up the top-document listener so it doesn't accumulate.
+			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
 		}, 5000 );
 
 		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
@@ -765,6 +732,9 @@
 			if ( hasHealthyTinyMCEEditor( $field, initializedEditor.id ) ) {
 				return;
 			}
+			// Stale data-initialized would cause setupTinyMCEField to attempt
+			// teardown of an editor that no longer exists; clear it now.
+			$field.removeAttr( 'data-initialized' );
 		}
 
 		// If the field is visible, initialize the TinyMCE editor immediately.
@@ -919,8 +889,10 @@
 		$( document )
 			.off( 'sowsetupform' + sowbTinyMCEEventNamespace )
 			.on( 'sowsetupform' + sowbTinyMCEEventNamespace, function( e, $form ) {
+				// $form is the wrapper element, not a field itself, so .find() is
+				// sufficient — no need to also .filter() the root element.
 				const $formFields = $form && $form.length ?
-					$form.filter( '.siteorigin-widget-field-type-tinymce' ).add( $form.find( '.siteorigin-widget-field-type-tinymce' ) ) :
+					$form.find( '.siteorigin-widget-field-type-tinymce' ) :
 					null;
 				setupSiteEditorTinyMCEFields( $formFields );
 			} );
@@ -930,9 +902,7 @@
 		// in the parent and re-dispatches it as a sowbBlockFormInit postMessage to the iframe, covering
 		// all field types. No separate listener is needed here.
 
-		$( function() {
-			setupSiteEditorTinyMCEFields();
-		} );
+		setupSiteEditorTinyMCEFields();
 	}
 
 } )( jQuery );

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -8,6 +8,20 @@
 	let _tinymcePreInitSeq = 0;
 
 	/**
+	 * Tracks in-flight TinyMCE editor initializations.
+	 *
+	 * Keyed by editor ID. Each entry holds `{ promise, resolve }` where `promise`
+	 * resolves (with no value) once the editor's `init` event has fired or the
+	 * 5 s safety timeout has elapsed. Entries are removed on resolution so the
+	 * map never grows unboundedly.
+	 *
+	 * Consumed by `window.sowbGetTinyMCEInitPromise`, which allows external code
+	 * (e.g. the save-bridge TinyMCE flusher) to await full editor readiness
+	 * before calling `editor.save()`.
+	 */
+	const _tinymceInitPending = {};
+
+	/**
 	 * Filters a jQuery collection to only those TinyMCE fields that are eligible
 	 * for editor initialization.
 	 *
@@ -561,6 +575,17 @@
 			.attr( 'data-tinymce-id', id )
 			.attr( 'id', id );
 
+		let _resolveInitPending;
+		_tinymceInitPending[ id ] = {
+			promise: new Promise( function( resolve ) {
+				_resolveInitPending = resolve;
+			} ),
+			resolve: function() {
+				_resolveInitPending();
+				delete _tinymceInitPending[ id ];
+			},
+		};
+
 		$field
 			.data( 'sowb-tinymce-initializing', true )
 			.data( 'sowb-tinymce-initializing-id', id );
@@ -622,6 +647,10 @@
 					if ( initTimeout ) {
 						clearTimeout( initTimeout );
 						$field.removeData( 'sowb-tinymce-init-timeout' );
+					}
+
+					if ( _tinymceInitPending[ id ] ) {
+						_tinymceInitPending[ id ].resolve();
 					}
 
 					$field.removeData( 'sowb-tinymce-initializing' );
@@ -691,6 +720,10 @@
 		}
 
 		const initTimeoutId = setTimeout( function() {
+			if ( _tinymceInitPending[ id ] ) {
+				_tinymceInitPending[ id ].resolve();
+			}
+
 			$field.removeData( 'sowb-tinymce-initializing' );
 			$field.removeData( 'sowb-tinymce-initializing-id' );
 			// If the TinyMCE init event never fired (e.g. field removed from DOM),
@@ -949,5 +982,27 @@
 
 		setupSiteEditorTinyMCEFields();
 	}
+
+	/**
+	 * Returns a Promise that resolves once the TinyMCE editor for the given ID
+	 * has finished initialising, or immediately if it is already ready.
+	 *
+	 * The promise always resolves (never rejects). If initialisation stalls the
+	 * safety timeout in `setupTinyMCEField` will resolve it after 5 seconds.
+	 *
+	 * Intended for use by the save-bridge TinyMCE flusher in admin.js so it can
+	 * await full editor readiness before calling `editor.save()`. The flusher
+	 * retrieves this via the field element's `ownerDocument.defaultView` (i.e.
+	 * the iframe's `window` in a Site Editor context) so that each frame's
+	 * pending-init map is consulted correctly.
+	 *
+	 * @param {string} editorId - The TinyMCE editor / textarea ID.
+	 * @return {Promise<void>}
+	 */
+	window.sowbGetTinyMCEInitPromise = function( editorId ) {
+		return _tinymceInitPending[ editorId ]
+			? _tinymceInitPending[ editorId ].promise
+			: Promise.resolve();
+	};
 
 } )( jQuery );

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -259,11 +259,13 @@
 		// Add the selected media to the TinyMCE editor.
 		mediaFrame.on( 'select', () => {
 			const attachment = mediaFrame.state().get( 'selection' ).first().toJSON();
-			const editor = window.tinymce.get( editorId );
+			const editor = window.tinymce ? window.tinymce.get( editorId ) : null;
 
-			editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
-			editor.save();
-			editor.fire( 'change' );
+			if ( editor ) {
+				editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
+				editor.save();
+				editor.fire( 'change' );
+			}
 		} );
 
 		// Change the mediaFrameOpen flag when the media frame is closed.
@@ -275,19 +277,58 @@
 	};
 
 	/**
-	 * Clears any pending TinyMCE setup state from a field.
+	 * Clears all pending TinyMCE setup state from a field element.
+	 *
+	 * Cancels any in-progress timers and intervals attached to the field and
+	 * removes the associated jQuery data keys:
+	 *   - `sowb-pre-init-visibility-poll`  — pre-init visibility interval
+	 *   - `sowb-tinymce-visibility-poll`   — post-init visibility interval
+	 *   - `sowb-tinymce-init-timeout`      — 5 s safety unlock timeout
+	 *   - `sowb-tinymce-initializing`      — initializing lock flag
+	 *   - `sowb-tinymce-initializing-id`   — ID recorded during initialization
+	 *   - `sowb-pre-init-bound`            — pre-init event listener flag
+	 *   - `data-pre-init` attribute
 	 *
 	 * @param {jQuery} $field - jQuery object of the field container element.
 	 */
 	const clearTinyMCEFieldPendingSetup = function( $field ) {
+		const preInitPoll = $field.data( 'sowb-pre-init-visibility-poll' );
+		if ( preInitPoll ) {
+			clearInterval( preInitPoll );
+			$field.removeData( 'sowb-pre-init-visibility-poll' );
+		}
+
 		const visibilityPoll = $field.data( 'sowb-tinymce-visibility-poll' );
 		if ( visibilityPoll ) {
 			clearInterval( visibilityPoll );
 			$field.removeData( 'sowb-tinymce-visibility-poll' );
 		}
 
+		const initTimeout = $field.data( 'sowb-tinymce-init-timeout' );
+		if ( initTimeout ) {
+			clearTimeout( initTimeout );
+			$field.removeData( 'sowb-tinymce-init-timeout' );
+		}
+
+		$field.removeData( 'sowb-tinymce-initializing' );
+		$field.removeData( 'sowb-tinymce-initializing-id' );
 		$field.removeData( 'sowb-pre-init-bound' );
 		$field.removeAttr( 'data-pre-init' );
+	};
+
+	/**
+	 * Resolves the best available WordPress editor API object.
+	 *
+	 * Prefers `wp.oldEditor` (present in iframe contexts for legacy compatibility)
+	 * over `wp.editor` so that teardown and initialization use the same object.
+	 *
+	 * @returns {Object|null} The resolved editor API, or null if unavailable.
+	 */
+	const resolveWpEditor = function() {
+		if ( ! window.wp ) {
+			return null;
+		}
+		return window.wp.oldEditor ? window.wp.oldEditor : ( window.wp.editor || null );
 	};
 
 	/**
@@ -352,11 +393,26 @@
 			return false;
 		}
 
+		const fieldElement = $field.get( 0 );
 		if ( window.tinymce && window.tinymce.get( id ) ) {
-			return true;
+			const editor = window.tinymce.get( id );
+			const editorElement = editor && typeof editor.getElement === 'function' ?
+				editor.getElement() :
+				( editor && editor.targetElm ? editor.targetElm : null );
+			const editorContainer = editor && typeof editor.getContainer === 'function' ?
+				editor.getContainer() :
+				null;
+
+			if ( editorElement && fieldElement && fieldElement.contains( editorElement ) ) {
+				return true;
+			}
+
+			if ( editorContainer && fieldElement && fieldElement.contains( editorContainer ) ) {
+				return true;
+			}
+
 		}
 
-		const fieldElement = $field.get( 0 );
 		const editorIframe = document.getElementById( id + '_ifr' );
 		if ( editorIframe && fieldElement && fieldElement.contains( editorIframe ) ) {
 			return true;
@@ -386,9 +442,7 @@
 			return;
 		}
 
-		const wpEditor = window.wp ? ( window.wp.oldEditor ? window.wp.oldEditor : window.wp.editor ) : null;
-
-		removeTinyMCEEditor( wpEditor, id );
+		removeTinyMCEEditor( resolveWpEditor(), id );
 
 		const editorWrap = document.getElementById( 'wp-' + id + '-wrap' );
 		if ( editorWrap ) {
@@ -401,12 +455,27 @@
 	};
 
 	/**
-	 * Sets up a TinyMCE field within a widget form.
-	 * Handles initialization of the TinyMCE editor, event binding, and UI setup.
+	 * Sets up a TinyMCE editor for a single widget form field.
+	 *
+	 * Handles the full initialization lifecycle:
+	 *   - Skips if an initialization is already in progress.
+	 *   - Tears down and replaces any stale editor state if re-initializing.
+	 *   - Resolves the WordPress editor API via `resolveWpEditor`; bails early
+	 *     if no editor API is available.
+	 *   - Assigns or reuses a stable unique ID for the textarea.
+	 *   - Listens for `wp-before-tinymce-init` to inject media buttons.
+	 *   - Waits for the textarea to become visible before calling
+	 *     `wpEditor.initialize`, using a 500 ms interval poll if it is hidden.
+	 *   - Sets a 5 s safety timeout to release the initializing lock if the
+	 *     TinyMCE `init` event never fires.
 	 *
 	 * @param {jQuery} $field - jQuery object of the field container element.
 	 */
 	const setupTinyMCEField = function( $field ) {
+		if ( $field.data( 'sowb-tinymce-initializing' ) ) {
+			return;
+		}
+
 		if ( $field.attr( 'data-initialized' ) ) {
 			const initializedEditor = getTinyMCEFieldEditor( $field );
 
@@ -427,17 +496,24 @@
 			window.tinyMCEPreInit = window.top.tinyMCEPreInit;
 		}
 
-		const wpEditor = wp.oldEditor ? wp.oldEditor : wp.editor;
-		if ( wpEditor && wpEditor.hasOwnProperty( 'autop' ) ) {
-			wp.editor.autop = wpEditor.autop;
-			wp.editor.removep = wpEditor.removep;
-			wp.editor.initialize = wpEditor.initialize
+		const wpEditor = resolveWpEditor();
+		if ( ! wpEditor ) {
+			return;
+		}
+
+		// In iframe contexts wp.oldEditor is the authoritative API. Copy its text-processing
+		// methods onto wp.editor so both references stay in sync.
+		if ( window.wp.oldEditor && window.wp.oldEditor.hasOwnProperty( 'autop' ) ) {
+			window.wp.editor.autop = window.wp.oldEditor.autop;
+			window.wp.editor.removep = window.wp.oldEditor.removep;
+			window.wp.editor.initialize = window.wp.oldEditor.initialize;
 		}
 
 		const $container = $field.find( '.siteorigin-widget-tinymce-container' );
-		const settings = $container.data( 'editorSettings' );
+		const settings = $.extend( true, {}, $container.data( 'editorSettings' ) || {} );
 
 		if (
+			window.top.tinyMCEPreInit &&
 			window.top.tinyMCEPreInit.mceInit &&
 			window.top.tinyMCEPreInit.mceInit.hasOwnProperty( 'content' )
 		) {
@@ -469,8 +545,28 @@
 		const $textarea = $container.find( 'textarea' );
 		// Prevent potential id overlap by appending the textarea field with a random id.
 		let id = $textarea.attr( 'data-tinymce-id' ) || $textarea.data( 'tinymce-id' );
+		const fieldElement = $field.get( 0 );
+		const textareaElement = $textarea.get( 0 );
+
+		if ( id ) {
+			const existingTextarea = document.getElementById( id );
+			if ( existingTextarea && textareaElement && existingTextarea !== textareaElement ) {
+				id = '';
+			}
+
+			const existingEditor = window.tinymce && window.tinymce.get( id ) ? window.tinymce.get( id ) : null;
+			const existingEditorContainer = existingEditor && typeof existingEditor.getContainer === 'function' ?
+				existingEditor.getContainer() :
+				null;
+
+			if ( existingEditorContainer && fieldElement && ! fieldElement.contains( existingEditorContainer ) ) {
+				id = '';
+			}
+		}
+
 		if ( ! id ) {
-			id = $textarea.attr( 'id' ) + Math.floor( Math.random() * 1000 );
+			const baseId = sanitizeIdSegment( $textarea.attr( 'id' ) || $textarea.attr( 'name' ) || 'sowb-tinymce' ) || 'sowb-tinymce';
+			id = baseId + '-' + Date.now() + '-' + Math.floor( Math.random() * 1000 );
 		}
 
 		$textarea
@@ -478,10 +574,21 @@
 			.attr( 'data-tinymce-id', id )
 			.attr( 'id', id );
 
-		$( window.document ).one( 'wp-before-tinymce-init', function( event, init ) {
+		$field
+			.data( 'sowb-tinymce-initializing', true )
+			.data( 'sowb-tinymce-initializing-id', id );
+
+		const fieldEventNamespace = '.sowTinymceField-' + ( sanitizeIdSegment( id ) || 'unknown' );
+
+		$( window.document )
+			.off( 'wp-before-tinymce-init' + fieldEventNamespace )
+			.on( 'wp-before-tinymce-init' + fieldEventNamespace, function( event, init ) {
 			if ( init.selector !== settings.tinymce.selector ) {
 				return;
 			}
+
+			$( window.document ).off( 'wp-before-tinymce-init' + fieldEventNamespace );
+
 			const mediaButtons = $container.data( 'mediaButtons' );
 			if (
 				typeof mediaButtons != 'undefined' &&
@@ -507,29 +614,49 @@
 			}
 		} );
 
-		$( window.top.document ).one( 'tinymce-editor-setup', function() {
+		$( window.top.document )
+			.off( 'tinymce-editor-setup' + fieldEventNamespace )
+			.on( 'tinymce-editor-setup' + fieldEventNamespace, function() {
 			const $wpEditorWrap = $field.find( '.wp-editor-wrap' );
 			if ( $wpEditorWrap.length > 0 && ! $wpEditorWrap.hasClass( settings.selectedEditor + '-active' ) ) {
 				setTimeout( function() {
 					window.switchEditors.go( id );
 				}, 10 );
 			}
+
+			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
 		} );
 
 		if ( settings.tinymce ) {
 			const setupEditor = function( editor ) {
+				editor.on( 'init', function() {
+					const initTimeout = $field.data( 'sowb-tinymce-init-timeout' );
+					if ( initTimeout ) {
+						clearTimeout( initTimeout );
+						$field.removeData( 'sowb-tinymce-init-timeout' );
+					}
+
+					$field.removeData( 'sowb-tinymce-initializing' );
+					$field.removeData( 'sowb-tinymce-initializing-id' );
+				} );
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
-					ed.save();
-					$textarea.trigger( 'change' );
+					if ( ed ) {
+						ed.save();
+						$textarea.trigger( 'change' );
+					}
 				} );
 
 				if ( $wpautopToggleField ) {
 					$wpautopToggleField.off( 'change' );
 					$wpautopToggleField.on( 'change', function() {
-						removeTinyMCEEditor( window.wp.editor, id );
+						const currentEditor = resolveWpEditor();
+						if ( ! currentEditor ) {
+							return;
+						}
+						removeTinyMCEEditor( currentEditor, id );
 						settings.tinymce.wpautop = $wpautopToggleField.is( ':checked' );
-						window.wp.editor.initialize( id, settings );
+						currentEditor.initialize( id, settings );
 					} );
 				}
 			};
@@ -563,7 +690,10 @@
 		} else {
 			const intervalId = setInterval( function() {
 				if ( $textarea.is( ':visible' ) ) {
-					wpEditor.initialize( id, settings );
+					const pollEditor = resolveWpEditor();
+					if ( pollEditor ) {
+						pollEditor.initialize( id, settings );
+					}
 					clearInterval( intervalId );
 					$field.removeData( 'sowb-tinymce-visibility-poll' );
 				}
@@ -571,6 +701,13 @@
 
 			$field.data( 'sowb-tinymce-visibility-poll', intervalId );
 		}
+
+		const initTimeoutId = setTimeout( function() {
+			$field.removeData( 'sowb-tinymce-initializing' );
+			$field.removeData( 'sowb-tinymce-initializing-id' );
+		}, 5000 );
+
+		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
 
 		$field.on( 'click', function( event ) {
 			const $target = $( event.target );
@@ -613,9 +750,21 @@
 	 */
 	const setupTinyMCEFieldInitializer = function() {
 		const $field = $( this );
+		const $textarea = $field.find( '.siteorigin-widget-tinymce-container textarea' ).first();
+
+		if ( $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length || ( $textarea.attr( 'id' ) || '' ).indexOf( '_id_' ) !== -1 ) {
+			return;
+		}
 
 		if ( $field.attr( 'data-pre-init' ) && ! $field.data( 'sowb-pre-init-bound' ) ) {
 			$field.removeAttr( 'data-pre-init' );
+		}
+
+		if ( $field.attr( 'data-initialized' ) ) {
+			const initializedEditor = getTinyMCEFieldEditor( $field );
+			if ( hasHealthyTinyMCEEditor( $field, initializedEditor.id ) ) {
+				return;
+			}
 		}
 
 		// If the field is visible, initialize the TinyMCE editor immediately.
@@ -628,12 +777,29 @@
 			return;
 		}
 
+		const preInitVisibilityPoll = setInterval( function() {
+			if ( $field.is( ':visible' ) ) {
+				clearInterval( preInitVisibilityPoll );
+				$field.removeData( 'sowb-pre-init-visibility-poll' );
+				$field.removeData( 'sowb-pre-init-bound' );
+				setupTinyMCEField( $field );
+			}
+		}, 250 );
+
+		$field.data( 'sowb-pre-init-visibility-poll', preInitVisibilityPoll );
+
 		// Mark the field for initialization and wait for it to become visible.
 		// Once visible, the 'sowsetupformfield' event triggers the editor setup.
 		$field
 			.data( 'sowb-pre-init-bound', true )
 			.one( 'sowsetupformfield', () => {
-				setupTinyMCEField( $field );
+				const existingPreInitPoll = $field.data( 'sowb-pre-init-visibility-poll' );
+				if ( existingPreInitPoll ) {
+					clearInterval( existingPreInitPoll );
+					$field.removeData( 'sowb-pre-init-visibility-poll' );
+				}
+				$field.removeData( 'sowb-pre-init-bound' );
+				setupTinyMCEFieldInitializer.call( $field.get( 0 ) );
 			} );
 	};
 
@@ -668,7 +834,13 @@
 	 * finished loading, so the iframe also calls this once its own script is
 	 * ready.
 	 */
-	const setupSiteEditorTinyMCEFields = function() {
+	const setupSiteEditorTinyMCEFields = function( $targetFields ) {
+		const hasTargetedFields = !! ( $targetFields && $targetFields.jquery && $targetFields.length );
+		const $rawFields = hasTargetedFields ?
+			$targetFields :
+			$( '.siteorigin-widget-field-type-tinymce' );
+		const $fields = getEligibleTinyMCEFields( $rawFields );
+
 		if (
 			window.wp &&
 			window.wp.editor &&
@@ -679,7 +851,7 @@
 			window.wp.editor.getDefaultSettings = window.top.wp.editor.getDefaultSettings;
 		}
 
-		$( '.siteorigin-widget-field-type-tinymce' ).each( function() {
+		$fields.each( function() {
 			setupTinyMCEFieldInitializer.call( this );
 		} );
 
@@ -688,19 +860,6 @@
 			$( window.top.document ).data( 'sortstop-bound', true );
 			$( window.top.document ).on( 'sortstop', sortStopEvent );
 		}
-	};
-
-	let siteEditorSetupScheduled = false;
-	const scheduleSiteEditorTinyMCEFields = function() {
-		if ( siteEditorSetupScheduled ) {
-			return;
-		}
-
-		siteEditorSetupScheduled = true;
-		setTimeout( function() {
-			siteEditorSetupScheduled = false;
-			setupSiteEditorTinyMCEFields();
-		}, 50 );
 	};
 
 
@@ -712,47 +871,68 @@
 			pagenow !== 'site-editor'
 		)
 	) {
-		$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-tinymce', setupTinyMCEFieldInitializer );
+		$( document )
+			.off( 'sowsetupformfield' + sowbTinyMCEEventNamespace, '.siteorigin-widget-field-type-tinymce' )
+			.on( 'sowsetupformfield' + sowbTinyMCEEventNamespace, '.siteorigin-widget-field-type-tinymce', setupTinyMCEFieldInitializer );
 	}
 
-	$( document ).on( 'sortstop', sortStopEvent );
+	$( document )
+		.off( 'sortstop' + sowbTinyMCEEventNamespace )
+		.on( 'sortstop' + sowbTinyMCEEventNamespace, sortStopEvent );
 
 	// Add support for the Site Editor.
-	window.addEventListener( 'message', function( e ) {
-		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
-			setupSiteEditorTinyMCEFields();
-		}
-	} );
+	if ( ! window.sowbTinyMCEMessageListenerBound ) {
+		window.sowbTinyMCEMessageListenerBound = true;
 
-	if ( window.frameElement ) {
-		$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-tinymce', setupTinyMCEFieldInitializer );
-		$( setupSiteEditorTinyMCEFields );
+		window.addEventListener( 'message', function( e ) {
+			if ( ! e || e.origin !== window.location.origin ) {
+				return;
+			}
 
-		if ( window.MutationObserver ) {
-			$( function() {
-				if ( ! document.body ) {
+			if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
+				let $messageFields = null;
+				if ( e.data.formSelector ) {
+					const $form = resolvePostMessageForms( e.data );
+					if ( $form.length ) {
+						$messageFields = getTinyMCEFieldsFromForms( $form );
+					} else {
+						return;
+					}
+				}
+
+				if ( $messageFields && ! $messageFields.length ) {
 					return;
 				}
 
-				const observer = new MutationObserver( scheduleSiteEditorTinyMCEFields );
-				observer.observe( document.body, {
-					attributes: true,
-					attributeFilter: [ 'class', 'style' ],
-					childList: true,
-					subtree: true,
-				} );
-			} );
-		} else {
-			let siteEditorSetupAttempts = 0;
-			const siteEditorSetupInterval = setInterval( function() {
-				setupSiteEditorTinyMCEFields();
-				siteEditorSetupAttempts++;
+				setupSiteEditorTinyMCEFields( $messageFields );
+			}
+		} );
+	}
 
-				if ( siteEditorSetupAttempts >= 20 ) {
-					clearInterval( siteEditorSetupInterval );
-				}
-			}, 250 );
-		}
+	if ( window.frameElement ) {
+		$( document )
+			.off( 'sowsetupformfield' + sowbTinyMCEEventNamespace, '.siteorigin-widget-field-type-tinymce' )
+			.on( 'sowsetupformfield' + sowbTinyMCEEventNamespace, '.siteorigin-widget-field-type-tinymce', function( e ) {
+				setupTinyMCEFieldInitializer.call( this, e );
+			} );
+
+		$( document )
+			.off( 'sowsetupform' + sowbTinyMCEEventNamespace )
+			.on( 'sowsetupform' + sowbTinyMCEEventNamespace, function( e, $form ) {
+				const $formFields = $form && $form.length ?
+					$form.filter( '.siteorigin-widget-field-type-tinymce' ).add( $form.find( '.siteorigin-widget-field-type-tinymce' ) ) :
+					null;
+				setupSiteEditorTinyMCEFields( $formFields );
+			} );
+
+		// sowrepeaterfieldsadded is fired by admin.js on the parent document, not the iframe's document,
+		// because admin.js always runs in the parent window context. widget-block.js handles this event
+		// in the parent and re-dispatches it as a sowbBlockFormInit postMessage to the iframe, covering
+		// all field types. No separate listener is needed here.
+
+		$( function() {
+			setupSiteEditorTinyMCEFields();
+		} );
 	}
 
 } )( jQuery );

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -949,6 +949,10 @@ var sowbForms = window.sowbForms || {};
 
 			// Create an object with the repeater html so we can make some changes to it.
 			var repeaterObject = $('<div>' + $el.find('> .siteorigin-widget-field-repeater-item-html').html() + '</div>');
+			repeaterObject
+				.find( '.siteorigin-widget-field[data-initialized]' )
+				.removeAttr( 'data-initialized' );
+
 			repeaterObject.find('.siteorigin-widget-input[data-name]').each(function () {
 				var $$ = $(this);
 				// Skip out items that are themselves inside repeater HTML wrappers

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -44,6 +44,28 @@ var sowbForms = window.sowbForms || {};
 
 	const repeaterVisibilitySensitiveFieldSelector = '.siteorigin-widget-field-type-tinymce, .siteorigin-widget-field-type-date-range';
 
+	sowbForms.sanitizeTinyMCEContent = function( content ) {
+		if ( typeof content !== 'string' || content.length === 0 ) {
+			return content;
+		}
+
+		if (
+			content.indexOf( 'mce_SELRES_' ) === -1 &&
+			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
+			content.indexOf( '\uFEFF' ) === -1
+		) {
+			return content;
+		}
+
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = content;
+		wrapper
+			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
+			.forEach( ( marker ) => marker.remove() );
+
+		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+	};
+
 	/**
 	 * Triggers setup for visibility-sensitive repeater fields after a repeater
 	 * item is added or expanded.
@@ -1218,7 +1240,7 @@ var sowbForms = window.sowbForms || {};
 								$inputElement.css( 'display', '' );
 								var curEd = tinymce.get( id );
 								if ( curEd ) {
-									var contentVal = curEd.getContent();
+									var contentVal = sowbForms.sanitizeTinyMCEContent( curEd.getContent() );
 									if ( ! _.isEmpty( contentVal ) ) {
 										$inputElement.val( contentVal );
 									} else if ( contentVal.search( '<' ) !== -1 && contentVal.search( '>' ) === -1) {
@@ -1690,10 +1712,10 @@ var sowbForms = window.sowbForms || {};
 					}
 
 					if ( editor !== null && typeof( editor.getContent ) === "function" && !editor.isHidden() ) {
-						fieldValue = editor.getContent();
+						fieldValue = sowbForms.sanitizeTinyMCEContent( editor.getContent() );
 					}
 					else {
-						fieldValue = $$.val();
+						fieldValue = sowbForms.sanitizeTinyMCEContent( $$.val() );
 					}
 				} else if ( $$.prop( 'tagName' ) === 'SELECT' ) {
 					var selected = $$.find( 'option:selected' );
@@ -1933,20 +1955,22 @@ var sowbForms = window.sowbForms || {};
 						editor = tinyMCE.get( $$.attr( 'id' ) );
 					}
 
+					var tinyMCEFieldValue = sowbForms.sanitizeTinyMCEContent( values.value );
 					if ( editor !== null && typeof( editor.setContent ) === "function" && ! editor.isHidden() && $$.parent().is( ':visible' ) ) {
-						if ( compareValues( editor.getContent(), values.value ) ) {
+						if ( compareValues( sowbForms.sanitizeTinyMCEContent( editor.getContent() ), tinyMCEFieldValue ) ) {
 							if ( editor.initialized ) {
-								editor.setContent( values.value );
+								editor.setContent( tinyMCEFieldValue );
 								updated = true;
 							} else {
 								editor.on('init', function () {
-									editor.setContent( values.value );
+									editor.setContent( tinyMCEFieldValue );
 								});
 								updated = true;
 							}
 						}
-					} else if ( compareValues( $$.val(), values.value ) ) {
-						$$.val( values.value );
+					}
+					else if ( compareValues( sowbForms.sanitizeTinyMCEContent( $$.val() ), tinyMCEFieldValue ) ) {
+						$$.val( tinyMCEFieldValue );
 						updated = true;
 					}
 				} else if ( $$.is( '.panels-data' ) ) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -2204,6 +2204,14 @@ var sowbForms = window.sowbForms || {};
 
 
 	$(function () {
+		// When running inside the block editor canvas iframe, initialize any
+		// widget forms that are already in the DOM — but only if jQuery UI
+		// (sortable) is also already loaded. Scripts are injected asynchronously
+		// so execution order is not guaranteed; if sortable isn't available yet
+		// sowSetupRepeater would throw and abort setup before color pickers.
+		// The polling interval in sowbSetupWidgetForm (widget-block.js) is the
+		// primary mechanism; this path is a complementary fast-path for the case
+		// where all scripts happen to load before the form is rendered.
 		$(document).trigger('sowadminloaded');
 	});
 

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -50,9 +50,12 @@ var sowbForms = window.sowbForms || {};
 		}
 	}
 
-	const repeaterSetupFieldSelector = [
+	const repeaterVisibilitySensitiveFieldSelector = [
 		'.siteorigin-widget-field-type-tinymce',
 		'.siteorigin-widget-field-type-date-range',
+	].join( ', ' );
+
+	const repeaterImmediateSetupFieldSelector = [
 		'.siteorigin-widget-field-type-media',
 		'.siteorigin-widget-field-type-multiple_media',
 	].join( ', ' );
@@ -85,25 +88,33 @@ var sowbForms = window.sowbForms || {};
 	 * Triggers setup for repeater fields that need explicit initialization after
 	 * a repeater item is added or expanded.
 	 *
-	 * Fires `sowsetupformfield` immediately on visible fields, and always fires
-	 * `sowrepeaterfieldsadded` on the document for all fields (including hidden
-	 * ones) so that iframe pre-init handlers can bind before fields become
-	 * visible. The `clientId` of the enclosing block, when present, is passed as
-	 * a second argument so that only the relevant block reacts.
+	 * Fires `sowsetupformfield` immediately on media fields and on visible
+	 * visibility-sensitive fields, and always fires `sowrepeaterfieldsadded` on
+	 * the document for all setup fields. The `clientId` of the enclosing block,
+	 * when present, is passed as a second argument so that only the relevant
+	 * block reacts.
 	 *
 	 * @param {jQuery} $container - The newly added or expanded repeater item/form.
 	 */
-	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
-		const $allFields = $container
-			.filter( repeaterSetupFieldSelector )
-			.add( $container.find( repeaterSetupFieldSelector ) )
+	const triggerRepeaterFieldSetup = ( $container ) => {
+		const $visibilitySensitiveFields = $container
+			.filter( repeaterVisibilitySensitiveFieldSelector )
+			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
 			// Exclude placeholder rows inside repeater item templates — these carry
 			// `_id_` in their textarea IDs and must never be initialized directly.
 			.not( function() {
 				return $( this ).closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
 			} );
 
-		const $fields = $allFields.filter( ':visible' );
+		const $immediateFields = $container
+			.filter( repeaterImmediateSetupFieldSelector )
+			.add( $container.find( repeaterImmediateSetupFieldSelector ) )
+			.not( function() {
+				return $( this ).closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+			} );
+
+		const $allFields = $visibilitySensitiveFields.add( $immediateFields );
+		const $fields = $visibilitySensitiveFields.filter( ':visible' ).add( $immediateFields );
 
 		$fields.each( function() {
 			$( this ).trigger( 'sowsetupformfield' );
@@ -982,7 +993,7 @@ var sowbForms = window.sowbForms || {};
 			$el.find( '> .siteorigin-widget-field-repeater-items' ).append( item ).sortable( 'refresh' ).trigger( 'updateFieldPositions' );
 			item.sowSetupRepeaterItems();
 			item.hide().slideDown( 'fast', function () {
-				triggerVisibleRepeaterVisibilityFieldSetup( $( this ) );
+				triggerRepeaterFieldSetup( $( this ) );
 				$( window ).trigger( 'resize' );
 			});
 			$el.trigger( 'change' );
@@ -1182,7 +1193,7 @@ var sowbForms = window.sowbForms || {};
 								$this.trigger( 'slideToggleCloseComplete' );
 							} else {
 								$this.trigger( 'slideToggleOpenComplete' );
-								triggerVisibleRepeaterVisibilityFieldSetup( $this );
+								triggerRepeaterFieldSetup( $this );
 							}
 
 							$( window ).trigger( 'resize' );
@@ -1358,7 +1369,7 @@ var sowbForms = window.sowbForms || {};
 						$items.append( $copyItem ).sortable( 'refresh' ).trigger( 'updateFieldPositions' );
 						$copyItem.sowSetupRepeaterItems();
 						$copyItem.hide().slideDown( 'fast', function () {
-							triggerVisibleRepeaterVisibilityFieldSetup( $( this ) );
+							triggerRepeaterFieldSetup( $( this ) );
 							$( window ).trigger( 'resize' );
 						});
 						// If increment is enabled for this item, trigger label updates.

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1655,6 +1655,145 @@ var sowbForms = window.sowbForms || {};
 		return formContainer.data( 'id-base' );
 	};
 
+	const widgetFieldFlushers = {};
+
+	const getElementWindow = function( element ) {
+		return element && element.ownerDocument && element.ownerDocument.defaultView ?
+			element.ownerDocument.defaultView :
+			window;
+	};
+
+	const getElementJQuery = function( element ) {
+		const elementWindow = getElementWindow( element );
+		return elementWindow.jQuery || $;
+	};
+
+	const normalizeWidgetFormContainer = function( formContainer ) {
+		if (
+			formContainer === undefined ||
+			formContainer === null ||
+			formContainer.length === 0
+		) {
+			return $();
+		}
+
+		const element = formContainer.jquery ? formContainer[0] : formContainer;
+		const elementJQuery = getElementJQuery( element );
+
+		return elementJQuery( element );
+	};
+
+	const getWidgetFieldType = function( $field ) {
+		const fieldClasses = ( $field.attr( 'class' ) || '' ).split( /\s+/ );
+
+		for ( let i = 0; i < fieldClasses.length; i++ ) {
+			const matches = fieldClasses[ i ].match( /^siteorigin-widget-field-type-(.+)$/ );
+
+			if ( matches ) {
+				return matches[1];
+			}
+		}
+
+		return null;
+	};
+
+	const normalizeWidgetFormSnapshotOptions = function( options ) {
+		return $.extend( {
+			awaitAsync: true,
+			triggerChange: false,
+		}, options || {} );
+	};
+
+	sowbForms.registerFieldFlusher = function( fieldType, callback ) {
+		if (
+			typeof fieldType !== 'string' ||
+			typeof callback !== 'function'
+		) {
+			return;
+		}
+
+		widgetFieldFlushers[ fieldType ] = callback;
+	};
+
+	sowbForms.flushWidgetForm = function( formContainer, options ) {
+		const $formContainer = normalizeWidgetFormContainer( formContainer );
+		const normalizedOptions = normalizeWidgetFormSnapshotOptions( options );
+		const flushPromises = [];
+
+		$formContainer.find( '.siteorigin-widget-field' ).each( function() {
+			const $field = getElementJQuery( this )( this );
+			const fieldType = getWidgetFieldType( $field );
+
+			if (
+				! fieldType ||
+				! widgetFieldFlushers[ fieldType ]
+			) {
+				return;
+			}
+
+			const flushResult = widgetFieldFlushers[ fieldType ]( $field, normalizedOptions );
+
+			if (
+				normalizedOptions.awaitAsync &&
+				flushResult &&
+				typeof flushResult.then === 'function'
+			) {
+				flushPromises.push( Promise.resolve( flushResult ) );
+			}
+		} );
+
+		return Promise.all( flushPromises ).then( function() {} );
+	};
+
+	sowbForms.getWidgetFormSnapshot = function( formContainer, options ) {
+		const $formContainer = normalizeWidgetFormContainer( formContainer );
+
+		return sowbForms.flushWidgetForm( $formContainer, options ).then( function() {
+			return sowbForms.getWidgetFormValues( $formContainer );
+		} );
+	};
+
+	sowbForms.registerFieldFlusher( 'tinymce', function( $field, options ) {
+		const fieldWindow = getElementWindow( $field[0] );
+		const fieldJQuery = fieldWindow.jQuery || $;
+		const flushPromises = [];
+
+		$field.find( 'textarea.wp-editor-area' ).each( function() {
+			const $textarea = fieldJQuery( this );
+			const editorId = $textarea.data( 'tinymce-id' ) || $textarea.attr( 'id' );
+			const initPromise = ( editorId && typeof fieldWindow.sowbGetTinyMCEInitPromise === 'function' ) ?
+				fieldWindow.sowbGetTinyMCEInitPromise( editorId ) :
+				Promise.resolve();
+
+			flushPromises.push(
+				initPromise.then( function() {
+					const editor = fieldWindow.tinymce && editorId ?
+						fieldWindow.tinymce.get( editorId ) :
+						null;
+
+					if (
+						editor &&
+						typeof editor.getContent === 'function' &&
+						(
+							typeof editor.isHidden !== 'function' ||
+							! editor.isHidden()
+						)
+					) {
+						$textarea.val( sowbForms.sanitizeTinyMCEContent( editor.getContent() ) );
+					} else {
+						$textarea.val( sowbForms.sanitizeTinyMCEContent( $textarea.val() ) );
+					}
+
+					if ( options.triggerChange ) {
+						$textarea.trigger( 'change' );
+					}
+				} )
+			);
+		} );
+
+		return Promise.all( flushPromises );
+	} );
+
 	sowbForms.getWidgetFormValues = function ( formContainer ) {
 
 		if ( _.isUndefined( formContainer ) ) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -44,16 +44,35 @@ var sowbForms = window.sowbForms || {};
 
 	const repeaterVisibilitySensitiveFieldSelector = '.siteorigin-widget-field-type-tinymce, .siteorigin-widget-field-type-date-range';
 
+	/**
+	 * Triggers setup for visibility-sensitive repeater fields after a repeater
+	 * item is added or expanded.
+	 *
+	 * Fires `sowsetupformfield` immediately on visible fields, and always fires
+	 * `sowrepeaterfieldsadded` on the document for all fields (including hidden
+	 * ones) so that iframe pre-init handlers can bind before fields become
+	 * visible. The `clientId` of the enclosing block, when present, is passed as
+	 * a second argument so that only the relevant block reacts.
+	 *
+	 * @param {jQuery} $container - The newly added or expanded repeater item/form.
+	 */
 	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
-		$container
+		const $allFields = $container
 			.filter( repeaterVisibilitySensitiveFieldSelector )
-			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
-			.filter( function() {
-				return $( this ).is( ':visible' );
-			} )
-			.each( function() {
-				$( this ).trigger( 'sowsetupformfield' );
-			} );
+			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) );
+
+		const $fields = $allFields.filter( ':visible' );
+
+		$fields.each( function() {
+			$( this ).trigger( 'sowsetupformfield' );
+		} );
+
+		// Fire a document-level event to notify iframe-context listeners of repeater field additions.
+		// This must include hidden fields so TinyMCE pre-init handlers can bind before they become visible.
+		if ( $allFields.length > 0 ) {
+			const clientId = $container.closest( '[data-block]' ).attr( 'data-block' ) || null;
+			$( document ).trigger( 'sowrepeaterfieldsadded', [ $allFields, clientId ] );
+		}
 	}
 
 	$.fn.sowSetupForm = function () {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -50,7 +50,12 @@ var sowbForms = window.sowbForms || {};
 		}
 	}
 
-	const repeaterVisibilitySensitiveFieldSelector = '.siteorigin-widget-field-type-tinymce, .siteorigin-widget-field-type-date-range';
+	const repeaterSetupFieldSelector = [
+		'.siteorigin-widget-field-type-tinymce',
+		'.siteorigin-widget-field-type-date-range',
+		'.siteorigin-widget-field-type-media',
+		'.siteorigin-widget-field-type-multiple_media',
+	].join( ', ' );
 
 	sowbForms.sanitizeTinyMCEContent = function( content ) {
 		if ( typeof content !== 'string' || content.length === 0 ) {
@@ -77,8 +82,8 @@ var sowbForms = window.sowbForms || {};
 	};
 
 	/**
-	 * Triggers setup for visibility-sensitive repeater fields after a repeater
-	 * item is added or expanded.
+	 * Triggers setup for repeater fields that need explicit initialization after
+	 * a repeater item is added or expanded.
 	 *
 	 * Fires `sowsetupformfield` immediately on visible fields, and always fires
 	 * `sowrepeaterfieldsadded` on the document for all fields (including hidden
@@ -90,8 +95,8 @@ var sowbForms = window.sowbForms || {};
 	 */
 	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
 		const $allFields = $container
-			.filter( repeaterVisibilitySensitiveFieldSelector )
-			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
+			.filter( repeaterSetupFieldSelector )
+			.add( $container.find( repeaterSetupFieldSelector ) )
 			// Exclude placeholder rows inside repeater item templates — these carry
 			// `_id_` in their textarea IDs and must never be initialized directly.
 			.not( function() {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -59,7 +59,12 @@ var sowbForms = window.sowbForms || {};
 	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
 		const $allFields = $container
 			.filter( repeaterVisibilitySensitiveFieldSelector )
-			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) );
+			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
+			// Exclude placeholder rows inside repeater item templates — these carry
+			// `_id_` in their textarea IDs and must never be initialized directly.
+			.not( function() {
+				return $( this ).closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+			} );
 
 		const $fields = $allFields.filter( ':visible' );
 
@@ -73,7 +78,7 @@ var sowbForms = window.sowbForms || {};
 			const clientId = $container.closest( '[data-block]' ).attr( 'data-block' ) || null;
 			$( document ).trigger( 'sowrepeaterfieldsadded', [ $allFields, clientId ] );
 		}
-	}
+	};
 
 	$.fn.sowSetupForm = function () {
 

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -4,7 +4,15 @@ var sowbForms = window.sowbForms || {};
 
 (function ($) {
 
+	if ( window.sowbWidgetAdminScriptLoaded ) {
+		return;
+	}
+
+	window.sowbWidgetAdminScriptLoaded = true;
+	window.sowbWidgetAdminScriptLoadedAt = Date.now();
+
 	const isBlockEditor = $( 'body' ).hasClass( 'block-editor-page' );
+
 
 	let fontList = '';
 	for ( const [ value, label ] of Object.entries( soWidgets.fonts ) ) {
@@ -63,7 +71,9 @@ var sowbForms = window.sowbForms || {};
 			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
 			.forEach( ( marker ) => marker.remove() );
 
-		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+		const sanitizedContent = wrapper.innerHTML.replace( /\uFEFF/g, '' );
+
+		return sanitizedContent;
 	};
 
 	/**
@@ -1742,7 +1752,7 @@ var sowbForms = window.sowbForms || {};
 			}
 		} );
 
-		return Promise.all( flushPromises ).then( function() {} );
+		return Promise.all( flushPromises );
 	};
 
 	sowbForms.getWidgetFormSnapshot = function( formContainer, options ) {
@@ -1787,6 +1797,7 @@ var sowbForms = window.sowbForms || {};
 					if ( options.triggerChange ) {
 						$textarea.trigger( 'change' );
 					}
+
 				} )
 			);
 		} );

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -860,9 +860,9 @@
 						dangerouslySetInnerHTML: {
 							__html: widgetPreviewHtml
 						},
-						ref: () => {
+						ref: ( previewElement ) => {
 							if ( ! previewInitialized ) {
-								jQuery( window.sowb ).trigger( 'setup_widgets', { preview: true } );
+								sowbSetupPreviewWidgets( previewElement );
 								mergeState( { previewInitialized: true } );
 							}
 						}
@@ -1206,6 +1206,20 @@ const sowbGetElementWindow = ( element ) => {
 	return element && element.ownerDocument && element.ownerDocument.defaultView ?
 		element.ownerDocument.defaultView :
 		window;
+};
+
+const sowbSetupPreviewWidgets = ( previewElement ) => {
+	sowbMaybeSetupSiteEditorAssets();
+
+	const previewWindow = sowbGetElementWindow( previewElement );
+	const previewJQuery = previewWindow.jQuery || jQuery;
+	const previewSowb = previewWindow.sowb || window.sowb;
+
+	if ( ! previewSowb ) {
+		return;
+	}
+
+	previewJQuery( previewSowb ).trigger( 'setup_widgets', { preview: true } );
 };
 
 /**
@@ -1600,6 +1614,10 @@ const sowbCanvasCloneElements = [
 	'#wplink-js',
 	'#buttons-css',
 	'#dashicons-css',
+
+	// Widget frontend preview scripts.
+	'#dessandro-imagesLoaded-js',
+	'#sow-image-grid-js',
 
 	// Load all styles imported using load-styles.php.
 	'link[href*="wp-admin/load-styles.php"]',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -27,6 +27,14 @@
 		return errorMessage;
 	};
 
+	const sowbSerializeWidgetData = ( widgetData ) => {
+		try {
+			return JSON.stringify( widgetData || {} );
+		} catch ( error ) {
+			return null;
+		}
+	};
+
 	// Certain widgets are excluded from the content check as
 	// they don't contain "standard" content indicators.
 	const widgetsExcludedFromContentCheck = [
@@ -246,7 +254,6 @@
 	 * @param {Function} setState - The setState function to update the component's state.
 	 * @param {Object} activeRequestRef - React ref tracking the active preview request.
 	 */
-
 	const sowbSetupWidgetForm = async ( props, state, setState, activeRequestRef ) => {
 		let $mainForm = sowbGetBlockForm( props.clientId );
 
@@ -257,14 +264,12 @@
 		// Re-wrap the form node with the jQuery instance that owns it. In the
 		// iframe path this is the iframe's jQuery; in the non-iframe path it is
 		// the parent jQuery. sowSetupForm(), wpColorPicker, and all other field
-		// plugins are bound to whichever jQuery ran their defining script — using
+		// plugins are bound to whichever jQuery ran their defining script, using
 		// the same instance here ensures event handlers fire correctly.
 		const formWindow = sowbGetElementWindow( $mainForm[ 0 ] );
 		const formJQuery = formWindow.jQuery || jQuery;
 		const formForms = formWindow.sowbForms || sowbForms;
 		$mainForm = formJQuery( $mainForm[ 0 ] );
-
-		sowbMaybeSetupSiteEditorAssets();
 
 		const switchToBlockPreview = async function() {
 			const oldTimer = $mainForm.data( 'sowb-preview-timer' );
@@ -309,7 +314,56 @@
 				} );
 		};
 
+		if ( $mainForm.data( 'sowb-block-form-initializing' ) ) {
+			return;
+		}
+
+		if ( $mainForm.data( 'sow-form-setup' ) === true ) {
+			bindBlockPreviewHandler();
+			setState( { formInitialized: true } );
+			return;
+		}
+
+		const setupFrame = sowbGetEditorCanvasFrame();
+		if ( ! $mainForm.data( 'sowb-form-setup-assets-cloned' ) ) {
+			sowbMaybeSetupSiteEditorAssets();
+			$mainForm.data( 'sowb-form-setup-assets-cloned', true );
+		}
+
+		const dependencyStatus = sowbEnsureFormSetupDependencies( setupFrame, formWindow, $mainForm );
+		if ( ! dependencyStatus.ready ) {
+
+			const oldRetryTimer = $mainForm.data( 'sowb-form-setup-dependency-retry' );
+			if ( oldRetryTimer ) {
+				clearTimeout( oldRetryTimer );
+			}
+
+			const retryCount = ( $mainForm.data( 'sowb-form-setup-dependency-retry-count' ) || 0 ) + 1;
+			$mainForm.data( 'sowb-form-setup-dependency-retry-count', retryCount );
+
+			if ( retryCount <= 40 ) {
+				$mainForm.data(
+					'sowb-form-setup-dependency-retry',
+					setTimeout( function() {
+						sowbSetupWidgetForm(
+							props,
+							state,
+							setState,
+							activeRequestRef
+						);
+					}, 250 )
+				);
+			}
+
+			return;
+		}
+		$mainForm.removeData( 'sowb-form-setup-dependency-retry' );
+		$mainForm.removeData( 'sowb-form-setup-dependency-retry-count' );
+
+		$mainForm.data( 'sowb-block-form-initializing', true );
 		$mainForm.data( 'backupDisabled', true );
+
+		let currentWidgetDataJson = sowbSerializeWidgetData( props.attributes.widgetData );
 
 		if ( props.attributes.widgetData ) {
 			// If we call `setWidgetFormValues` with the last parameter
@@ -317,11 +371,20 @@
 			// for some fields e.g. color and media fields.
 			formForms.setWidgetFormValues( $mainForm, props.attributes.widgetData );
 		} else {
-			props.setAttributes( { widgetData: formForms.getWidgetFormValues( $mainForm ) } );
+			const initialWidgetData = formForms.getWidgetFormValues( $mainForm );
+			currentWidgetDataJson = sowbSerializeWidgetData( initialWidgetData );
+			props.setAttributes( { widgetData: initialWidgetData } );
 		}
 
-		$mainForm.sowSetupForm();
+		try {
+			$mainForm.sowSetupForm();
+		} catch ( error ) {
+			$mainForm.removeData( 'sowb-block-form-initializing' );
+			throw error;
+		}
 		bindBlockPreviewHandler();
+		$mainForm.removeData( 'sowb-block-form-initializing' );
+		$mainForm.data( 'sowb-block-last-widget-data-json', currentWidgetDataJson );
 
 		// Namespace the change event so multiple sowbSetupWidgetForm calls for
 		// the same block (React double-render / stale closures) don't stack up
@@ -338,6 +401,16 @@
 				// As setAttributes doesn't support callbacks, we have to manually
 				// pass the widgetData to the preview.
 				var widgetData = formForms.getWidgetFormValues( $mainForm );
+				const widgetDataJson = sowbSerializeWidgetData( widgetData );
+
+				if (
+					widgetDataJson !== null &&
+					widgetDataJson === $mainForm.data( 'sowb-block-last-widget-data-json' )
+				) {
+					return;
+				}
+
+				$mainForm.data( 'sowb-block-last-widget-data-json', widgetDataJson );
 				props.setAttributes( { widgetData: widgetData } );
 
 				// Set up a preview debounce timer to prevent multiple requests.
@@ -430,6 +503,7 @@
 
 		const sendInitMessage = () => {
 			try {
+				sowbEnsureIframeOldEditorApi( iframeElement );
 				iframeWindow.postMessage( message, targetOrigin );
 			} catch ( e ) {
 				console.error( 'SiteOrigin Widgets: Failed to send postMessage to iframe:', e );
@@ -1112,8 +1186,12 @@
 		} )
 	} );
 
-	// Copy over assets to the editor iframe asap.
-	sowbMaybeSetupSiteEditorAssets();
+	// Copy over assets to the editor iframe asap. When this script is itself
+	// running inside the editor iframe, the parent setup paths own asset
+	// cloning; self-cloning from the iframe can race with those paths.
+	if ( ! window.frameElement ) {
+		sowbMaybeSetupSiteEditorAssets();
+	}
 } )( window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.blockEditor );
 
 let sowbSiteEditorCanvas = false;
@@ -1181,6 +1259,87 @@ const sowbResolveWpEditor = () => {
 };
 window.sowbResolveWpEditor = sowbResolveWpEditor;
 
+const sowbGetFormSetupDependencyStatus = ( formWindow, $form ) => {
+	const formJQuery = formWindow && formWindow.jQuery ? formWindow.jQuery : null;
+	let isIframeForm = false;
+	try {
+		isIframeForm = !! (
+			formWindow &&
+			(
+				formWindow !== window ||
+				formWindow.frameElement
+			)
+		);
+	} catch ( e ) {
+		isIframeForm = formWindow !== window;
+	}
+	const hasRepeater = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-repeater, .siteorigin-widget-field-type-repeater' ).length
+	);
+	const hasSlider = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-type-slider' ).length
+	);
+	const hasTinyMCE = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-type-tinymce' ).length
+	);
+	const hasWpEditorApi = !! (
+		formWindow &&
+		formWindow.wp &&
+		(
+			(
+				formWindow.wp.oldEditor &&
+				typeof formWindow.wp.oldEditor.initialize === 'function'
+			) ||
+			(
+				formWindow.wp.editor &&
+				typeof formWindow.wp.editor.initialize === 'function'
+			)
+		)
+	);
+
+	return {
+		hasJQuery: !! formJQuery,
+		hasSowSetupForm: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.sowSetupForm === 'function' ),
+		hasJQueryUi: !! ( formJQuery && formJQuery.ui ),
+		hasMouse: !! ( formJQuery && formJQuery.ui && formJQuery.ui.mouse ),
+		hasSortable: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.sortable === 'function' ),
+		hasSliderApi: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.slider === 'function' ),
+		hasRepeater,
+		hasSlider,
+		hasTinyMCE,
+		isIframeForm,
+		hasWpEditorApi,
+		ready: !! (
+			formJQuery &&
+			formJQuery.fn &&
+			typeof formJQuery.fn.sowSetupForm === 'function' &&
+			( ! hasRepeater || typeof formJQuery.fn.sortable === 'function' ) &&
+			( ! hasSlider || typeof formJQuery.fn.slider === 'function' ) &&
+			( ! hasTinyMCE || ! isIframeForm || hasWpEditorApi )
+		),
+	};
+};
+
+const sowbEnsureFormSetupDependencies = ( frame, formWindow, $form ) => {
+	if ( frame ) {
+		sowbEnsureIframeOldEditorApi( frame );
+	}
+
+	const dependencyStatus = sowbGetFormSetupDependencyStatus( formWindow, $form );
+
+	if ( dependencyStatus.ready ) {
+		return dependencyStatus;
+	}
+
+	return dependencyStatus;
+};
+
 const sowbResolveSiteEditorFrame = ( frame = null ) => {
 	if ( frame ) {
 		if ( frame.jquery ) {
@@ -1242,10 +1401,12 @@ const sowbGetBlockForm = ( clientId ) => {
 	}
 
 	// No iframe (e.g. widgets.php Block Widgets screen, classic editor).
-	return jQuery( document )
+	const $mainDocumentForm = jQuery( document )
 		.find( '[data-block="' + clientId + '"]' )
 		.find( '.siteorigin-widget-form-main[data-class]' )
 		.first();
+
+	return $mainDocumentForm;
 };
 
 const sowbIsDirectWidgetBlock = ( block ) => {
@@ -1291,17 +1452,19 @@ const sowbGetBlockFormSnapshot = async ( $form ) => {
 		formForms &&
 		typeof formForms.getWidgetFormSnapshot === 'function'
 	) {
-		return await formForms.getWidgetFormSnapshot( $ownerForm, {
+		const widgetData = await formForms.getWidgetFormSnapshot( $ownerForm, {
 			awaitAsync: true,
 			triggerChange: false,
 		} );
+		return widgetData;
 	}
 
 	if (
 		formForms &&
 		typeof formForms.getWidgetFormValues === 'function'
 	) {
-		return formForms.getWidgetFormValues( $ownerForm );
+		const widgetData = formForms.getWidgetFormValues( $ownerForm );
+		return widgetData;
 	}
 
 	return null;
@@ -1521,6 +1684,238 @@ const sowbGetElementById = ( doc, id ) => {
 	return doc.getElementById( id );
 };
 
+const sowbIsScriptHandleLoadedInWindow = ( targetWindow, scriptId ) => {
+	if ( ! targetWindow || ! scriptId ) {
+		return false;
+	}
+
+	switch ( scriptId ) {
+		case 'jquery-core-js':
+			return !! targetWindow.jQuery;
+		case 'jquery-migrate-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.migrateVersion
+			);
+		case 'jquery-ui-core-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.ui
+			);
+		case 'jquery-ui-mouse-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.ui &&
+				targetWindow.jQuery.ui.mouse
+			);
+		case 'jquery-ui-slider-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.slider === 'function'
+			);
+		case 'jquery-ui-sortable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.sortable === 'function'
+			);
+		case 'jquery-ui-resizable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.resizable === 'function'
+			);
+		case 'jquery-ui-draggable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.draggable === 'function'
+			);
+		case 'iris-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.iris === 'function'
+			);
+		case 'wp-color-picker-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.wpColorPicker === 'function'
+			);
+		case 'siteorigin-widget-admin-js-extra':
+			return !! targetWindow.soWidgets;
+		case 'siteorigin-widget-admin-js':
+			return !! (
+				targetWindow.sowbWidgetAdminScriptLoaded ||
+				(
+					targetWindow.sowbForms &&
+					targetWindow.jQuery &&
+					targetWindow.jQuery.fn &&
+					typeof targetWindow.jQuery.fn.sowSetupForm === 'function'
+				)
+			);
+		case 'so-tinymce-field-js':
+			return !! (
+				targetWindow.sowbTinyMCEFieldScriptLoaded ||
+				typeof targetWindow.sowbGetTinyMCEInitPromise === 'function'
+			);
+		case 'editor-js':
+			return !! (
+				targetWindow.wp &&
+				(
+					(
+						targetWindow.wp.oldEditor &&
+						typeof targetWindow.wp.oldEditor.initialize === 'function'
+					) ||
+					(
+						targetWindow.wp.editor &&
+						typeof targetWindow.wp.editor.initialize === 'function'
+					)
+				)
+			);
+		case 'wp-tinymce-js':
+			return !! targetWindow.tinymce;
+		case 'quicktags-js':
+			return !! targetWindow.QTags;
+		case 'underscore-js':
+			return !! targetWindow._;
+		default:
+			return false;
+	}
+};
+
+const sowbGetEditorAssetSourceDocument = () => {
+	try {
+		if (
+			window.frameElement &&
+			window.parent &&
+			window.parent.document
+		) {
+			return window.parent.document;
+		}
+	} catch ( e ) {
+	}
+
+	return document;
+};
+
+const sowbEnsureIframeEditorGlobals = ( frame ) => {
+	if (
+		! frame ||
+		! frame.contentWindow
+	) {
+		return;
+	}
+
+	const iframeWindow = frame.contentWindow;
+	const topWindow = window.top || window;
+	const globals = [
+		'ajaxurl',
+		'userSettings',
+		'wpCookies',
+		'getUserSetting',
+		'setUserSetting',
+		'deleteUserSetting',
+		'getAllUserSettings',
+	];
+
+	globals.forEach( ( globalName ) => {
+		if (
+			typeof iframeWindow[ globalName ] === 'undefined' &&
+			typeof topWindow[ globalName ] !== 'undefined'
+		) {
+			iframeWindow[ globalName ] = topWindow[ globalName ];
+		}
+	} );
+};
+
+const sowbEnsureIframeOldEditorApi = ( frame ) => {
+	if (
+		! frame ||
+		! frame.contentDocument ||
+		! frame.contentWindow ||
+		! frame.contentDocument.body
+	) {
+		return;
+	}
+
+	sowbEnsureIframeEditorGlobals( frame );
+
+	const iframeWindow = frame.contentWindow;
+	if (
+		iframeWindow.wp &&
+		iframeWindow.wp.oldEditor &&
+		typeof iframeWindow.wp.oldEditor.initialize === 'function'
+	) {
+		return;
+	}
+
+	if (
+		iframeWindow.wp &&
+		iframeWindow.wp.editor &&
+		typeof iframeWindow.wp.editor.initialize === 'function'
+	) {
+		iframeWindow.wp.oldEditor = iframeWindow.wp.editor;
+		return;
+	}
+
+	if ( frame.contentDocument.getElementById( 'sowb-editor-js-retry' ) ) {
+		return;
+	}
+
+	if (
+		iframeWindow.sowbEditorJsRetryPending ||
+		(
+			iframeWindow.sowbScriptClonePending &&
+			iframeWindow.sowbScriptClonePending[ 'id:editor-js' ]
+		)
+	) {
+		return;
+	}
+
+	const sourceDoc = sowbGetEditorAssetSourceDocument();
+	const editorScript = sowbGetElementById( sourceDoc, 'editor-js' );
+	if ( ! editorScript || ! editorScript.src ) {
+		return;
+	}
+
+	const previousEditor = iframeWindow.wp && iframeWindow.wp.editor;
+	const retryScript = frame.contentDocument.createElement( 'script' );
+	retryScript.id = 'sowb-editor-js-retry';
+	retryScript.src = editorScript.src;
+	retryScript.async = false;
+	retryScript.onload = () => {
+		iframeWindow.sowbEditorJsRetryPending = false;
+		if (
+			! iframeWindow.wp ||
+			! iframeWindow.wp.editor ||
+			typeof iframeWindow.wp.editor.initialize !== 'function'
+		) {
+			return;
+		}
+
+		const oldEditor = iframeWindow.wp.editor;
+		iframeWindow.wp.oldEditor = oldEditor;
+
+		if (
+			previousEditor &&
+			previousEditor !== oldEditor
+		) {
+			Object.assign( previousEditor, oldEditor );
+			iframeWindow.wp.editor = previousEditor;
+		}
+
+	};
+	retryScript.onerror = ( event ) => {
+		iframeWindow.sowbEditorJsRetryPending = false;
+	};
+
+	iframeWindow.sowbEditorJsRetryPending = true;
+	frame.contentDocument.body.appendChild( retryScript );
+};
+
 /**
  * Gets the editor settings for a TinyMCE container.
  *
@@ -1639,6 +2034,31 @@ const sowbCloneElementToCanvas = ( $canvasBody, element, $source ) => {
 	const sourceDoc = $source && $source[0] && $source[0].nodeType === 9 ?
 		$source[0] :
 		element.ownerDocument;
+	const canvasWindow = canvasDoc && canvasDoc.defaultView;
+	const tagName = element.tagName ? element.tagName.toLowerCase() : '';
+	const assetAttribute = element.hasAttribute( 'src' ) ? 'src' : (
+		element.hasAttribute( 'href' ) ? 'href' : ''
+	);
+	const assetUrl = assetAttribute ?
+		sowbNormalizeAssetUrl(
+			element.getAttribute( assetAttribute ),
+			sowbGetDocumentHref( sourceDoc )
+		) :
+		'';
+	const scriptCloneKey = tagName === 'script' ?
+		( element.id ? 'id:' + element.id : ( assetUrl ? 'url:' + assetUrl : '' ) ) :
+		'';
+
+	if ( scriptCloneKey && canvasWindow ) {
+		canvasWindow.sowbScriptClonePending = canvasWindow.sowbScriptClonePending || {};
+
+		if (
+			canvasWindow.sowbScriptClonePending[ scriptCloneKey ] ||
+			sowbIsScriptHandleLoadedInWindow( canvasWindow, element.id )
+		) {
+			return false;
+		}
+	}
 
 	if (
 		element.id &&
@@ -1647,32 +2067,51 @@ const sowbCloneElementToCanvas = ( $canvasBody, element, $source ) => {
 		return false;
 	}
 
-	const assetAttribute = element.hasAttribute( 'src' ) ? 'src' : (
-		element.hasAttribute( 'href' ) ? 'href' : ''
-	);
+	if ( assetUrl ) {
+		const selector = assetAttribute === 'src' ? 'script[src]' : 'link[href]';
+		const existingAsset = $canvasBody.find( selector ).toArray().some( ( candidate ) => {
+			return sowbNormalizeAssetUrl(
+				candidate.getAttribute( assetAttribute ),
+				sowbGetDocumentHref( candidate.ownerDocument )
+			) === assetUrl;
+		} );
 
-	if ( assetAttribute ) {
-		const assetUrl = sowbNormalizeAssetUrl(
-			element.getAttribute( assetAttribute ),
-			sowbGetDocumentHref( sourceDoc )
-		);
-
-		if ( assetUrl ) {
-			const selector = assetAttribute === 'src' ? 'script[src]' : 'link[href]';
-			const existingAsset = $canvasBody.find( selector ).toArray().some( ( candidate ) => {
-				return sowbNormalizeAssetUrl(
-					candidate.getAttribute( assetAttribute ),
-					sowbGetDocumentHref( candidate.ownerDocument )
-				) === assetUrl;
-			} );
-
-			if ( existingAsset ) {
-				return false;
-			}
+		if ( existingAsset ) {
+			return false;
 		}
 	}
 
-	$canvasBody.append( element.outerHTML );
+	let clonedElement;
+	if ( tagName === 'script' ) {
+		clonedElement = canvasDoc.createElement( 'script' );
+		for ( const attribute of element.attributes ) {
+			clonedElement.setAttribute( attribute.name, attribute.value );
+		}
+		clonedElement.textContent = element.textContent;
+		clonedElement.async = false;
+		if ( scriptCloneKey && canvasWindow ) {
+			clonedElement.addEventListener( 'load', () => {
+				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+			}, { once: true } );
+			clonedElement.addEventListener( 'error', () => {
+				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+			}, { once: true } );
+		}
+	} else {
+		clonedElement = element.cloneNode( true );
+	}
+	if ( scriptCloneKey && canvasWindow ) {
+		canvasWindow.sowbScriptClonePending[ scriptCloneKey ] = true;
+	}
+	$canvasBody[0].appendChild( clonedElement );
+	if (
+		tagName === 'script' &&
+		! assetUrl &&
+		scriptCloneKey &&
+		canvasWindow
+	) {
+		delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+	}
 	return true;
 };
 
@@ -1728,6 +2167,15 @@ const sowbCloneElementsToCanvas = ( $canvasBody, sourceDoc ) => {
 	for ( const selector of sowbCanvasCloneElements ) {
 		const $element = $source.find( selector );
 		if ( $element.length === 0 ) {
+			if ( [
+				'#wp-tinymce-js',
+				'#quicktags-js-extra',
+				'#quicktags-js',
+				'#siteorigin-widget-admin-js',
+				'#so-tinymce-field-js',
+				'#underscore-js',
+			].includes( selector ) ) {
+			}
 			continue;
 		}
 
@@ -1736,6 +2184,15 @@ const sowbCloneElementsToCanvas = ( $canvasBody, sourceDoc ) => {
 			continue;
 		}
 
+		if ( [
+			'#wp-tinymce-js',
+			'#quicktags-js-extra',
+			'#quicktags-js',
+			'#siteorigin-widget-admin-js',
+			'#so-tinymce-field-js',
+			'#underscore-js',
+		].includes( selector ) ) {
+		}
 		sowbCloneElementToCanvas( $canvasBody, element, $source );
 	}
 };
@@ -1757,8 +2214,6 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 		sourceDoc || document
 	);
 	const assetRootList = [ ...assetRoots ];
-	let previousMatchedScriptRoot = '';
-	let pendingDependencyScripts = [];
 
 	const cloneAssetElement = ( element ) => {
 		if ( element.tagName.toLowerCase() === 'script' ) {
@@ -1767,6 +2222,14 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 
 		sowbCloneElementToCanvas( $canvasBody, element, $source );
 	};
+
+	if ( assetRootList.some( ( assetRoot ) => assetRoot.indexOf( '/web-font-selector/js/' ) !== -1 ) ) {
+		$source
+			.find( '#web-font-loader-js, script[src*="ajax.googleapis.com/ajax/libs/webfont/"]' )
+			.each( function() {
+				cloneAssetElement( this );
+			} );
+	}
 
 	$source.find( 'script[src], link[rel="stylesheet"][href]' ).each( function() {
 		const tagName = this.tagName.toLowerCase();
@@ -1779,26 +2242,7 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 			'';
 
 		if ( matchedRoot ) {
-			if ( tagName === 'script' ) {
-				// WordPress prints script dependencies before dependents, but the
-				// DOM does not expose dependency handles. If a TinyMCE companion
-				// package has root-matched scripts on both sides of an intervening
-				// script, preserve that in-between dependency before the later
-				// matched script runs in the iframe.
-				if ( previousMatchedScriptRoot === matchedRoot ) {
-					pendingDependencyScripts.forEach( cloneAssetElement );
-				}
-
-				pendingDependencyScripts = [];
-				previousMatchedScriptRoot = matchedRoot;
-			}
-
 			cloneAssetElement( this );
-			return;
-		}
-
-		if ( tagName === 'script' && previousMatchedScriptRoot ) {
-			pendingDependencyScripts.push( this );
 		}
 	} );
 };
@@ -1858,8 +2302,10 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 		sourceDoc = document;
 	}
 
+	sowbEnsureIframeEditorGlobals( currentFrame );
 	sowbCloneElementsToCanvas( $canvasBody, sourceDoc );
 	sowbCloneTinyMCEExternalPluginAssets( $canvasBody, sourceDoc );
+	sowbEnsureIframeOldEditorApi( currentFrame );
 
 	// Is ajaxurl set?
 	try {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1036,6 +1036,31 @@
 
 let sowbSiteEditorCanvas = false;
 
+/**
+ * Resolves the best available WordPress editor API object.
+ *
+ * Prefers `wp.oldEditor` (present in iframe contexts for legacy compatibility)
+ * over `wp.editor` so that teardown and initialization use the same object.
+ * Requires the resolved object to expose `initialize()` before returning it,
+ * so callers always receive a fully usable API or null.
+ *
+ * Exposed as `window.sowbResolveWpEditor` so shared infrastructure
+ * (e.g. `tinymce-field.js`) and third-party code can call the same
+ * implementation without duplicating the guard logic.
+ *
+ * @returns {Object|null} The resolved editor API, or null if unavailable.
+ */
+const sowbResolveWpEditor = () => {
+	if ( ! window.wp ) {
+		return null;
+	}
+	const candidate = window.wp.oldEditor && typeof window.wp.oldEditor.initialize === 'function'
+		? window.wp.oldEditor
+		: ( window.wp.editor || null );
+	return candidate && typeof candidate.initialize === 'function' ? candidate : null;
+};
+window.sowbResolveWpEditor = sowbResolveWpEditor;
+
 const sowbResolveSiteEditorFrame = ( frame = null ) => {
 	if ( frame ) {
 		if ( frame.jquery ) {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -311,14 +311,22 @@
 		} );
 
 		setState( { formInitialized: true } );
+		jQuery( document ).trigger( 'sowsetupform', [ $mainForm ] );
 	};
 
 	/**
 	 * Initializes WB Form Fields in the Site Editor iframe.
 	 *
-	 * Unlike the regular editor, the Site Editor uses an iframe to
-	 * display blocks. This requires us to reinitialize WB form fields
-	 * in the iframe context after the form has been set up.
+	 * Unlike the regular editor, the Site Editor uses an iframe to display
+	 * blocks. This function resolves the iframe window, builds a postMessage
+	 * payload targeting this block's form, sends it immediately, and attaches
+	 * a persistent document-level listener so that a fresh message is sent
+	 * whenever a repeater item is added inside this block.
+	 *
+	 * @param {string} clientId - The block's client ID.
+	 *
+	 * @returns {Function|null} Cleanup function that removes the repeater
+	 *                          listener, or null if no iframe was found.
 	 */
 	const initializeFormFieldsInIframe = ( clientId ) => {
 		const iframeElement = sowbResolveSiteEditorFrame();
@@ -357,10 +365,9 @@
 			return null;
 		}
 
-		const timeoutIds = [];
 		const blockSelector = clientId ? `[data-block="${ clientId }"]` : '';
 		const formSelector = blockSelector ?
-			`${ blockSelector } .siteorigin-widget-form-main` :
+			`${ blockSelector } .siteorigin-widget-form.siteorigin-widget-form-main` :
 			'';
 		const message = {
 			action: 'sowbBlockFormInit',
@@ -377,14 +384,25 @@
 			}
 		};
 
-		[ 0, 250, 1000, 3000, 6000 ].forEach( ( delay ) => {
-			timeoutIds.push( setTimeout( sendInitMessage, delay ) );
-		} );
+		// Send once immediately: by the time this effect runs, React has already
+		// rendered the form HTML and setWidgetFormValues has restored any saved
+		// repeater items, so the iframe DOM is stable.
+		sendInitMessage();
+
+		// Persistent event-driven listener: send a fresh postMessage whenever any
+		// repeater item is added inside this block's form, at any point in time.
+		const repeaterEventNamespace = '.sowbFormInit-' + clientId.replace( /-/g, '' );
+		jQuery( document )
+			.off( 'sowrepeaterfieldsadded' + repeaterEventNamespace )
+			.on( 'sowrepeaterfieldsadded' + repeaterEventNamespace, ( event, $fields, originClientId ) => {
+				if ( originClientId && originClientId !== clientId ) {
+					return;
+				}
+				sendInitMessage();
+			} );
 
 		return () => {
-			timeoutIds.forEach( ( timeoutId ) => {
-				clearTimeout( timeoutId );
-			} );
+			jQuery( document ).off( 'sowrepeaterfieldsadded' + repeaterEventNamespace );
 		};
 	};
 
@@ -541,7 +559,11 @@
 				return;
 			}
 
-			const initKey = `${ props.clientId }::${ state.widgetFormHtml }`;
+			// Use a compact fingerprint rather than the full HTML blob to avoid storing
+			// and comparing large strings on every effect run. Sample both ends to
+			// reduce collision risk for forms with identical boilerplate wrappers.
+			const formFingerprint = state.widgetFormHtml.length + ':' + state.widgetFormHtml.slice( 0, 32 ) + state.widgetFormHtml.slice( -32 );
+			const initKey = `${ props.clientId }::${ formFingerprint }`;
 			if ( iframeFormInitKeyRef.current === initKey ) {
 				return;
 			}
@@ -1060,14 +1082,14 @@ const sowbGetBlockForm = ( clientId ) => {
 
 	if ( $canvas.length === 0 ) {
 		// No iframe (e.g. widgets.php Block Widgets screen, classic editor).
-		return jQuery( '[data-block="' + clientId + '"]' ).find( '.siteorigin-widget-form-main' );
+		return jQuery( '[data-block="' + clientId + '"]' ).find( '.siteorigin-widget-form.siteorigin-widget-form-main' );
 	}
 
 	// Return the main WB form from inside the editor iframe.
 	return $canvas
 		.contents()
 		.find( '[data-block="' + clientId + '"]' )
-		.find( '.siteorigin-widget-form-main' );
+		.find( '.siteorigin-widget-form.siteorigin-widget-form-main' );
 };
 
 const sowbCanvasCloneElements = [

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -266,6 +266,32 @@
 
 		sowbMaybeSetupSiteEditorAssets();
 
+		const switchToBlockPreview = async function() {
+			const oldTimer = $mainForm.data( 'sowb-preview-timer' );
+			if ( oldTimer ) {
+				clearTimeout( oldTimer );
+			}
+
+			const widgetData = await sowbSnapshotBlockFormToAttributes( props, $mainForm );
+
+			setState( {
+				editing: false,
+				previewInitialized: false,
+				widgetPreviewHtml: false,
+			} );
+
+			if ( widgetData ) {
+				sowbGenerateWidgetPreview(
+					props,
+					false,
+					setState,
+					widgetData,
+					props.widget.class,
+					activeRequestRef
+				);
+			}
+		};
+
 		const bindBlockPreviewHandler = function() {
 			// sowSetupForm() binds the legacy widget preview modal handler. Direct
 			// widget blocks have their own React preview path, so take ownership of
@@ -279,11 +305,7 @@
 					event.preventDefault();
 					event.stopImmediatePropagation();
 
-					setState( {
-						editing: false,
-						previewInitialized: false,
-						widgetPreviewHtml: false,
-					} );
+					switchToBlockPreview();
 				} );
 		};
 
@@ -483,6 +505,27 @@
 		const activeRequestRef = element.useRef( null );
 		const iframeFormInitKeyRef = element.useRef( null );
 
+		const switchToBlockPreview = async () => {
+			const widgetData = await sowbSnapshotBlockFormToAttributes( props );
+
+			mergeState( {
+				editing: false,
+				previewInitialized: false,
+				widgetPreviewHtml: false,
+			} );
+
+			if ( widgetData ) {
+				sowbGenerateWidgetPreview(
+					props,
+					false,
+					mergeState,
+					widgetData,
+					props.widget.class,
+					activeRequestRef
+				);
+			}
+		};
+
 		// Ensure widgetClass attribute is set once (was done in constructor).
 		element.useEffect( () => {
 			if ( ! props.attributes.widgetClass ) {
@@ -656,7 +699,7 @@
 										event.stopPropagation();
 									}
 
-									mergeState( { editing: false } );
+									switchToBlockPreview();
 								},
 								icon: 'visibility'
 							}
@@ -1262,6 +1305,26 @@ const sowbGetBlockFormSnapshot = async ( $form ) => {
 	}
 
 	return null;
+};
+
+const sowbSnapshotBlockFormToAttributes = async ( props, $form = null ) => {
+	const $snapshotForm = $form && $form.length ?
+		$form :
+		sowbGetBlockForm( props.clientId );
+
+	if ( ! $snapshotForm || $snapshotForm.length === 0 ) {
+		return null;
+	}
+
+	const widgetData = await sowbGetBlockFormSnapshot( $snapshotForm );
+
+	if ( ! sowbHasWidgetDataSnapshot( widgetData ) ) {
+		return null;
+	}
+
+	props.setAttributes( { widgetData } );
+
+	return widgetData;
 };
 
 const sowbCloneBlocksWithWidgetData = ( blocks, widgetDataByClientId ) => {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -311,7 +311,6 @@
 		} );
 
 		setState( { formInitialized: true } );
-		jQuery( document ).trigger( 'sowsetupform', [ $mainForm ] );
 	};
 
 	/**

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -266,19 +266,26 @@
 
 		sowbMaybeSetupSiteEditorAssets();
 
-		// The preview-container 'a' click toggles React state in the parent
-		// component. Native DOM click events cross frame boundaries so this
-		// binding works from either context.
-		const $previewContainer = $mainForm.siblings( '.siteorigin-widget-preview' );
-		$previewContainer.find( '> a' ).on( 'click', function( event ) {
-			event.stopImmediatePropagation();
+		const bindBlockPreviewHandler = function() {
+			// sowSetupForm() binds the legacy widget preview modal handler. Direct
+			// widget blocks have their own React preview path, so take ownership of
+			// this link after setup and prevent the legacy form/iframe submit path
+			// from navigating the editor canvas.
+			$mainForm
+				.siblings( '.siteorigin-widget-preview' )
+				.find( '> a' )
+				.off( 'click' )
+				.on( 'click.sowbBlockPreview', function( event ) {
+					event.preventDefault();
+					event.stopImmediatePropagation();
 
-			setState( {
-				editing: false,
-				previewInitialized: false,
-				widgetPreviewHtml: false,
-			} );
-		} );
+					setState( {
+						editing: false,
+						previewInitialized: false,
+						widgetPreviewHtml: false,
+					} );
+				} );
+		};
 
 		$mainForm.data( 'backupDisabled', true );
 
@@ -292,6 +299,7 @@
 		}
 
 		$mainForm.sowSetupForm();
+		bindBlockPreviewHandler();
 
 		// Namespace the change event so multiple sowbSetupWidgetForm calls for
 		// the same block (React double-render / stale closures) don't stack up
@@ -642,7 +650,14 @@
 							ToolbarButton,
 							{
 								label: __( 'Preview widget.', 'so-widgets-bundle' ),
-								onClick: () => mergeState( { editing: false } ),
+								onClick: ( event ) => {
+									if ( event ) {
+										event.preventDefault();
+										event.stopPropagation();
+									}
+
+									mergeState( { editing: false } );
+								},
 								icon: 'visibility'
 							}
 						)
@@ -691,12 +706,19 @@
 							ToolbarButton,
 							{
 								label: __( 'Edit widget.', 'so-widgets-bundle' ),
-								onClick: () => mergeState( {
-									editing: true,
-									loadingForm: false,
-									widgetFormHtml: '',
-									formInitialized: false,
-								} ),
+								onClick: ( event ) => {
+									if ( event ) {
+										event.preventDefault();
+										event.stopPropagation();
+									}
+
+									mergeState( {
+										editing: true,
+										loadingForm: false,
+										widgetFormHtml: '',
+										formInitialized: false,
+									} );
+								},
 								icon: 'edit'
 							}
 						)

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -248,13 +248,27 @@
 	 */
 
 	const sowbSetupWidgetForm = async ( props, state, setState, activeRequestRef ) => {
-		const $mainForm = sowbGetBlockForm( props.clientId );
+		let $mainForm = sowbGetBlockForm( props.clientId );
 
 		if ( $mainForm.length === 0 || state.formInitialized ) {
 			return;
 		}
 
+		// Re-wrap the form node with the jQuery instance that owns it. In the
+		// iframe path this is the iframe's jQuery; in the non-iframe path it is
+		// the parent jQuery. sowSetupForm(), wpColorPicker, and all other field
+		// plugins are bound to whichever jQuery ran their defining script — using
+		// the same instance here ensures event handlers fire correctly.
+		const formWindow = sowbGetElementWindow( $mainForm[ 0 ] );
+		const formJQuery = formWindow.jQuery || jQuery;
+		const formForms = formWindow.sowbForms || sowbForms;
+		$mainForm = formJQuery( $mainForm[ 0 ] );
+
 		sowbMaybeSetupSiteEditorAssets();
+
+		// The preview-container 'a' click toggles React state in the parent
+		// component. Native DOM click events cross frame boundaries so this
+		// binding works from either context.
 		const $previewContainer = $mainForm.siblings( '.siteorigin-widget-preview' );
 		$previewContainer.find( '> a' ).on( 'click', function( event ) {
 			event.stopImmediatePropagation();
@@ -272,43 +286,49 @@
 			// If we call `setWidgetFormValues` with the last parameter
 			// ( `triggerChange` ) set to false, it won't show the correct values
 			// for some fields e.g. color and media fields.
-			sowbForms.setWidgetFormValues( $mainForm, props.attributes.widgetData );
+			formForms.setWidgetFormValues( $mainForm, props.attributes.widgetData );
 		} else {
-			props.setAttributes( { widgetData: sowbForms.getWidgetFormValues( $mainForm ) } );
+			props.setAttributes( { widgetData: formForms.getWidgetFormValues( $mainForm ) } );
 		}
 
 		$mainForm.sowSetupForm();
 
-		$mainForm.on( 'change', function() {
-			// Check form has been set up before reacting to changes.
-			if ( ! $mainForm.data( 'sow-form-setup' ) ) {
-				return;
-			}
+		// Namespace the change event so multiple sowbSetupWidgetForm calls for
+		// the same block (React double-render / stale closures) don't stack up
+		// duplicate handlers on the same DOM node.
+		const changeNs = '.sowbBlock-' + props.clientId.replace( /-/g, '' );
+		$mainForm
+			.off( 'change' + changeNs )
+			.on( 'change' + changeNs, function() {
+				// Only react to changes once the form has been fully set up.
+				if ( ! $mainForm.data( 'sow-form-setup' ) ) {
+					return;
+				}
 
-			// As setAttributes doesn't support callbacks, we have to manually
-			// pass the widgetData to the preview.
-			var widgetData = sowbForms.getWidgetFormValues( $mainForm );
-			props.setAttributes( { widgetData: widgetData } );
+				// As setAttributes doesn't support callbacks, we have to manually
+				// pass the widgetData to the preview.
+				var widgetData = formForms.getWidgetFormValues( $mainForm );
+				props.setAttributes( { widgetData: widgetData } );
 
-			// Set up a preview debounce timer to prevent multiple requests.
-			var oldTimer = $mainForm.data( 'sowb-preview-timer' );
-			if ( oldTimer ) {
-				clearTimeout( oldTimer );
-			}
+				// Set up a preview debounce timer to prevent multiple requests.
+				var oldTimer = $mainForm.data( 'sowb-preview-timer' );
+				if ( oldTimer ) {
+					clearTimeout( oldTimer );
+				}
 
-			var sowb_preview_timer = setTimeout( () => {
-				sowbGenerateWidgetPreview(
-					props,
-					false,
-					setState,
-					widgetData,
-					props.widget.class,
-					activeRequestRef
-				);
-			}, 300 );
+				var sowb_preview_timer = setTimeout( () => {
+					sowbGenerateWidgetPreview(
+						props,
+						false,
+						setState,
+						widgetData,
+						props.widget.class,
+						activeRequestRef
+					);
+				}, 300 );
 
-			$mainForm.data( 'sowb-preview-timer', sowb_preview_timer );
-		} );
+				$mainForm.data( 'sowb-preview-timer', sowb_preview_timer );
+			} );
 
 		setState( { formInitialized: true } );
 	};
@@ -648,7 +668,7 @@
 						)
 					) :
 					el( 'div', {
-						className: 'so-widget-block-container siteorigin-widget-form-main wp-core-ui',
+						className: 'so-widget-block-container siteorigin-widget-form siteorigin-widget-form-main wp-core-ui',
 						dangerouslySetInnerHTML: { __html: widgetFormHtml },
 						ref: () => {
 							sowbSetupWidgetForm(
@@ -1027,14 +1047,49 @@
 		} )
 	} );
 
-	// Copy over assets to the Site Editor iframe asap.
-	if ( window.frameElement ) {
-		sowbSiteEditorCanvas = window.frameElement;
-		sowbMaybeSetupSiteEditorAssets();
-	}
+	// Copy over assets to the editor iframe asap.
+	sowbMaybeSetupSiteEditorAssets();
 } )( window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.blockEditor );
 
 let sowbSiteEditorCanvas = false;
+
+/**
+ * Returns the window that owns the given DOM element.
+ *
+ * @param {Element} element
+ * @returns {Window}
+ */
+const sowbGetElementWindow = ( element ) => {
+	return element && element.ownerDocument && element.ownerDocument.defaultView ?
+		element.ownerDocument.defaultView :
+		window;
+};
+
+/**
+ * Returns the editor canvas iframe element, or null if not found / not accessible.
+ *
+ * Checks the Site Editor canvas, the post-editor canvas, and — when this script
+ * is running inside the iframe itself — window.frameElement.
+ *
+ * @returns {HTMLIFrameElement|null}
+ */
+const sowbGetEditorCanvasFrame = () => {
+	const siteEditorCanvas = document.querySelector( '.edit-site-visual-editor__editor-canvas' );
+	if ( siteEditorCanvas && siteEditorCanvas.contentDocument ) {
+		return siteEditorCanvas;
+	}
+
+	const editorCanvas = document.querySelector( 'iframe[name="editor-canvas"]' );
+	if ( editorCanvas && editorCanvas.contentDocument ) {
+		return editorCanvas;
+	}
+
+	if ( window.frameElement && window.frameElement.contentDocument ) {
+		return window.frameElement;
+	}
+
+	return null;
+};
 
 /**
  * Resolves the best available WordPress editor API object.
@@ -1099,32 +1154,33 @@ const sowbResolveSiteEditorFrame = ( frame = null ) => {
  * @returns {jQuery} jQuery reference to the widget form
  */
 const sowbGetBlockForm = ( clientId ) => {
-	// Re-resolve the editor canvas on every call rather than caching to false,
-	// because the iframe element is mounted asynchronously by the block editor.
-	// Site Editor uses `.edit-site-visual-editor__editor-canvas`; the post editor
-	// (default since WP 6.5) uses `iframe[name="editor-canvas"]`.
-	let $canvas = jQuery( '.edit-site-visual-editor__editor-canvas' );
-	if ( $canvas.length === 0 ) {
-		$canvas = jQuery( 'iframe[name="editor-canvas"]' );
+	const frame = sowbGetEditorCanvasFrame();
+
+	if ( frame && frame.contentDocument && frame.contentWindow ) {
+		// Update the cached canvas reference for sowbMaybeSetupSiteEditorAssets().
+		if ( frame !== window.frameElement ) {
+			sowbSiteEditorCanvas = jQuery( frame );
+		}
+
+		// Use the iframe's own jQuery so the returned object is already in the
+		// correct jQuery instance — sowSetupForm(), wpColorPicker, and all other
+		// field plugins are bound to this same jQuery when their scripts run.
+		const frameJQuery = frame.contentWindow.jQuery || jQuery;
+		const $iframeForm = frameJQuery( frame.contentDocument )
+			.find( '[data-block="' + clientId + '"]' )
+			.find( '.siteorigin-widget-form-main[data-class]' )
+			.first();
+
+		if ( $iframeForm.length > 0 ) {
+			return $iframeForm;
+		}
 	}
 
-	// Cache the resolved canvas for use by sowbMaybeSetupSiteEditorAssets()
-	// and other consumers, but only when the canvas is actually present so
-	// we never lock in an empty result before the iframe has mounted.
-	if ( $canvas.length > 0 ) {
-		sowbSiteEditorCanvas = $canvas;
-	}
-
-	if ( $canvas.length === 0 ) {
-		// No iframe (e.g. widgets.php Block Widgets screen, classic editor).
-		return jQuery( '[data-block="' + clientId + '"]' ).find( '.siteorigin-widget-form.siteorigin-widget-form-main' );
-	}
-
-	// Return the main WB form from inside the editor iframe.
-	return $canvas
-		.contents()
+	// No iframe (e.g. widgets.php Block Widgets screen, classic editor).
+	return jQuery( document )
 		.find( '[data-block="' + clientId + '"]' )
-		.find( '.siteorigin-widget-form.siteorigin-widget-form-main' );
+		.find( '.siteorigin-widget-form-main[data-class]' )
+		.first();
 };
 
 const sowbCanvasCloneElements = [

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1205,10 +1205,154 @@ const sowbGetBlockForm = ( clientId ) => {
 		.first();
 };
 
+const sowbIsDirectWidgetBlock = ( block ) => {
+	return block &&
+		typeof block.name === 'string' &&
+		block.name.indexOf( 'sowb/' ) === 0 &&
+		block.name !== 'sowb/widget-block' &&
+		block.isValid !== false;
+};
+
+const sowbFindDirectWidgetBlocks = ( blocks ) => {
+	return blocks.reduce( ( foundBlocks, block ) => {
+		if ( sowbIsDirectWidgetBlock( block ) ) {
+			foundBlocks.push( block );
+		}
+
+		if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+			foundBlocks.push( ...sowbFindDirectWidgetBlocks( block.innerBlocks ) );
+		}
+
+		return foundBlocks;
+	}, [] );
+};
+
+const sowbHasWidgetDataSnapshot = ( widgetData ) => {
+	return widgetData &&
+		typeof widgetData === 'object' &&
+		! Array.isArray( widgetData ) &&
+		Object.keys( widgetData ).length > 0;
+};
+
+const sowbGetBlockFormSnapshot = async ( $form ) => {
+	if ( ! $form || $form.length === 0 ) {
+		return null;
+	}
+
+	const formWindow = sowbGetElementWindow( $form[0] );
+	const formJQuery = formWindow.jQuery || jQuery;
+	const formForms = formWindow.sowbForms || sowbForms;
+	const $ownerForm = formJQuery( $form[0] );
+
+	if (
+		formForms &&
+		typeof formForms.getWidgetFormSnapshot === 'function'
+	) {
+		return await formForms.getWidgetFormSnapshot( $ownerForm, {
+			awaitAsync: true,
+			triggerChange: false,
+		} );
+	}
+
+	if (
+		formForms &&
+		typeof formForms.getWidgetFormValues === 'function'
+	) {
+		return formForms.getWidgetFormValues( $ownerForm );
+	}
+
+	return null;
+};
+
+const sowbCloneBlocksWithWidgetData = ( blocks, widgetDataByClientId ) => {
+	return blocks.map( ( block ) => {
+		const clonedBlock = {
+			...block,
+			attributes: {
+				...( block.attributes || {} ),
+			},
+			innerBlocks: block.innerBlocks ?
+				sowbCloneBlocksWithWidgetData( block.innerBlocks, widgetDataByClientId ) :
+				[],
+		};
+
+		if ( Object.prototype.hasOwnProperty.call( widgetDataByClientId, block.clientId ) ) {
+			clonedBlock.attributes.widgetData = widgetDataByClientId[ block.clientId ];
+		}
+
+		return clonedBlock;
+	} );
+};
+
+wp.hooks.addFilter(
+	'editor.preSavePost',
+	'sowb/direct-widget-block-save-bridge',
+	async function( edits ) {
+		const blockEditorSelect = wp.data.select( 'core/block-editor' );
+		const blocks = blockEditorSelect.getBlocks();
+		const directBlocks = sowbFindDirectWidgetBlocks( blocks );
+
+		if ( directBlocks.length === 0 ) {
+			return edits;
+		}
+
+		const widgetDataByClientId = {};
+
+		for ( const block of directBlocks ) {
+			const $form = sowbGetBlockForm( block.clientId );
+
+			if ( $form.length === 0 ) {
+				continue;
+			}
+
+			const widgetData = await sowbGetBlockFormSnapshot( $form );
+
+			if ( ! sowbHasWidgetDataSnapshot( widgetData ) ) {
+				continue;
+			}
+
+			widgetDataByClientId[ block.clientId ] = widgetData;
+		}
+
+		const clientIds = Object.keys( widgetDataByClientId );
+		if ( clientIds.length === 0 ) {
+			return edits;
+		}
+
+		const clonedBlocks = sowbCloneBlocksWithWidgetData( blocks, widgetDataByClientId );
+		const nextEdits = {
+			...( edits || {} ),
+			content: wp.blocks.serialize( clonedBlocks ),
+		};
+		const attrsByClientId = clientIds.reduce( ( attributes, clientId ) => {
+			attributes[ clientId ] = {
+				widgetData: widgetDataByClientId[ clientId ],
+			};
+
+			return attributes;
+		}, {} );
+		const blockEditorDispatch = wp.data.dispatch( 'core/block-editor' );
+
+		if (
+			blockEditorDispatch &&
+			typeof blockEditorDispatch.updateBlockAttributes === 'function'
+		) {
+			blockEditorDispatch.updateBlockAttributes(
+				clientIds,
+				attrsByClientId,
+				{ uniqueByBlock: true }
+			);
+		}
+
+		return nextEdits;
+	}
+);
+
 const sowbCanvasCloneElements = [
 	// WP Scripts and assets.
 	'#jquery-core-js',
 	'#jquery-migrate-js',
+	'#underscore-js',
 	'#editor-js-after',
 	'#wp-tinymce-js',
 	'#utils-js',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -369,6 +369,9 @@
 		const formSelector = blockSelector ?
 			`${ blockSelector } .siteorigin-widget-form.siteorigin-widget-form-main` :
 			'';
+		// Built once from stable closure values (clientId, blockSelector, formSelector
+		// are all derived from props/state that do not change during this effect's
+		// lifetime) and reused by every sendInitMessage() call.
 		const message = {
 			action: 'sowbBlockFormInit',
 			clientId,
@@ -395,6 +398,9 @@
 		jQuery( document )
 			.off( 'sowrepeaterfieldsadded' + repeaterEventNamespace )
 			.on( 'sowrepeaterfieldsadded' + repeaterEventNamespace, ( event, $fields, originClientId ) => {
+				// $fields (the newly added field elements) is provided by admin.js for the
+				// benefit of other listeners. Not needed here — we send a full-form postMessage
+				// rather than targeting individual fields.
 				if ( originClientId && originClientId !== clientId ) {
 					return;
 				}
@@ -573,9 +579,14 @@
 			if ( ! sowbBlockEditorAdmin.wpScriptDebug || state.devModeRemount ) {
 				const cleanup = initializeFormFieldsInIframe( props.clientId );
 				if ( cleanup ) {
+					// Record the key only on success so that a failed attempt
+					// (no iframe window yet) is retried on the next render cycle.
 					iframeFormInitKeyRef.current = initKey;
 					return cleanup;
 				}
+				// initializeFormFieldsInIframe returned null: the iframe window is
+				// not reachable yet. iframeFormInitKeyRef is intentionally left at
+				// its current value so the effect runs again on the next render.
 			}
 		}, [
 			props.clientId,

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -27,6 +27,8 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_widget_block_editor_assets' ) );
 
+		add_filter( 'siteorigin_panels_filter_content_enabled', array( $this, 'disable_panels_content_for_widget_blocks' ) );
+
 		add_action( 'wp_ajax_so_widgets_block_migration_notice_consent', array( $this, 'block_migration_consent' ) );
 	}
 
@@ -48,7 +50,110 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		foreach ( $post_types as $post_type ) {
 			add_action( 'rest_pre_insert_' . $post_type, array( $this, 'server_side_validation' ), 10, 2 );
+			add_action( 'rest_after_insert_' . $post_type, array( $this, 'clear_panels_data_for_widget_blocks' ), 10, 3 );
 		}
+	}
+
+	/**
+	 * Prevent stale Page Builder metadata from replacing block editor widget content.
+	 *
+	 * @param bool $enabled Whether SiteOrigin Panels should filter post content.
+	 *
+	 * @return bool
+	 */
+	public function disable_panels_content_for_widget_blocks( $enabled ) {
+		if ( ! $enabled || is_admin() ) {
+			return $enabled;
+		}
+
+		$post = get_post();
+
+		if (
+			empty( $post ) ||
+			empty( $post->post_content )
+		) {
+			return $enabled;
+		}
+
+		return $this->content_has_widget_blocks( $post->post_content ) ? false : $enabled;
+	}
+
+	/**
+	 * Clear stale Page Builder data when a REST save contains SOWB widget blocks.
+	 *
+	 * @param WP_Post         $post     Inserted or updated post object.
+	 * @param WP_REST_Request $request  REST request.
+	 * @param bool            $creating Whether this was a create request.
+	 *
+	 * @return void
+	 */
+	public function clear_panels_data_for_widget_blocks( $post, $request, $creating ) {
+		if (
+			empty( $post ) ||
+			! is_a( $post, 'WP_Post' ) ||
+			wp_is_post_revision( $post->ID ) ||
+			wp_is_post_autosave( $post->ID ) ||
+			empty( $post->post_content ) ||
+			! $this->content_has_widget_blocks( $post->post_content ) ||
+			! get_post_meta( $post->ID, 'panels_data', true )
+		) {
+			return;
+		}
+
+		delete_post_meta( $post->ID, 'panels_data' );
+	}
+
+	/**
+	 * Check whether serialized block content contains a SOWB widget block.
+	 *
+	 * @param string $content Serialized block content.
+	 *
+	 * @return bool
+	 */
+	private function content_has_widget_blocks( $content ) {
+		if (
+			empty( $content ) ||
+			! function_exists( 'parse_blocks' ) ||
+			(
+				function_exists( 'has_blocks' ) &&
+				! has_blocks( $content )
+			)
+		) {
+			return false;
+		}
+
+		return $this->blocks_have_widget_blocks( parse_blocks( $content ) );
+	}
+
+	/**
+	 * Recursively check parsed blocks for SOWB widget blocks.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 *
+	 * @return bool
+	 */
+	private function blocks_have_widget_blocks( $blocks ) {
+		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
+			return false;
+		}
+
+		foreach ( $blocks as $block ) {
+			if (
+				! empty( $block['blockName'] ) &&
+				strpos( $block['blockName'], 'sowb/' ) === 0
+			) {
+				return true;
+			}
+
+			if (
+				! empty( $block['innerBlocks'] ) &&
+				$this->blocks_have_widget_blocks( $block['innerBlocks'] )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/e2e/wb-form-field-site-editor.test.js
+++ b/tests/e2e/wb-form-field-site-editor.test.js
@@ -846,12 +846,37 @@ test(
 	'Test the Image Grid widget.',
 	async ( { page } ) => {
 		const {
+			admin,
 			offset,
 			widget
 		} = await testPrep(
 			page,
 			'sowb/siteorigin-widgets-imagegrid-widget'
 		);
+
+		const imagesRepeater = widget.locator( '.siteorigin-widget-field-images > .siteorigin-widget-field-repeater' );
+		const addImageButton = imagesRepeater.locator( '> .siteorigin-widget-field-repeater-add' );
+		await ensureElementVisible( addImageButton, offset );
+		await addImageButton.click();
+
+		const imageItems = imagesRepeater.locator( '> .siteorigin-widget-field-repeater-items > .siteorigin-widget-field-repeater-item' );
+		await expect( imageItems ).toHaveCount( 1 );
+
+		const firstImageItem = imageItems.first();
+		const firstImageTop = firstImageItem.locator( '> .siteorigin-widget-field-repeater-item-top' );
+		await ensureElementVisible( firstImageTop, offset );
+		await firstImageTop.click( { force: true } );
+
+		const firstImageMediaField = firstImageItem.locator( '.siteorigin-widget-field-image' );
+		const firstImageMediaButton = firstImageMediaField.locator( '.media-upload-button' );
+		await ensureElementVisible( firstImageMediaButton, offset );
+		await firstImageMediaButton.click( { force: true } );
+
+		await uploadImageToMediaLibrary( admin );
+
+		await expect(
+			firstImageMediaField.locator( '.siteorigin-widget-input[type="hidden"]:not(.media-fallback-external)' )
+		).toHaveValue( /.+/ );
 
 		const imagePaddingSetting = widget.locator( '.siteorigin-widget-field-padding' );
 		await ensureElementVisible( imagePaddingSetting, offset );


### PR DESCRIPTION
This PR amends https://github.com/siteorigin/so-widgets-bundle/pull/2308 to resolve a number of performance and stability issues I was facing during testing. It also works towards resolving a portion of https://github.com/siteorigin/so-widgets-bundle/issues/2310 - I'm working on an additional focused PR for that and progress has been going well.

## What and why
Direct SiteOrigin widget blocks in the iframed block editor (Site Editor, post editor canvas) could leave TinyMCE fields in an unreachable half-initialized state, waste CPU on staggered timeout polling, and accidentally attempt setup on repeater placeholder rows. This PR replaces all of those paths with targeted, event-driven initialization and adds several layers of defensive hardening.

## Performance

- Eliminates staggered timeout polling. The previous initializeFormFieldsInIframe fired 5 postMessage calls at [0, 250, 1000, 3000, 6000] ms regardless of whether fields were ready. This is replaced by a single immediate send at the point React has already rendered and restored form values, plus a persistent sowrepeaterfieldsadded document listener that sends a fresh message only when a repeater item is actually added.
- Eliminates MutationObserver polling over the entire iframe subtree (attributes, childList, subtree) that was used as a fallback to re-run setupSiteEditorTinyMCEFields on every DOM change. Replaced by the targeted sowbBlockFormInit postMessage pathway.
- Eliminates staggered setInterval fallback (20 × 250 ms = 5 s of polling) for browsers without MutationObserver support.
- Form fingerprint instead of full HTML blob as the useEffect cache key — avoids storing and comparing multi-kilobyte strings on every render cycle.

## Safety and hardening

### Half-initialised field prevention:

- setupTinyMCEField now acquires a sowb-tinymce-initializing lock on entry and releases it in the TinyMCE init event callback, preventing a second concurrent setup attempt from running on the same field.
- A 5 s safety timeout releases the lock if the init event never fires (e.g. the field is removed from the DOM mid-setup), so the field is never permanently stranded.
- setupTinyMCEFieldInitializer calls hasHealthyTinyMCEEditor before re-entering setup and clears stale data-initialized when the editor is found to be unhealthy, directly targeting the data-initialized=true / editorInitialized: false / tinymceIframeCount: 0 stuck state.

### Pre-init listener/poll race prevention:

- A per-field preInitEventNamespace (stored as sowb-pre-init-namespace jQuery data) makes the visibility poll and the sowsetupformfield listener mutually exclusive — whichever fires first cancels the other.
- clearTinyMCEFieldPendingSetup reads the stored namespace back and calls $field.off(), so the listener is always cancelled even when setupTinyMCEField is called independently (e.g. from sortStopEvent).
- wp.oldEditor guard:

- resolveWpEditor() requires the resolved editor object to have an initialize() method before returning it, preventing a wp.oldEditor reference from being used in contexts where it is only partially populated.

### Repeater template placeholder exclusion:

- getEligibleTinyMCEFields and an early-return guard in setupTinyMCEFieldInitializer both reject fields whose textarea ID contains _id_ or whose closest ancestor is .siteorigin-widget-field-repeater-item-html, so unclonable template rows are never initialized.
- triggerVisibleRepeaterVisibilityFieldSetup in admin.js filters template rows out of the $allFields collection before dispatching sowrepeaterfieldsadded, so no downstream consumer ever receives placeholder fields in the event payload.

### postMessage handler deduplication:

The message listener reference is stored as window._sowbTinyMCEMessageHandler and removed via removeEventListener before re-registration, replacing the window.sowbTinyMCEMessageListenerBound boolean that could not actually remove a duplicate listener.

### CSS selector precision:

All sowbGetBlockForm and formSelector references tightened from .siteorigin-widget-form-main to .siteorigin-widget-form.siteorigin-widget-form-main, matching the compound class the PHP template always emits and preventing false matches on elements that only carry the -main suffix.

## Miscellaneous:

- _tinymceIdSeq split into _tinymceDomIdSeq (TinyMCE textarea IDs) and _tinymcePreInitSeq (pre-init event namespaces) — the two counters have different lifetimes and should not share state.
- selectBestFormInstance connected signal now uses this.ownerDocument.documentElement.contains(this) instead of the closure document, so the score is accurate when the function is called from the parent window against iframe-DOM elements.
- sowsetupform iframe listener bails early on absent $form rather than passing null to setupSiteEditorTinyMCEFields.
- All document-level event bindings use namespaced events (.sowTinymce) with explicit .off() before .on() to prevent listener accumulation across hot reloads or repeated script evaluation.

## Testing
Please test this PR when either all Widget Bundle Blocks are present on the page, or a _really_ large Hero block or two. The more you do, the more you remove, etc, the worse the performance would previously get. Please note that this PR intentionally doesn't update the Playwrite tests - those are very time-consuming to get right, and overall this is quite a broad issue. Once the bleeding has stopped, we'll circle back and add tests.