### PR TITLE
Block Editor: fix direct widget preview and save persistence

### DIFF
--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -1,12 +1,19 @@
 /* global jQuery, soWidgets */
 
 ( function( $ ) {
+	const isRepeaterTemplateField = function( $field ) {
+		return $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+	};
 
 	const setupMediaField = function( e ) {
 		const $field = $( this );
 		const $media = $field.find( '> .media-field-wrapper' );
 		const $inputField = $field.find( '.siteorigin-widget-input' ).not( '.media-fallback-external' );
 		const $externalField = $field.find( '.media-fallback-external' );
+
+		if ( isRepeaterTemplateField( $field ) ) {
+			return;
+		}
 
 		if ( $field.attr( 'data-initialized' ) ) {
 			return;
@@ -487,7 +494,12 @@
 	window.addEventListener( 'message', function( e ) {
 		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
 			$( '.siteorigin-widget-field-type-media' ).each( function() {
-				if ( $( this ).attr( 'data-initialized' ) ) {
+				const $field = $( this );
+
+				if (
+					isRepeaterTemplateField( $field ) ||
+					$field.attr( 'data-initialized' )
+				) {
 					return;
 				}
 

--- a/base/inc/fields/js/media-field.js
+++ b/base/inc/fields/js/media-field.js
@@ -471,9 +471,10 @@
 		} );
 	};
 
-	// If the current page isn't the site editor, set up the Media field now.
+	// In the Site Editor iframe, repeater rows added after the initial block
+	// postMessage still rely on the normal field setup event.
 	if (
-		window.top === window.self &&
+		window.top !== window.self ||
 		(
 			typeof pagenow === 'string' &&
 			pagenow !== 'site-editor'

--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -156,16 +156,17 @@
 		$field.data( 'initialized', true );
 	};
 
-	 // If the current page isn't the site editor, set up the Multiple Media field now.
-	 if (
-		 window.top === window.self &&
-		 (
-			 typeof pagenow === 'string' &&
-			 pagenow !== 'site-editor'
-		 )
-	 ) {
-		 $( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-multiple_media', setupMultipleMediaField );
-	 }
+	// In the Site Editor iframe, repeater rows added after the initial block
+	// postMessage still rely on the normal field setup event.
+	if (
+		window.top !== window.self ||
+		(
+			typeof pagenow === 'string' &&
+			pagenow !== 'site-editor'
+		)
+	) {
+		$( document ).on( 'sowsetupformfield', '.siteorigin-widget-field-type-multiple_media', setupMultipleMediaField );
+	}
 
 	// Add support for the Site Editor.
 	window.addEventListener( 'message', function( e ) {

--- a/base/inc/fields/js/multiple-media-field.js
+++ b/base/inc/fields/js/multiple-media-field.js
@@ -1,8 +1,16 @@
 /* global jQuery, soWidgets */
 
 ( function( $ ) {
+	const isRepeaterTemplateField = function( $field ) {
+		return $field.closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+	};
+
 	const setupMultipleMediaField = function() {
 		const $field = $( this );
+
+		if ( isRepeaterTemplateField( $field ) ) {
+			return;
+		}
 
 		if ( $field.data( 'initialized' ) ) {
 			return;
@@ -172,6 +180,10 @@
 	window.addEventListener( 'message', function( e ) {
 		if ( e.data && e.data.action === 'sowbBlockFormInit' ) {
 			$( '.siteorigin-widget-field-type-multiple_media' ).each( function() {
+				if ( isRepeaterTemplateField( $( this ) ) ) {
+					return;
+				}
+
 				setupMultipleMediaField.call( this );
 			} );
 		}

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -206,48 +206,6 @@
 			.replace( /^-+|-+$/g, '' );
 	};
 
-	const sanitizeTinyMCEContent = function( content ) {
-		if (
-			window.sowbForms &&
-			typeof window.sowbForms.sanitizeTinyMCEContent === 'function'
-		) {
-			return window.sowbForms.sanitizeTinyMCEContent( content );
-		}
-
-		if ( typeof content !== 'string' || content.length === 0 ) {
-			return content;
-		}
-
-		if (
-			content.indexOf( 'mce_SELRES_' ) === -1 &&
-			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
-			content.indexOf( '\uFEFF' ) === -1
-		) {
-			return content;
-		}
-
-		const wrapper = document.createElement( 'div' );
-		wrapper.innerHTML = content;
-		wrapper
-			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
-			.forEach( ( marker ) => marker.remove() );
-
-		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
-	};
-
-	const saveTinyMCEEditorContent = function( editor, $textarea ) {
-		if ( ! editor || typeof editor.getContent !== 'function' ) {
-			return '';
-		}
-
-		const content = sanitizeTinyMCEContent( editor.getContent() );
-		if ( $textarea && $textarea.length ) {
-			$textarea.val( content );
-		}
-
-		return content;
-	};
-
 	/**
 	 * Resolves the best available WordPress editor API object.
 	 *
@@ -308,10 +266,7 @@
 
 			if ( editor ) {
 				editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
-				saveTinyMCEEditorContent(
-					editor,
-					$( typeof editor.getElement === 'function' ? editor.getElement() : document.getElementById( editorId ) )
-				);
+				editor.save();
 				editor.fire( 'change' );
 			}
 		} );
@@ -602,16 +557,6 @@
 		let id = $textarea.attr( 'data-tinymce-id' ) || $textarea.data( 'tinymce-id' );
 		const fieldElement = $field.get( 0 );
 		const textareaElement = $textarea.get( 0 );
-		const updateTextTabLabel = function() {
-			const textTab = document.getElementById( id + '-html' );
-			if ( textTab ) {
-				const codeLabel = window.top.wp && window.top.wp.i18n && typeof window.top.wp.i18n.__ === 'function'
-					? window.top.wp.i18n.__( 'Code' )
-					: 'Code';
-				textTab.textContent = codeLabel;
-				textTab.setAttribute( 'aria-label', codeLabel );
-			}
-		};
 
 		if ( id ) {
 			const existingTextarea = document.getElementById( id );
@@ -726,7 +671,7 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
-						saveTinyMCEEditorContent( ed, $textarea );
+						ed.save();
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -751,7 +696,10 @@
 					if ( window.frameElement ) {
 						// Fix code tab label in the Site Editor.
 						editor.on( 'init', () => {
-							updateTextTabLabel();
+							const textTab = document.querySelector( `#${id}-html` );
+							if ( textTab ) {
+								textTab.innerHTML = window.top.wp.i18n.__( 'Code' );
+							}
 						} );
 					}
 
@@ -809,22 +757,15 @@
 				const editor = window.tinymce.get( id );
 				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
 				if ( editor !== null ) {
-					let content = sanitizeTinyMCEContent( $textarea.val() );
+					let content = $textarea.val();
 					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
 						content = content.replace( /</g, '' );
+						$textarea.val( content );
 					}
-					$textarea.val( content );
 					editor.setContent( window.switchEditors.wpautop( content ) );
-				}
-			} else {
-				const editor = window.tinymce.get( id );
-				if ( editor !== null ) {
-					saveTinyMCEEditorContent( editor, $textarea );
 				}
 			}
 			settings.selectedEditor = mode;
-			updateTextTabLabel();
-			setTimeout( updateTextTabLabel, 0 );
 
 			$field.find( 'textarea.wp-editor-area' ).css(
 				'visibility', mode === 'tmce' ? 'hidden' : 'visible'

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -2,6 +2,13 @@
 
 ( function( $ ) {
 
+	if ( window.sowbTinyMCEFieldScriptLoaded ) {
+		return;
+	}
+
+	window.sowbTinyMCEFieldScriptLoaded = true;
+	window.sowbTinyMCEFieldScriptLoadedAt = Date.now();
+
 	let mediaFrameOpen = false;
 	const sowbTinyMCEEventNamespace = '.sowTinymce';
 	let _tinymceDomIdSeq = 0;
@@ -584,6 +591,10 @@
 			.attr( 'data-tinymce-id', id )
 			.attr( 'id', id );
 
+		if ( textareaElement ) {
+			textareaElement.sowbTinyMCELastSyncedContent = $textarea.val();
+		}
+
 		_tinymceInitPending[ id ] = ( function( entryId ) {
 			let storedResolve;
 			const promise = new Promise( function( resolve ) {
@@ -607,50 +618,50 @@
 		$( window.document )
 			.off( 'wp-before-tinymce-init' + fieldEventNamespace )
 			.on( 'wp-before-tinymce-init' + fieldEventNamespace, function( event, init ) {
-			if ( init.selector !== settings.tinymce.selector ) {
-				return;
-			}
-
-			$( window.document ).off( 'wp-before-tinymce-init' + fieldEventNamespace );
-
-			const mediaButtons = $container.data( 'mediaButtons' );
-			if (
-				typeof mediaButtons != 'undefined' &&
-				$field.find( '.wp-media-buttons' ).length === 0
-			) {
-				$field.find( '.wp-editor-tabs' ).before( mediaButtons.html );
-			}
-
-			const addMediaButton = $field.find( '.add_media' );
-			if ( addMediaButton.length > 0 ) {
-				const $textarea = $container.find( 'textarea' );
-				const editorId = $textarea.data( 'tinymce-id' );
-				addMediaButton.attr( 'data-editor', editorId );
-
-				if ( window.frameElement ) {
-					addMediaButton
-						.removeClass( 'insert-media add_media' )
-						.addClass( 'siteorigin-widget-tinymce-add-media' )
-						.off( 'click.sowbMedia' )
-						.on( 'click.sowbMedia', () => {
-							siteEditorAddMediaOverride( editorId );
-						} );
+				if ( init.selector !== settings.tinymce.selector ) {
+					return;
 				}
-			}
-		} );
+
+				$( window.document ).off( 'wp-before-tinymce-init' + fieldEventNamespace );
+
+				const mediaButtons = $container.data( 'mediaButtons' );
+				if (
+					typeof mediaButtons != 'undefined' &&
+					$field.find( '.wp-media-buttons' ).length === 0
+				) {
+					$field.find( '.wp-editor-tabs' ).before( mediaButtons.html );
+				}
+
+				const addMediaButton = $field.find( '.add_media' );
+				if ( addMediaButton.length > 0 ) {
+					const $textarea = $container.find( 'textarea' );
+					const editorId = $textarea.data( 'tinymce-id' );
+					addMediaButton.attr( 'data-editor', editorId );
+
+					if ( window.frameElement ) {
+						addMediaButton
+							.removeClass( 'insert-media add_media' )
+							.addClass( 'siteorigin-widget-tinymce-add-media' )
+							.off( 'click.sowbMedia' )
+							.on( 'click.sowbMedia', () => {
+								siteEditorAddMediaOverride( editorId );
+							} );
+					}
+				}
+			} );
 
 		$( window.top.document )
 			.off( 'tinymce-editor-setup' + fieldEventNamespace )
 			.on( 'tinymce-editor-setup' + fieldEventNamespace, function() {
-			const $wpEditorWrap = $field.find( '.wp-editor-wrap' );
-			if ( $wpEditorWrap.length > 0 && ! $wpEditorWrap.hasClass( settings.selectedEditor + '-active' ) ) {
-				setTimeout( function() {
-					window.switchEditors.go( id );
-				}, 10 );
-			}
+				const $wpEditorWrap = $field.find( '.wp-editor-wrap' );
+				if ( $wpEditorWrap.length > 0 && ! $wpEditorWrap.hasClass( settings.selectedEditor + '-active' ) ) {
+					setTimeout( function() {
+						window.switchEditors.go( id );
+					}, 10 );
+				}
 
-			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
-		} );
+				$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
+			} );
 
 		if ( settings.tinymce ) {
 			const setupEditor = function( editor ) {
@@ -671,7 +682,20 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
+						const textareaNode = $textarea.get( 0 );
+						const previousContent = textareaNode ?
+							textareaNode.sowbTinyMCELastSyncedContent :
+							undefined;
 						ed.save();
+
+						const currentContent = $textarea.val();
+						if ( textareaNode && previousContent === currentContent ) {
+							return;
+						}
+
+						if ( textareaNode ) {
+							textareaNode.sowbTinyMCELastSyncedContent = currentContent;
+						}
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -713,6 +737,20 @@
 			window.tinymce.EditorManager.overrideDefaults( { base_url: settings.baseURL, suffix: settings.suffix } );
 		}
 
+		const initTimeoutId = setTimeout( function() {
+			if ( _tinymceInitPending[ id ] ) {
+				_tinymceInitPending[ id ].resolve();
+			}
+
+			$field.removeData( 'sowb-tinymce-initializing' );
+			$field.removeData( 'sowb-tinymce-initializing-id' );
+			// If the TinyMCE init event never fired (e.g. field removed from DOM),
+			// clean up the top-document listener so it doesn't accumulate.
+			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
+		}, 5000 );
+
+		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
+
 		// Wait for textarea to be visible before initialization.
 		if ( $textarea.is( ':visible' ) ) {
 			wpEditor.initialize( id, settings );
@@ -731,49 +769,59 @@
 			$field.data( 'sowb-tinymce-visibility-poll', intervalId );
 		}
 
-		const initTimeoutId = setTimeout( function() {
-			if ( _tinymceInitPending[ id ] ) {
-				_tinymceInitPending[ id ].resolve();
-			}
-
-			$field.removeData( 'sowb-tinymce-initializing' );
-			$field.removeData( 'sowb-tinymce-initializing-id' );
-			// If the TinyMCE init event never fired (e.g. field removed from DOM),
-			// clean up the top-document listener so it doesn't accumulate.
-			$( window.top.document ).off( 'tinymce-editor-setup' + fieldEventNamespace );
-		}, 5000 );
-
-		$field.data( 'sowb-tinymce-init-timeout', initTimeoutId );
-
-		$field.on( 'click', function( event ) {
-			const $target = $( event.target );
-			if ( ! $target.is( '.wp-switch-editor' ) ) {
-				return;
-			}
-
-			const mode = $target.hasClass( 'switch-tmce' ) ? 'tmce' : 'html';
-
-			if ( mode === 'tmce' ) {
-				const editor = window.tinymce.get( id );
-				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
-				if ( editor !== null ) {
-					let content = $textarea.val();
-					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
-						content = content.replace( /</g, '' );
-						$textarea.val( content );
-					}
-					editor.setContent( window.switchEditors.wpautop( content ) );
+		$field
+			.off( 'click.sowTinymceSwitchEditor' )
+			.on( 'click.sowTinymceSwitchEditor', function( event ) {
+				const $target = $( event.target );
+				if ( ! $target.is( '.wp-switch-editor' ) ) {
+					return;
 				}
-			}
-			settings.selectedEditor = mode;
 
-			$field.find( 'textarea.wp-editor-area' ).css(
-				'visibility', mode === 'tmce' ? 'hidden' : 'visible'
-			);
+				const mode = $target.hasClass( 'switch-tmce' ) ? 'tmce' : 'html';
+				const $selectedEditor = $field.find( '.siteorigin-widget-tinymce-selected-editor' );
+				if ( $selectedEditor.val() === mode ) {
+					return;
+				}
 
+				const fieldNode = $field.get( 0 );
+				const now = Date.now();
+				const lastSwitchClick = fieldNode && fieldNode.sowbTinyMCELastSwitchClick ?
+					fieldNode.sowbTinyMCELastSwitchClick :
+					null;
+				if (
+					lastSwitchClick &&
+					lastSwitchClick.mode === mode &&
+					now - lastSwitchClick.time < 50
+				) {
+					return;
+				}
+				if ( fieldNode ) {
+					fieldNode.sowbTinyMCELastSwitchClick = {
+						mode,
+						time: now,
+					};
+				}
 
-			$field.find( '.siteorigin-widget-tinymce-selected-editor' ).val( mode );
-		} );
+				if ( mode === 'tmce' ) {
+					const editor = window.tinymce.get( id );
+					// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
+					if ( editor !== null ) {
+						let content = $textarea.val();
+						if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
+							content = content.replace( /</g, '' );
+							$textarea.val( content );
+						}
+						editor.setContent( window.switchEditors.wpautop( content ) );
+					}
+				}
+				settings.selectedEditor = mode;
+
+				$field.find( 'textarea.wp-editor-area' ).css(
+					'visibility', mode === 'tmce' ? 'hidden' : 'visible'
+				);
+
+				$selectedEditor.val( mode );
+			} );
 	};
 
 	/**
@@ -984,12 +1032,18 @@
 		$( document )
 			.off( 'sowsetupform' + sowbTinyMCEEventNamespace )
 			.on( 'sowsetupform' + sowbTinyMCEEventNamespace, function( e, $form ) {
-				if ( ! $form || ! $form.length ) {
+				const $setupTarget = $form && $form.jquery ?
+					$form :
+					$( $form || [] );
+				if ( ! $setupTarget.length ) {
 					return;
 				}
-				// $form is the wrapper element, not a field itself, so .find() is
-				// sufficient — no need to also .filter() the root element.
-				setupSiteEditorTinyMCEFields( $form.find( '.siteorigin-widget-field-type-tinymce' ) );
+
+				setupSiteEditorTinyMCEFields(
+					$setupTarget
+						.filter( '.siteorigin-widget-field-type-tinymce' )
+						.add( $setupTarget.find( '.siteorigin-widget-field-type-tinymce' ) )
+				);
 			} );
 
 		// sowrepeaterfieldsadded is fired by admin.js on the parent document, not the iframe's document,

--- a/base/inc/fields/js/tinymce-field.js
+++ b/base/inc/fields/js/tinymce-field.js
@@ -206,6 +206,48 @@
 			.replace( /^-+|-+$/g, '' );
 	};
 
+	const sanitizeTinyMCEContent = function( content ) {
+		if (
+			window.sowbForms &&
+			typeof window.sowbForms.sanitizeTinyMCEContent === 'function'
+		) {
+			return window.sowbForms.sanitizeTinyMCEContent( content );
+		}
+
+		if ( typeof content !== 'string' || content.length === 0 ) {
+			return content;
+		}
+
+		if (
+			content.indexOf( 'mce_SELRES_' ) === -1 &&
+			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
+			content.indexOf( '\uFEFF' ) === -1
+		) {
+			return content;
+		}
+
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = content;
+		wrapper
+			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
+			.forEach( ( marker ) => marker.remove() );
+
+		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+	};
+
+	const saveTinyMCEEditorContent = function( editor, $textarea ) {
+		if ( ! editor || typeof editor.getContent !== 'function' ) {
+			return '';
+		}
+
+		const content = sanitizeTinyMCEContent( editor.getContent() );
+		if ( $textarea && $textarea.length ) {
+			$textarea.val( content );
+		}
+
+		return content;
+	};
+
 	/**
 	 * Resolves the best available WordPress editor API object.
 	 *
@@ -266,7 +308,10 @@
 
 			if ( editor ) {
 				editor.insertContent( `<img src="${ attachment.url }" alt="${ attachment.alt }" />` );
-				editor.save();
+				saveTinyMCEEditorContent(
+					editor,
+					$( typeof editor.getElement === 'function' ? editor.getElement() : document.getElementById( editorId ) )
+				);
 				editor.fire( 'change' );
 			}
 		} );
@@ -557,6 +602,16 @@
 		let id = $textarea.attr( 'data-tinymce-id' ) || $textarea.data( 'tinymce-id' );
 		const fieldElement = $field.get( 0 );
 		const textareaElement = $textarea.get( 0 );
+		const updateTextTabLabel = function() {
+			const textTab = document.getElementById( id + '-html' );
+			if ( textTab ) {
+				const codeLabel = window.top.wp && window.top.wp.i18n && typeof window.top.wp.i18n.__ === 'function'
+					? window.top.wp.i18n.__( 'Code' )
+					: 'Code';
+				textTab.textContent = codeLabel;
+				textTab.setAttribute( 'aria-label', codeLabel );
+			}
+		};
 
 		if ( id ) {
 			const existingTextarea = document.getElementById( id );
@@ -671,7 +726,7 @@
 				editor.on( 'change', function() {
 					const ed = window.tinymce.get( id );
 					if ( ed ) {
-						ed.save();
+						saveTinyMCEEditorContent( ed, $textarea );
 						$textarea.trigger( 'change' );
 					}
 				} );
@@ -696,10 +751,7 @@
 					if ( window.frameElement ) {
 						// Fix code tab label in the Site Editor.
 						editor.on( 'init', () => {
-							const textTab = document.querySelector( `#${id}-html` );
-							if ( textTab ) {
-								textTab.innerHTML = window.top.wp.i18n.__( 'Code' );
-							}
+							updateTextTabLabel();
 						} );
 					}
 
@@ -757,15 +809,22 @@
 				const editor = window.tinymce.get( id );
 				// Quick bit of sanitization to prevent catastrophic backtracking in TinyMCE HTML parser regex.
 				if ( editor !== null ) {
-					let content = $textarea.val();
+					let content = sanitizeTinyMCEContent( $textarea.val() );
 					if ( content.search( '<' ) !== -1 && content.search( '>' ) === -1 ) {
 						content = content.replace( /</g, '' );
-						$textarea.val( content );
 					}
+					$textarea.val( content );
 					editor.setContent( window.switchEditors.wpautop( content ) );
+				}
+			} else {
+				const editor = window.tinymce.get( id );
+				if ( editor !== null ) {
+					saveTinyMCEEditorContent( editor, $textarea );
 				}
 			}
 			settings.selectedEditor = mode;
+			updateTextTabLabel();
+			setTimeout( updateTextTabLabel, 0 );
 
 			$field.find( 'textarea.wp-editor-area' ).css(
 				'visibility', mode === 'tmce' ? 'hidden' : 'visible'

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -949,6 +949,10 @@ var sowbForms = window.sowbForms || {};
 
 			// Create an object with the repeater html so we can make some changes to it.
 			var repeaterObject = $('<div>' + $el.find('> .siteorigin-widget-field-repeater-item-html').html() + '</div>');
+			repeaterObject
+				.find( '.siteorigin-widget-field[data-initialized]' )
+				.removeAttr( 'data-initialized' );
+
 			repeaterObject.find('.siteorigin-widget-input[data-name]').each(function () {
 				var $$ = $(this);
 				// Skip out items that are themselves inside repeater HTML wrappers

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -44,6 +44,28 @@ var sowbForms = window.sowbForms || {};
 
 	const repeaterVisibilitySensitiveFieldSelector = '.siteorigin-widget-field-type-tinymce, .siteorigin-widget-field-type-date-range';
 
+	sowbForms.sanitizeTinyMCEContent = function( content ) {
+		if ( typeof content !== 'string' || content.length === 0 ) {
+			return content;
+		}
+
+		if (
+			content.indexOf( 'mce_SELRES_' ) === -1 &&
+			content.indexOf( 'data-mce-type="bookmark"' ) === -1 &&
+			content.indexOf( '\uFEFF' ) === -1
+		) {
+			return content;
+		}
+
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = content;
+		wrapper
+			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
+			.forEach( ( marker ) => marker.remove() );
+
+		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+	};
+
 	/**
 	 * Triggers setup for visibility-sensitive repeater fields after a repeater
 	 * item is added or expanded.
@@ -1218,7 +1240,7 @@ var sowbForms = window.sowbForms || {};
 								$inputElement.css( 'display', '' );
 								var curEd = tinymce.get( id );
 								if ( curEd ) {
-									var contentVal = curEd.getContent();
+									var contentVal = sowbForms.sanitizeTinyMCEContent( curEd.getContent() );
 									if ( ! _.isEmpty( contentVal ) ) {
 										$inputElement.val( contentVal );
 									} else if ( contentVal.search( '<' ) !== -1 && contentVal.search( '>' ) === -1) {
@@ -1690,10 +1712,10 @@ var sowbForms = window.sowbForms || {};
 					}
 
 					if ( editor !== null && typeof( editor.getContent ) === "function" && !editor.isHidden() ) {
-						fieldValue = editor.getContent();
+						fieldValue = sowbForms.sanitizeTinyMCEContent( editor.getContent() );
 					}
 					else {
-						fieldValue = $$.val();
+						fieldValue = sowbForms.sanitizeTinyMCEContent( $$.val() );
 					}
 				} else if ( $$.prop( 'tagName' ) === 'SELECT' ) {
 					var selected = $$.find( 'option:selected' );
@@ -1933,20 +1955,22 @@ var sowbForms = window.sowbForms || {};
 						editor = tinyMCE.get( $$.attr( 'id' ) );
 					}
 
+					var tinyMCEFieldValue = sowbForms.sanitizeTinyMCEContent( values.value );
 					if ( editor !== null && typeof( editor.setContent ) === "function" && ! editor.isHidden() && $$.parent().is( ':visible' ) ) {
-						if ( compareValues( editor.getContent(), values.value ) ) {
+						if ( compareValues( sowbForms.sanitizeTinyMCEContent( editor.getContent() ), tinyMCEFieldValue ) ) {
 							if ( editor.initialized ) {
-								editor.setContent( values.value );
+								editor.setContent( tinyMCEFieldValue );
 								updated = true;
 							} else {
 								editor.on('init', function () {
-									editor.setContent( values.value );
+									editor.setContent( tinyMCEFieldValue );
 								});
 								updated = true;
 							}
 						}
-					} else if ( compareValues( $$.val(), values.value ) ) {
-						$$.val( values.value );
+					}
+					else if ( compareValues( sowbForms.sanitizeTinyMCEContent( $$.val() ), tinyMCEFieldValue ) ) {
+						$$.val( tinyMCEFieldValue );
 						updated = true;
 					}
 				} else if ( $$.is( '.panels-data' ) ) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -50,9 +50,12 @@ var sowbForms = window.sowbForms || {};
 		}
 	}
 
-	const repeaterSetupFieldSelector = [
+	const repeaterVisibilitySensitiveFieldSelector = [
 		'.siteorigin-widget-field-type-tinymce',
 		'.siteorigin-widget-field-type-date-range',
+	].join( ', ' );
+
+	const repeaterImmediateSetupFieldSelector = [
 		'.siteorigin-widget-field-type-media',
 		'.siteorigin-widget-field-type-multiple_media',
 	].join( ', ' );
@@ -85,25 +88,33 @@ var sowbForms = window.sowbForms || {};
 	 * Triggers setup for repeater fields that need explicit initialization after
 	 * a repeater item is added or expanded.
 	 *
-	 * Fires `sowsetupformfield` immediately on visible fields, and always fires
-	 * `sowrepeaterfieldsadded` on the document for all fields (including hidden
-	 * ones) so that iframe pre-init handlers can bind before fields become
-	 * visible. The `clientId` of the enclosing block, when present, is passed as
-	 * a second argument so that only the relevant block reacts.
+	 * Fires `sowsetupformfield` immediately on media fields and on visible
+	 * visibility-sensitive fields, and always fires `sowrepeaterfieldsadded` on
+	 * the document for all setup fields. The `clientId` of the enclosing block,
+	 * when present, is passed as a second argument so that only the relevant
+	 * block reacts.
 	 *
 	 * @param {jQuery} $container - The newly added or expanded repeater item/form.
 	 */
-	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
-		const $allFields = $container
-			.filter( repeaterSetupFieldSelector )
-			.add( $container.find( repeaterSetupFieldSelector ) )
+	const triggerRepeaterFieldSetup = ( $container ) => {
+		const $visibilitySensitiveFields = $container
+			.filter( repeaterVisibilitySensitiveFieldSelector )
+			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
 			// Exclude placeholder rows inside repeater item templates — these carry
 			// `_id_` in their textarea IDs and must never be initialized directly.
 			.not( function() {
 				return $( this ).closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
 			} );
 
-		const $fields = $allFields.filter( ':visible' );
+		const $immediateFields = $container
+			.filter( repeaterImmediateSetupFieldSelector )
+			.add( $container.find( repeaterImmediateSetupFieldSelector ) )
+			.not( function() {
+				return $( this ).closest( '.siteorigin-widget-field-repeater-item-html' ).length > 0;
+			} );
+
+		const $allFields = $visibilitySensitiveFields.add( $immediateFields );
+		const $fields = $visibilitySensitiveFields.filter( ':visible' ).add( $immediateFields );
 
 		$fields.each( function() {
 			$( this ).trigger( 'sowsetupformfield' );
@@ -982,7 +993,7 @@ var sowbForms = window.sowbForms || {};
 			$el.find( '> .siteorigin-widget-field-repeater-items' ).append( item ).sortable( 'refresh' ).trigger( 'updateFieldPositions' );
 			item.sowSetupRepeaterItems();
 			item.hide().slideDown( 'fast', function () {
-				triggerVisibleRepeaterVisibilityFieldSetup( $( this ) );
+				triggerRepeaterFieldSetup( $( this ) );
 				$( window ).trigger( 'resize' );
 			});
 			$el.trigger( 'change' );
@@ -1182,7 +1193,7 @@ var sowbForms = window.sowbForms || {};
 								$this.trigger( 'slideToggleCloseComplete' );
 							} else {
 								$this.trigger( 'slideToggleOpenComplete' );
-								triggerVisibleRepeaterVisibilityFieldSetup( $this );
+								triggerRepeaterFieldSetup( $this );
 							}
 
 							$( window ).trigger( 'resize' );
@@ -1358,7 +1369,7 @@ var sowbForms = window.sowbForms || {};
 						$items.append( $copyItem ).sortable( 'refresh' ).trigger( 'updateFieldPositions' );
 						$copyItem.sowSetupRepeaterItems();
 						$copyItem.hide().slideDown( 'fast', function () {
-							triggerVisibleRepeaterVisibilityFieldSetup( $( this ) );
+							triggerRepeaterFieldSetup( $( this ) );
 							$( window ).trigger( 'resize' );
 						});
 						// If increment is enabled for this item, trigger label updates.

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -1655,6 +1655,145 @@ var sowbForms = window.sowbForms || {};
 		return formContainer.data( 'id-base' );
 	};
 
+	const widgetFieldFlushers = {};
+
+	const getElementWindow = function( element ) {
+		return element && element.ownerDocument && element.ownerDocument.defaultView ?
+			element.ownerDocument.defaultView :
+			window;
+	};
+
+	const getElementJQuery = function( element ) {
+		const elementWindow = getElementWindow( element );
+		return elementWindow.jQuery || $;
+	};
+
+	const normalizeWidgetFormContainer = function( formContainer ) {
+		if (
+			formContainer === undefined ||
+			formContainer === null ||
+			formContainer.length === 0
+		) {
+			return $();
+		}
+
+		const element = formContainer.jquery ? formContainer[0] : formContainer;
+		const elementJQuery = getElementJQuery( element );
+
+		return elementJQuery( element );
+	};
+
+	const getWidgetFieldType = function( $field ) {
+		const fieldClasses = ( $field.attr( 'class' ) || '' ).split( /\s+/ );
+
+		for ( let i = 0; i < fieldClasses.length; i++ ) {
+			const matches = fieldClasses[ i ].match( /^siteorigin-widget-field-type-(.+)$/ );
+
+			if ( matches ) {
+				return matches[1];
+			}
+		}
+
+		return null;
+	};
+
+	const normalizeWidgetFormSnapshotOptions = function( options ) {
+		return $.extend( {
+			awaitAsync: true,
+			triggerChange: false,
+		}, options || {} );
+	};
+
+	sowbForms.registerFieldFlusher = function( fieldType, callback ) {
+		if (
+			typeof fieldType !== 'string' ||
+			typeof callback !== 'function'
+		) {
+			return;
+		}
+
+		widgetFieldFlushers[ fieldType ] = callback;
+	};
+
+	sowbForms.flushWidgetForm = function( formContainer, options ) {
+		const $formContainer = normalizeWidgetFormContainer( formContainer );
+		const normalizedOptions = normalizeWidgetFormSnapshotOptions( options );
+		const flushPromises = [];
+
+		$formContainer.find( '.siteorigin-widget-field' ).each( function() {
+			const $field = getElementJQuery( this )( this );
+			const fieldType = getWidgetFieldType( $field );
+
+			if (
+				! fieldType ||
+				! widgetFieldFlushers[ fieldType ]
+			) {
+				return;
+			}
+
+			const flushResult = widgetFieldFlushers[ fieldType ]( $field, normalizedOptions );
+
+			if (
+				normalizedOptions.awaitAsync &&
+				flushResult &&
+				typeof flushResult.then === 'function'
+			) {
+				flushPromises.push( Promise.resolve( flushResult ) );
+			}
+		} );
+
+		return Promise.all( flushPromises ).then( function() {} );
+	};
+
+	sowbForms.getWidgetFormSnapshot = function( formContainer, options ) {
+		const $formContainer = normalizeWidgetFormContainer( formContainer );
+
+		return sowbForms.flushWidgetForm( $formContainer, options ).then( function() {
+			return sowbForms.getWidgetFormValues( $formContainer );
+		} );
+	};
+
+	sowbForms.registerFieldFlusher( 'tinymce', function( $field, options ) {
+		const fieldWindow = getElementWindow( $field[0] );
+		const fieldJQuery = fieldWindow.jQuery || $;
+		const flushPromises = [];
+
+		$field.find( 'textarea.wp-editor-area' ).each( function() {
+			const $textarea = fieldJQuery( this );
+			const editorId = $textarea.data( 'tinymce-id' ) || $textarea.attr( 'id' );
+			const initPromise = ( editorId && typeof fieldWindow.sowbGetTinyMCEInitPromise === 'function' ) ?
+				fieldWindow.sowbGetTinyMCEInitPromise( editorId ) :
+				Promise.resolve();
+
+			flushPromises.push(
+				initPromise.then( function() {
+					const editor = fieldWindow.tinymce && editorId ?
+						fieldWindow.tinymce.get( editorId ) :
+						null;
+
+					if (
+						editor &&
+						typeof editor.getContent === 'function' &&
+						(
+							typeof editor.isHidden !== 'function' ||
+							! editor.isHidden()
+						)
+					) {
+						$textarea.val( sowbForms.sanitizeTinyMCEContent( editor.getContent() ) );
+					} else {
+						$textarea.val( sowbForms.sanitizeTinyMCEContent( $textarea.val() ) );
+					}
+
+					if ( options.triggerChange ) {
+						$textarea.trigger( 'change' );
+					}
+				} )
+			);
+		} );
+
+		return Promise.all( flushPromises );
+	} );
+
 	sowbForms.getWidgetFormValues = function ( formContainer ) {
 
 		if ( _.isUndefined( formContainer ) ) {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -50,7 +50,12 @@ var sowbForms = window.sowbForms || {};
 		}
 	}
 
-	const repeaterVisibilitySensitiveFieldSelector = '.siteorigin-widget-field-type-tinymce, .siteorigin-widget-field-type-date-range';
+	const repeaterSetupFieldSelector = [
+		'.siteorigin-widget-field-type-tinymce',
+		'.siteorigin-widget-field-type-date-range',
+		'.siteorigin-widget-field-type-media',
+		'.siteorigin-widget-field-type-multiple_media',
+	].join( ', ' );
 
 	sowbForms.sanitizeTinyMCEContent = function( content ) {
 		if ( typeof content !== 'string' || content.length === 0 ) {
@@ -77,8 +82,8 @@ var sowbForms = window.sowbForms || {};
 	};
 
 	/**
-	 * Triggers setup for visibility-sensitive repeater fields after a repeater
-	 * item is added or expanded.
+	 * Triggers setup for repeater fields that need explicit initialization after
+	 * a repeater item is added or expanded.
 	 *
 	 * Fires `sowsetupformfield` immediately on visible fields, and always fires
 	 * `sowrepeaterfieldsadded` on the document for all fields (including hidden
@@ -90,8 +95,8 @@ var sowbForms = window.sowbForms || {};
 	 */
 	const triggerVisibleRepeaterVisibilityFieldSetup = ( $container ) => {
 		const $allFields = $container
-			.filter( repeaterVisibilitySensitiveFieldSelector )
-			.add( $container.find( repeaterVisibilitySensitiveFieldSelector ) )
+			.filter( repeaterSetupFieldSelector )
+			.add( $container.find( repeaterSetupFieldSelector ) )
 			// Exclude placeholder rows inside repeater item templates — these carry
 			// `_id_` in their textarea IDs and must never be initialized directly.
 			.not( function() {

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -4,7 +4,15 @@ var sowbForms = window.sowbForms || {};
 
 (function ($) {
 
+	if ( window.sowbWidgetAdminScriptLoaded ) {
+		return;
+	}
+
+	window.sowbWidgetAdminScriptLoaded = true;
+	window.sowbWidgetAdminScriptLoadedAt = Date.now();
+
 	const isBlockEditor = $( 'body' ).hasClass( 'block-editor-page' );
+
 
 	let fontList = '';
 	for ( const [ value, label ] of Object.entries( soWidgets.fonts ) ) {
@@ -63,7 +71,9 @@ var sowbForms = window.sowbForms || {};
 			.querySelectorAll( 'span[data-mce-type="bookmark"], span.mce_SELRES_start, span.mce_SELRES_end' )
 			.forEach( ( marker ) => marker.remove() );
 
-		return wrapper.innerHTML.replace( /\uFEFF/g, '' );
+		const sanitizedContent = wrapper.innerHTML.replace( /\uFEFF/g, '' );
+
+		return sanitizedContent;
 	};
 
 	/**
@@ -1742,7 +1752,7 @@ var sowbForms = window.sowbForms || {};
 			}
 		} );
 
-		return Promise.all( flushPromises ).then( function() {} );
+		return Promise.all( flushPromises );
 	};
 
 	sowbForms.getWidgetFormSnapshot = function( formContainer, options ) {
@@ -1787,6 +1797,7 @@ var sowbForms = window.sowbForms || {};
 					if ( options.triggerChange ) {
 						$textarea.trigger( 'change' );
 					}
+
 				} )
 			);
 		} );

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -860,9 +860,9 @@
 						dangerouslySetInnerHTML: {
 							__html: widgetPreviewHtml
 						},
-						ref: () => {
+						ref: ( previewElement ) => {
 							if ( ! previewInitialized ) {
-								jQuery( window.sowb ).trigger( 'setup_widgets', { preview: true } );
+								sowbSetupPreviewWidgets( previewElement );
 								mergeState( { previewInitialized: true } );
 							}
 						}
@@ -1206,6 +1206,20 @@ const sowbGetElementWindow = ( element ) => {
 	return element && element.ownerDocument && element.ownerDocument.defaultView ?
 		element.ownerDocument.defaultView :
 		window;
+};
+
+const sowbSetupPreviewWidgets = ( previewElement ) => {
+	sowbMaybeSetupSiteEditorAssets();
+
+	const previewWindow = sowbGetElementWindow( previewElement );
+	const previewJQuery = previewWindow.jQuery || jQuery;
+	const previewSowb = previewWindow.sowb || window.sowb;
+
+	if ( ! previewSowb ) {
+		return;
+	}
+
+	previewJQuery( previewSowb ).trigger( 'setup_widgets', { preview: true } );
 };
 
 /**
@@ -1600,6 +1614,10 @@ const sowbCanvasCloneElements = [
 	'#wplink-js',
 	'#buttons-css',
 	'#dashicons-css',
+
+	// Widget frontend preview scripts.
+	'#dessandro-imagesLoaded-js',
+	'#sow-image-grid-js',
 
 	// Load all styles imported using load-styles.php.
 	'link[href*="wp-admin/load-styles.php"]',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -27,6 +27,14 @@
 		return errorMessage;
 	};
 
+	const sowbSerializeWidgetData = ( widgetData ) => {
+		try {
+			return JSON.stringify( widgetData || {} );
+		} catch ( error ) {
+			return null;
+		}
+	};
+
 	// Certain widgets are excluded from the content check as
 	// they don't contain "standard" content indicators.
 	const widgetsExcludedFromContentCheck = [
@@ -246,7 +254,6 @@
 	 * @param {Function} setState - The setState function to update the component's state.
 	 * @param {Object} activeRequestRef - React ref tracking the active preview request.
 	 */
-
 	const sowbSetupWidgetForm = async ( props, state, setState, activeRequestRef ) => {
 		let $mainForm = sowbGetBlockForm( props.clientId );
 
@@ -257,14 +264,12 @@
 		// Re-wrap the form node with the jQuery instance that owns it. In the
 		// iframe path this is the iframe's jQuery; in the non-iframe path it is
 		// the parent jQuery. sowSetupForm(), wpColorPicker, and all other field
-		// plugins are bound to whichever jQuery ran their defining script — using
+		// plugins are bound to whichever jQuery ran their defining script, using
 		// the same instance here ensures event handlers fire correctly.
 		const formWindow = sowbGetElementWindow( $mainForm[ 0 ] );
 		const formJQuery = formWindow.jQuery || jQuery;
 		const formForms = formWindow.sowbForms || sowbForms;
 		$mainForm = formJQuery( $mainForm[ 0 ] );
-
-		sowbMaybeSetupSiteEditorAssets();
 
 		const switchToBlockPreview = async function() {
 			const oldTimer = $mainForm.data( 'sowb-preview-timer' );
@@ -309,7 +314,56 @@
 				} );
 		};
 
+		if ( $mainForm.data( 'sowb-block-form-initializing' ) ) {
+			return;
+		}
+
+		if ( $mainForm.data( 'sow-form-setup' ) === true ) {
+			bindBlockPreviewHandler();
+			setState( { formInitialized: true } );
+			return;
+		}
+
+		const setupFrame = sowbGetEditorCanvasFrame();
+		if ( ! $mainForm.data( 'sowb-form-setup-assets-cloned' ) ) {
+			sowbMaybeSetupSiteEditorAssets();
+			$mainForm.data( 'sowb-form-setup-assets-cloned', true );
+		}
+
+		const dependencyStatus = sowbEnsureFormSetupDependencies( setupFrame, formWindow, $mainForm );
+		if ( ! dependencyStatus.ready ) {
+
+			const oldRetryTimer = $mainForm.data( 'sowb-form-setup-dependency-retry' );
+			if ( oldRetryTimer ) {
+				clearTimeout( oldRetryTimer );
+			}
+
+			const retryCount = ( $mainForm.data( 'sowb-form-setup-dependency-retry-count' ) || 0 ) + 1;
+			$mainForm.data( 'sowb-form-setup-dependency-retry-count', retryCount );
+
+			if ( retryCount <= 40 ) {
+				$mainForm.data(
+					'sowb-form-setup-dependency-retry',
+					setTimeout( function() {
+						sowbSetupWidgetForm(
+							props,
+							state,
+							setState,
+							activeRequestRef
+						);
+					}, 250 )
+				);
+			}
+
+			return;
+		}
+		$mainForm.removeData( 'sowb-form-setup-dependency-retry' );
+		$mainForm.removeData( 'sowb-form-setup-dependency-retry-count' );
+
+		$mainForm.data( 'sowb-block-form-initializing', true );
 		$mainForm.data( 'backupDisabled', true );
+
+		let currentWidgetDataJson = sowbSerializeWidgetData( props.attributes.widgetData );
 
 		if ( props.attributes.widgetData ) {
 			// If we call `setWidgetFormValues` with the last parameter
@@ -317,11 +371,20 @@
 			// for some fields e.g. color and media fields.
 			formForms.setWidgetFormValues( $mainForm, props.attributes.widgetData );
 		} else {
-			props.setAttributes( { widgetData: formForms.getWidgetFormValues( $mainForm ) } );
+			const initialWidgetData = formForms.getWidgetFormValues( $mainForm );
+			currentWidgetDataJson = sowbSerializeWidgetData( initialWidgetData );
+			props.setAttributes( { widgetData: initialWidgetData } );
 		}
 
-		$mainForm.sowSetupForm();
+		try {
+			$mainForm.sowSetupForm();
+		} catch ( error ) {
+			$mainForm.removeData( 'sowb-block-form-initializing' );
+			throw error;
+		}
 		bindBlockPreviewHandler();
+		$mainForm.removeData( 'sowb-block-form-initializing' );
+		$mainForm.data( 'sowb-block-last-widget-data-json', currentWidgetDataJson );
 
 		// Namespace the change event so multiple sowbSetupWidgetForm calls for
 		// the same block (React double-render / stale closures) don't stack up
@@ -338,6 +401,16 @@
 				// As setAttributes doesn't support callbacks, we have to manually
 				// pass the widgetData to the preview.
 				var widgetData = formForms.getWidgetFormValues( $mainForm );
+				const widgetDataJson = sowbSerializeWidgetData( widgetData );
+
+				if (
+					widgetDataJson !== null &&
+					widgetDataJson === $mainForm.data( 'sowb-block-last-widget-data-json' )
+				) {
+					return;
+				}
+
+				$mainForm.data( 'sowb-block-last-widget-data-json', widgetDataJson );
 				props.setAttributes( { widgetData: widgetData } );
 
 				// Set up a preview debounce timer to prevent multiple requests.
@@ -430,6 +503,7 @@
 
 		const sendInitMessage = () => {
 			try {
+				sowbEnsureIframeOldEditorApi( iframeElement );
 				iframeWindow.postMessage( message, targetOrigin );
 			} catch ( e ) {
 				console.error( 'SiteOrigin Widgets: Failed to send postMessage to iframe:', e );
@@ -1112,8 +1186,12 @@
 		} )
 	} );
 
-	// Copy over assets to the editor iframe asap.
-	sowbMaybeSetupSiteEditorAssets();
+	// Copy over assets to the editor iframe asap. When this script is itself
+	// running inside the editor iframe, the parent setup paths own asset
+	// cloning; self-cloning from the iframe can race with those paths.
+	if ( ! window.frameElement ) {
+		sowbMaybeSetupSiteEditorAssets();
+	}
 } )( window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.components, window.wp.blockEditor );
 
 let sowbSiteEditorCanvas = false;
@@ -1181,6 +1259,87 @@ const sowbResolveWpEditor = () => {
 };
 window.sowbResolveWpEditor = sowbResolveWpEditor;
 
+const sowbGetFormSetupDependencyStatus = ( formWindow, $form ) => {
+	const formJQuery = formWindow && formWindow.jQuery ? formWindow.jQuery : null;
+	let isIframeForm = false;
+	try {
+		isIframeForm = !! (
+			formWindow &&
+			(
+				formWindow !== window ||
+				formWindow.frameElement
+			)
+		);
+	} catch ( e ) {
+		isIframeForm = formWindow !== window;
+	}
+	const hasRepeater = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-repeater, .siteorigin-widget-field-type-repeater' ).length
+	);
+	const hasSlider = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-type-slider' ).length
+	);
+	const hasTinyMCE = !! (
+		$form &&
+		$form.length &&
+		$form.find( '.siteorigin-widget-field-type-tinymce' ).length
+	);
+	const hasWpEditorApi = !! (
+		formWindow &&
+		formWindow.wp &&
+		(
+			(
+				formWindow.wp.oldEditor &&
+				typeof formWindow.wp.oldEditor.initialize === 'function'
+			) ||
+			(
+				formWindow.wp.editor &&
+				typeof formWindow.wp.editor.initialize === 'function'
+			)
+		)
+	);
+
+	return {
+		hasJQuery: !! formJQuery,
+		hasSowSetupForm: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.sowSetupForm === 'function' ),
+		hasJQueryUi: !! ( formJQuery && formJQuery.ui ),
+		hasMouse: !! ( formJQuery && formJQuery.ui && formJQuery.ui.mouse ),
+		hasSortable: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.sortable === 'function' ),
+		hasSliderApi: !! ( formJQuery && formJQuery.fn && typeof formJQuery.fn.slider === 'function' ),
+		hasRepeater,
+		hasSlider,
+		hasTinyMCE,
+		isIframeForm,
+		hasWpEditorApi,
+		ready: !! (
+			formJQuery &&
+			formJQuery.fn &&
+			typeof formJQuery.fn.sowSetupForm === 'function' &&
+			( ! hasRepeater || typeof formJQuery.fn.sortable === 'function' ) &&
+			( ! hasSlider || typeof formJQuery.fn.slider === 'function' ) &&
+			( ! hasTinyMCE || ! isIframeForm || hasWpEditorApi )
+		),
+	};
+};
+
+const sowbEnsureFormSetupDependencies = ( frame, formWindow, $form ) => {
+	if ( frame ) {
+		sowbEnsureIframeOldEditorApi( frame );
+	}
+
+	const dependencyStatus = sowbGetFormSetupDependencyStatus( formWindow, $form );
+
+	if ( dependencyStatus.ready ) {
+		return dependencyStatus;
+	}
+
+	return dependencyStatus;
+};
+
 const sowbResolveSiteEditorFrame = ( frame = null ) => {
 	if ( frame ) {
 		if ( frame.jquery ) {
@@ -1242,10 +1401,12 @@ const sowbGetBlockForm = ( clientId ) => {
 	}
 
 	// No iframe (e.g. widgets.php Block Widgets screen, classic editor).
-	return jQuery( document )
+	const $mainDocumentForm = jQuery( document )
 		.find( '[data-block="' + clientId + '"]' )
 		.find( '.siteorigin-widget-form-main[data-class]' )
 		.first();
+
+	return $mainDocumentForm;
 };
 
 const sowbIsDirectWidgetBlock = ( block ) => {
@@ -1291,17 +1452,19 @@ const sowbGetBlockFormSnapshot = async ( $form ) => {
 		formForms &&
 		typeof formForms.getWidgetFormSnapshot === 'function'
 	) {
-		return await formForms.getWidgetFormSnapshot( $ownerForm, {
+		const widgetData = await formForms.getWidgetFormSnapshot( $ownerForm, {
 			awaitAsync: true,
 			triggerChange: false,
 		} );
+		return widgetData;
 	}
 
 	if (
 		formForms &&
 		typeof formForms.getWidgetFormValues === 'function'
 	) {
-		return formForms.getWidgetFormValues( $ownerForm );
+		const widgetData = formForms.getWidgetFormValues( $ownerForm );
+		return widgetData;
 	}
 
 	return null;
@@ -1521,6 +1684,238 @@ const sowbGetElementById = ( doc, id ) => {
 	return doc.getElementById( id );
 };
 
+const sowbIsScriptHandleLoadedInWindow = ( targetWindow, scriptId ) => {
+	if ( ! targetWindow || ! scriptId ) {
+		return false;
+	}
+
+	switch ( scriptId ) {
+		case 'jquery-core-js':
+			return !! targetWindow.jQuery;
+		case 'jquery-migrate-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.migrateVersion
+			);
+		case 'jquery-ui-core-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.ui
+			);
+		case 'jquery-ui-mouse-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.ui &&
+				targetWindow.jQuery.ui.mouse
+			);
+		case 'jquery-ui-slider-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.slider === 'function'
+			);
+		case 'jquery-ui-sortable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.sortable === 'function'
+			);
+		case 'jquery-ui-resizable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.resizable === 'function'
+			);
+		case 'jquery-ui-draggable-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.draggable === 'function'
+			);
+		case 'iris-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.iris === 'function'
+			);
+		case 'wp-color-picker-js':
+			return !! (
+				targetWindow.jQuery &&
+				targetWindow.jQuery.fn &&
+				typeof targetWindow.jQuery.fn.wpColorPicker === 'function'
+			);
+		case 'siteorigin-widget-admin-js-extra':
+			return !! targetWindow.soWidgets;
+		case 'siteorigin-widget-admin-js':
+			return !! (
+				targetWindow.sowbWidgetAdminScriptLoaded ||
+				(
+					targetWindow.sowbForms &&
+					targetWindow.jQuery &&
+					targetWindow.jQuery.fn &&
+					typeof targetWindow.jQuery.fn.sowSetupForm === 'function'
+				)
+			);
+		case 'so-tinymce-field-js':
+			return !! (
+				targetWindow.sowbTinyMCEFieldScriptLoaded ||
+				typeof targetWindow.sowbGetTinyMCEInitPromise === 'function'
+			);
+		case 'editor-js':
+			return !! (
+				targetWindow.wp &&
+				(
+					(
+						targetWindow.wp.oldEditor &&
+						typeof targetWindow.wp.oldEditor.initialize === 'function'
+					) ||
+					(
+						targetWindow.wp.editor &&
+						typeof targetWindow.wp.editor.initialize === 'function'
+					)
+				)
+			);
+		case 'wp-tinymce-js':
+			return !! targetWindow.tinymce;
+		case 'quicktags-js':
+			return !! targetWindow.QTags;
+		case 'underscore-js':
+			return !! targetWindow._;
+		default:
+			return false;
+	}
+};
+
+const sowbGetEditorAssetSourceDocument = () => {
+	try {
+		if (
+			window.frameElement &&
+			window.parent &&
+			window.parent.document
+		) {
+			return window.parent.document;
+		}
+	} catch ( e ) {
+	}
+
+	return document;
+};
+
+const sowbEnsureIframeEditorGlobals = ( frame ) => {
+	if (
+		! frame ||
+		! frame.contentWindow
+	) {
+		return;
+	}
+
+	const iframeWindow = frame.contentWindow;
+	const topWindow = window.top || window;
+	const globals = [
+		'ajaxurl',
+		'userSettings',
+		'wpCookies',
+		'getUserSetting',
+		'setUserSetting',
+		'deleteUserSetting',
+		'getAllUserSettings',
+	];
+
+	globals.forEach( ( globalName ) => {
+		if (
+			typeof iframeWindow[ globalName ] === 'undefined' &&
+			typeof topWindow[ globalName ] !== 'undefined'
+		) {
+			iframeWindow[ globalName ] = topWindow[ globalName ];
+		}
+	} );
+};
+
+const sowbEnsureIframeOldEditorApi = ( frame ) => {
+	if (
+		! frame ||
+		! frame.contentDocument ||
+		! frame.contentWindow ||
+		! frame.contentDocument.body
+	) {
+		return;
+	}
+
+	sowbEnsureIframeEditorGlobals( frame );
+
+	const iframeWindow = frame.contentWindow;
+	if (
+		iframeWindow.wp &&
+		iframeWindow.wp.oldEditor &&
+		typeof iframeWindow.wp.oldEditor.initialize === 'function'
+	) {
+		return;
+	}
+
+	if (
+		iframeWindow.wp &&
+		iframeWindow.wp.editor &&
+		typeof iframeWindow.wp.editor.initialize === 'function'
+	) {
+		iframeWindow.wp.oldEditor = iframeWindow.wp.editor;
+		return;
+	}
+
+	if ( frame.contentDocument.getElementById( 'sowb-editor-js-retry' ) ) {
+		return;
+	}
+
+	if (
+		iframeWindow.sowbEditorJsRetryPending ||
+		(
+			iframeWindow.sowbScriptClonePending &&
+			iframeWindow.sowbScriptClonePending[ 'id:editor-js' ]
+		)
+	) {
+		return;
+	}
+
+	const sourceDoc = sowbGetEditorAssetSourceDocument();
+	const editorScript = sowbGetElementById( sourceDoc, 'editor-js' );
+	if ( ! editorScript || ! editorScript.src ) {
+		return;
+	}
+
+	const previousEditor = iframeWindow.wp && iframeWindow.wp.editor;
+	const retryScript = frame.contentDocument.createElement( 'script' );
+	retryScript.id = 'sowb-editor-js-retry';
+	retryScript.src = editorScript.src;
+	retryScript.async = false;
+	retryScript.onload = () => {
+		iframeWindow.sowbEditorJsRetryPending = false;
+		if (
+			! iframeWindow.wp ||
+			! iframeWindow.wp.editor ||
+			typeof iframeWindow.wp.editor.initialize !== 'function'
+		) {
+			return;
+		}
+
+		const oldEditor = iframeWindow.wp.editor;
+		iframeWindow.wp.oldEditor = oldEditor;
+
+		if (
+			previousEditor &&
+			previousEditor !== oldEditor
+		) {
+			Object.assign( previousEditor, oldEditor );
+			iframeWindow.wp.editor = previousEditor;
+		}
+
+	};
+	retryScript.onerror = ( event ) => {
+		iframeWindow.sowbEditorJsRetryPending = false;
+	};
+
+	iframeWindow.sowbEditorJsRetryPending = true;
+	frame.contentDocument.body.appendChild( retryScript );
+};
+
 /**
  * Gets the editor settings for a TinyMCE container.
  *
@@ -1639,6 +2034,31 @@ const sowbCloneElementToCanvas = ( $canvasBody, element, $source ) => {
 	const sourceDoc = $source && $source[0] && $source[0].nodeType === 9 ?
 		$source[0] :
 		element.ownerDocument;
+	const canvasWindow = canvasDoc && canvasDoc.defaultView;
+	const tagName = element.tagName ? element.tagName.toLowerCase() : '';
+	const assetAttribute = element.hasAttribute( 'src' ) ? 'src' : (
+		element.hasAttribute( 'href' ) ? 'href' : ''
+	);
+	const assetUrl = assetAttribute ?
+		sowbNormalizeAssetUrl(
+			element.getAttribute( assetAttribute ),
+			sowbGetDocumentHref( sourceDoc )
+		) :
+		'';
+	const scriptCloneKey = tagName === 'script' ?
+		( element.id ? 'id:' + element.id : ( assetUrl ? 'url:' + assetUrl : '' ) ) :
+		'';
+
+	if ( scriptCloneKey && canvasWindow ) {
+		canvasWindow.sowbScriptClonePending = canvasWindow.sowbScriptClonePending || {};
+
+		if (
+			canvasWindow.sowbScriptClonePending[ scriptCloneKey ] ||
+			sowbIsScriptHandleLoadedInWindow( canvasWindow, element.id )
+		) {
+			return false;
+		}
+	}
 
 	if (
 		element.id &&
@@ -1647,32 +2067,51 @@ const sowbCloneElementToCanvas = ( $canvasBody, element, $source ) => {
 		return false;
 	}
 
-	const assetAttribute = element.hasAttribute( 'src' ) ? 'src' : (
-		element.hasAttribute( 'href' ) ? 'href' : ''
-	);
+	if ( assetUrl ) {
+		const selector = assetAttribute === 'src' ? 'script[src]' : 'link[href]';
+		const existingAsset = $canvasBody.find( selector ).toArray().some( ( candidate ) => {
+			return sowbNormalizeAssetUrl(
+				candidate.getAttribute( assetAttribute ),
+				sowbGetDocumentHref( candidate.ownerDocument )
+			) === assetUrl;
+		} );
 
-	if ( assetAttribute ) {
-		const assetUrl = sowbNormalizeAssetUrl(
-			element.getAttribute( assetAttribute ),
-			sowbGetDocumentHref( sourceDoc )
-		);
-
-		if ( assetUrl ) {
-			const selector = assetAttribute === 'src' ? 'script[src]' : 'link[href]';
-			const existingAsset = $canvasBody.find( selector ).toArray().some( ( candidate ) => {
-				return sowbNormalizeAssetUrl(
-					candidate.getAttribute( assetAttribute ),
-					sowbGetDocumentHref( candidate.ownerDocument )
-				) === assetUrl;
-			} );
-
-			if ( existingAsset ) {
-				return false;
-			}
+		if ( existingAsset ) {
+			return false;
 		}
 	}
 
-	$canvasBody.append( element.outerHTML );
+	let clonedElement;
+	if ( tagName === 'script' ) {
+		clonedElement = canvasDoc.createElement( 'script' );
+		for ( const attribute of element.attributes ) {
+			clonedElement.setAttribute( attribute.name, attribute.value );
+		}
+		clonedElement.textContent = element.textContent;
+		clonedElement.async = false;
+		if ( scriptCloneKey && canvasWindow ) {
+			clonedElement.addEventListener( 'load', () => {
+				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+			}, { once: true } );
+			clonedElement.addEventListener( 'error', () => {
+				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+			}, { once: true } );
+		}
+	} else {
+		clonedElement = element.cloneNode( true );
+	}
+	if ( scriptCloneKey && canvasWindow ) {
+		canvasWindow.sowbScriptClonePending[ scriptCloneKey ] = true;
+	}
+	$canvasBody[0].appendChild( clonedElement );
+	if (
+		tagName === 'script' &&
+		! assetUrl &&
+		scriptCloneKey &&
+		canvasWindow
+	) {
+		delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+	}
 	return true;
 };
 
@@ -1728,6 +2167,15 @@ const sowbCloneElementsToCanvas = ( $canvasBody, sourceDoc ) => {
 	for ( const selector of sowbCanvasCloneElements ) {
 		const $element = $source.find( selector );
 		if ( $element.length === 0 ) {
+			if ( [
+				'#wp-tinymce-js',
+				'#quicktags-js-extra',
+				'#quicktags-js',
+				'#siteorigin-widget-admin-js',
+				'#so-tinymce-field-js',
+				'#underscore-js',
+			].includes( selector ) ) {
+			}
 			continue;
 		}
 
@@ -1736,6 +2184,15 @@ const sowbCloneElementsToCanvas = ( $canvasBody, sourceDoc ) => {
 			continue;
 		}
 
+		if ( [
+			'#wp-tinymce-js',
+			'#quicktags-js-extra',
+			'#quicktags-js',
+			'#siteorigin-widget-admin-js',
+			'#so-tinymce-field-js',
+			'#underscore-js',
+		].includes( selector ) ) {
+		}
 		sowbCloneElementToCanvas( $canvasBody, element, $source );
 	}
 };
@@ -1757,8 +2214,6 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 		sourceDoc || document
 	);
 	const assetRootList = [ ...assetRoots ];
-	let previousMatchedScriptRoot = '';
-	let pendingDependencyScripts = [];
 
 	const cloneAssetElement = ( element ) => {
 		if ( element.tagName.toLowerCase() === 'script' ) {
@@ -1767,6 +2222,14 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 
 		sowbCloneElementToCanvas( $canvasBody, element, $source );
 	};
+
+	if ( assetRootList.some( ( assetRoot ) => assetRoot.indexOf( '/web-font-selector/js/' ) !== -1 ) ) {
+		$source
+			.find( '#web-font-loader-js, script[src*="ajax.googleapis.com/ajax/libs/webfont/"]' )
+			.each( function() {
+				cloneAssetElement( this );
+			} );
+	}
 
 	$source.find( 'script[src], link[rel="stylesheet"][href]' ).each( function() {
 		const tagName = this.tagName.toLowerCase();
@@ -1779,26 +2242,7 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 			'';
 
 		if ( matchedRoot ) {
-			if ( tagName === 'script' ) {
-				// WordPress prints script dependencies before dependents, but the
-				// DOM does not expose dependency handles. If a TinyMCE companion
-				// package has root-matched scripts on both sides of an intervening
-				// script, preserve that in-between dependency before the later
-				// matched script runs in the iframe.
-				if ( previousMatchedScriptRoot === matchedRoot ) {
-					pendingDependencyScripts.forEach( cloneAssetElement );
-				}
-
-				pendingDependencyScripts = [];
-				previousMatchedScriptRoot = matchedRoot;
-			}
-
 			cloneAssetElement( this );
-			return;
-		}
-
-		if ( tagName === 'script' && previousMatchedScriptRoot ) {
-			pendingDependencyScripts.push( this );
 		}
 	} );
 };
@@ -1858,8 +2302,10 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 		sourceDoc = document;
 	}
 
+	sowbEnsureIframeEditorGlobals( currentFrame );
 	sowbCloneElementsToCanvas( $canvasBody, sourceDoc );
 	sowbCloneTinyMCEExternalPluginAssets( $canvasBody, sourceDoc );
+	sowbEnsureIframeOldEditorApi( currentFrame );
 
 	// Is ajaxurl set?
 	try {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -266,6 +266,32 @@
 
 		sowbMaybeSetupSiteEditorAssets();
 
+		const switchToBlockPreview = async function() {
+			const oldTimer = $mainForm.data( 'sowb-preview-timer' );
+			if ( oldTimer ) {
+				clearTimeout( oldTimer );
+			}
+
+			const widgetData = await sowbSnapshotBlockFormToAttributes( props, $mainForm );
+
+			setState( {
+				editing: false,
+				previewInitialized: false,
+				widgetPreviewHtml: false,
+			} );
+
+			if ( widgetData ) {
+				sowbGenerateWidgetPreview(
+					props,
+					false,
+					setState,
+					widgetData,
+					props.widget.class,
+					activeRequestRef
+				);
+			}
+		};
+
 		const bindBlockPreviewHandler = function() {
 			// sowSetupForm() binds the legacy widget preview modal handler. Direct
 			// widget blocks have their own React preview path, so take ownership of
@@ -279,11 +305,7 @@
 					event.preventDefault();
 					event.stopImmediatePropagation();
 
-					setState( {
-						editing: false,
-						previewInitialized: false,
-						widgetPreviewHtml: false,
-					} );
+					switchToBlockPreview();
 				} );
 		};
 
@@ -483,6 +505,27 @@
 		const activeRequestRef = element.useRef( null );
 		const iframeFormInitKeyRef = element.useRef( null );
 
+		const switchToBlockPreview = async () => {
+			const widgetData = await sowbSnapshotBlockFormToAttributes( props );
+
+			mergeState( {
+				editing: false,
+				previewInitialized: false,
+				widgetPreviewHtml: false,
+			} );
+
+			if ( widgetData ) {
+				sowbGenerateWidgetPreview(
+					props,
+					false,
+					mergeState,
+					widgetData,
+					props.widget.class,
+					activeRequestRef
+				);
+			}
+		};
+
 		// Ensure widgetClass attribute is set once (was done in constructor).
 		element.useEffect( () => {
 			if ( ! props.attributes.widgetClass ) {
@@ -656,7 +699,7 @@
 										event.stopPropagation();
 									}
 
-									mergeState( { editing: false } );
+									switchToBlockPreview();
 								},
 								icon: 'visibility'
 							}
@@ -1262,6 +1305,26 @@ const sowbGetBlockFormSnapshot = async ( $form ) => {
 	}
 
 	return null;
+};
+
+const sowbSnapshotBlockFormToAttributes = async ( props, $form = null ) => {
+	const $snapshotForm = $form && $form.length ?
+		$form :
+		sowbGetBlockForm( props.clientId );
+
+	if ( ! $snapshotForm || $snapshotForm.length === 0 ) {
+		return null;
+	}
+
+	const widgetData = await sowbGetBlockFormSnapshot( $snapshotForm );
+
+	if ( ! sowbHasWidgetDataSnapshot( widgetData ) ) {
+		return null;
+	}
+
+	props.setAttributes( { widgetData } );
+
+	return widgetData;
 };
 
 const sowbCloneBlocksWithWidgetData = ( blocks, widgetDataByClientId ) => {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -266,19 +266,26 @@
 
 		sowbMaybeSetupSiteEditorAssets();
 
-		// The preview-container 'a' click toggles React state in the parent
-		// component. Native DOM click events cross frame boundaries so this
-		// binding works from either context.
-		const $previewContainer = $mainForm.siblings( '.siteorigin-widget-preview' );
-		$previewContainer.find( '> a' ).on( 'click', function( event ) {
-			event.stopImmediatePropagation();
+		const bindBlockPreviewHandler = function() {
+			// sowSetupForm() binds the legacy widget preview modal handler. Direct
+			// widget blocks have their own React preview path, so take ownership of
+			// this link after setup and prevent the legacy form/iframe submit path
+			// from navigating the editor canvas.
+			$mainForm
+				.siblings( '.siteorigin-widget-preview' )
+				.find( '> a' )
+				.off( 'click' )
+				.on( 'click.sowbBlockPreview', function( event ) {
+					event.preventDefault();
+					event.stopImmediatePropagation();
 
-			setState( {
-				editing: false,
-				previewInitialized: false,
-				widgetPreviewHtml: false,
-			} );
-		} );
+					setState( {
+						editing: false,
+						previewInitialized: false,
+						widgetPreviewHtml: false,
+					} );
+				} );
+		};
 
 		$mainForm.data( 'backupDisabled', true );
 
@@ -292,6 +299,7 @@
 		}
 
 		$mainForm.sowSetupForm();
+		bindBlockPreviewHandler();
 
 		// Namespace the change event so multiple sowbSetupWidgetForm calls for
 		// the same block (React double-render / stale closures) don't stack up
@@ -642,7 +650,14 @@
 							ToolbarButton,
 							{
 								label: __( 'Preview widget.', 'so-widgets-bundle' ),
-								onClick: () => mergeState( { editing: false } ),
+								onClick: ( event ) => {
+									if ( event ) {
+										event.preventDefault();
+										event.stopPropagation();
+									}
+
+									mergeState( { editing: false } );
+								},
 								icon: 'visibility'
 							}
 						)
@@ -691,12 +706,19 @@
 							ToolbarButton,
 							{
 								label: __( 'Edit widget.', 'so-widgets-bundle' ),
-								onClick: () => mergeState( {
-									editing: true,
-									loadingForm: false,
-									widgetFormHtml: '',
-									formInitialized: false,
-								} ),
+								onClick: ( event ) => {
+									if ( event ) {
+										event.preventDefault();
+										event.stopPropagation();
+									}
+
+									mergeState( {
+										editing: true,
+										loadingForm: false,
+										widgetFormHtml: '',
+										formInitialized: false,
+									} );
+								},
 								icon: 'edit'
 							}
 						)

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1205,10 +1205,154 @@ const sowbGetBlockForm = ( clientId ) => {
 		.first();
 };
 
+const sowbIsDirectWidgetBlock = ( block ) => {
+	return block &&
+		typeof block.name === 'string' &&
+		block.name.indexOf( 'sowb/' ) === 0 &&
+		block.name !== 'sowb/widget-block' &&
+		block.isValid !== false;
+};
+
+const sowbFindDirectWidgetBlocks = ( blocks ) => {
+	return blocks.reduce( ( foundBlocks, block ) => {
+		if ( sowbIsDirectWidgetBlock( block ) ) {
+			foundBlocks.push( block );
+		}
+
+		if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+			foundBlocks.push( ...sowbFindDirectWidgetBlocks( block.innerBlocks ) );
+		}
+
+		return foundBlocks;
+	}, [] );
+};
+
+const sowbHasWidgetDataSnapshot = ( widgetData ) => {
+	return widgetData &&
+		typeof widgetData === 'object' &&
+		! Array.isArray( widgetData ) &&
+		Object.keys( widgetData ).length > 0;
+};
+
+const sowbGetBlockFormSnapshot = async ( $form ) => {
+	if ( ! $form || $form.length === 0 ) {
+		return null;
+	}
+
+	const formWindow = sowbGetElementWindow( $form[0] );
+	const formJQuery = formWindow.jQuery || jQuery;
+	const formForms = formWindow.sowbForms || sowbForms;
+	const $ownerForm = formJQuery( $form[0] );
+
+	if (
+		formForms &&
+		typeof formForms.getWidgetFormSnapshot === 'function'
+	) {
+		return await formForms.getWidgetFormSnapshot( $ownerForm, {
+			awaitAsync: true,
+			triggerChange: false,
+		} );
+	}
+
+	if (
+		formForms &&
+		typeof formForms.getWidgetFormValues === 'function'
+	) {
+		return formForms.getWidgetFormValues( $ownerForm );
+	}
+
+	return null;
+};
+
+const sowbCloneBlocksWithWidgetData = ( blocks, widgetDataByClientId ) => {
+	return blocks.map( ( block ) => {
+		const clonedBlock = {
+			...block,
+			attributes: {
+				...( block.attributes || {} ),
+			},
+			innerBlocks: block.innerBlocks ?
+				sowbCloneBlocksWithWidgetData( block.innerBlocks, widgetDataByClientId ) :
+				[],
+		};
+
+		if ( Object.prototype.hasOwnProperty.call( widgetDataByClientId, block.clientId ) ) {
+			clonedBlock.attributes.widgetData = widgetDataByClientId[ block.clientId ];
+		}
+
+		return clonedBlock;
+	} );
+};
+
+wp.hooks.addFilter(
+	'editor.preSavePost',
+	'sowb/direct-widget-block-save-bridge',
+	async function( edits ) {
+		const blockEditorSelect = wp.data.select( 'core/block-editor' );
+		const blocks = blockEditorSelect.getBlocks();
+		const directBlocks = sowbFindDirectWidgetBlocks( blocks );
+
+		if ( directBlocks.length === 0 ) {
+			return edits;
+		}
+
+		const widgetDataByClientId = {};
+
+		for ( const block of directBlocks ) {
+			const $form = sowbGetBlockForm( block.clientId );
+
+			if ( $form.length === 0 ) {
+				continue;
+			}
+
+			const widgetData = await sowbGetBlockFormSnapshot( $form );
+
+			if ( ! sowbHasWidgetDataSnapshot( widgetData ) ) {
+				continue;
+			}
+
+			widgetDataByClientId[ block.clientId ] = widgetData;
+		}
+
+		const clientIds = Object.keys( widgetDataByClientId );
+		if ( clientIds.length === 0 ) {
+			return edits;
+		}
+
+		const clonedBlocks = sowbCloneBlocksWithWidgetData( blocks, widgetDataByClientId );
+		const nextEdits = {
+			...( edits || {} ),
+			content: wp.blocks.serialize( clonedBlocks ),
+		};
+		const attrsByClientId = clientIds.reduce( ( attributes, clientId ) => {
+			attributes[ clientId ] = {
+				widgetData: widgetDataByClientId[ clientId ],
+			};
+
+			return attributes;
+		}, {} );
+		const blockEditorDispatch = wp.data.dispatch( 'core/block-editor' );
+
+		if (
+			blockEditorDispatch &&
+			typeof blockEditorDispatch.updateBlockAttributes === 'function'
+		) {
+			blockEditorDispatch.updateBlockAttributes(
+				clientIds,
+				attrsByClientId,
+				{ uniqueByBlock: true }
+			);
+		}
+
+		return nextEdits;
+	}
+);
+
 const sowbCanvasCloneElements = [
 	// WP Scripts and assets.
 	'#jquery-core-js',
 	'#jquery-migrate-js',
+	'#underscore-js',
 	'#editor-js-after',
 	'#wp-tinymce-js',
 	'#utils-js',

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -27,6 +27,8 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_widget_block_editor_assets' ) );
 
+		add_filter( 'siteorigin_panels_filter_content_enabled', array( $this, 'disable_panels_content_for_widget_blocks' ) );
+
 		add_action( 'wp_ajax_so_widgets_block_migration_notice_consent', array( $this, 'block_migration_consent' ) );
 	}
 
@@ -48,7 +50,110 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		foreach ( $post_types as $post_type ) {
 			add_action( 'rest_pre_insert_' . $post_type, array( $this, 'server_side_validation' ), 10, 2 );
+			add_action( 'rest_after_insert_' . $post_type, array( $this, 'clear_panels_data_for_widget_blocks' ), 10, 3 );
 		}
+	}
+
+	/**
+	 * Prevent stale Page Builder metadata from replacing block editor widget content.
+	 *
+	 * @param bool $enabled Whether SiteOrigin Panels should filter post content.
+	 *
+	 * @return bool
+	 */
+	public function disable_panels_content_for_widget_blocks( $enabled ) {
+		if ( ! $enabled || is_admin() ) {
+			return $enabled;
+		}
+
+		$post = get_post();
+
+		if (
+			empty( $post ) ||
+			empty( $post->post_content )
+		) {
+			return $enabled;
+		}
+
+		return $this->content_has_widget_blocks( $post->post_content ) ? false : $enabled;
+	}
+
+	/**
+	 * Clear stale Page Builder data when a REST save contains SOWB widget blocks.
+	 *
+	 * @param WP_Post         $post     Inserted or updated post object.
+	 * @param WP_REST_Request $request  REST request.
+	 * @param bool            $creating Whether this was a create request.
+	 *
+	 * @return void
+	 */
+	public function clear_panels_data_for_widget_blocks( $post, $request, $creating ) {
+		if (
+			empty( $post ) ||
+			! is_a( $post, 'WP_Post' ) ||
+			wp_is_post_revision( $post->ID ) ||
+			wp_is_post_autosave( $post->ID ) ||
+			empty( $post->post_content ) ||
+			! $this->content_has_widget_blocks( $post->post_content ) ||
+			! get_post_meta( $post->ID, 'panels_data', true )
+		) {
+			return;
+		}
+
+		delete_post_meta( $post->ID, 'panels_data' );
+	}
+
+	/**
+	 * Check whether serialized block content contains a SOWB widget block.
+	 *
+	 * @param string $content Serialized block content.
+	 *
+	 * @return bool
+	 */
+	private function content_has_widget_blocks( $content ) {
+		if (
+			empty( $content ) ||
+			! function_exists( 'parse_blocks' ) ||
+			(
+				function_exists( 'has_blocks' ) &&
+				! has_blocks( $content )
+			)
+		) {
+			return false;
+		}
+
+		return $this->blocks_have_widget_blocks( parse_blocks( $content ) );
+	}
+
+	/**
+	 * Recursively check parsed blocks for SOWB widget blocks.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 *
+	 * @return bool
+	 */
+	private function blocks_have_widget_blocks( $blocks ) {
+		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
+			return false;
+		}
+
+		foreach ( $blocks as $block ) {
+			if (
+				! empty( $block['blockName'] ) &&
+				strpos( $block['blockName'], 'sowb/' ) === 0
+			) {
+				return true;
+			}
+
+			if (
+				! empty( $block['innerBlocks'] ) &&
+				$this->blocks_have_widget_blocks( $block['innerBlocks'] )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/e2e/wb-form-field-site-editor.test.js
+++ b/tests/e2e/wb-form-field-site-editor.test.js
@@ -846,12 +846,37 @@ test(
 	'Test the Image Grid widget.',
 	async ( { page } ) => {
 		const {
+			admin,
 			offset,
 			widget
 		} = await testPrep(
 			page,
 			'sowb/siteorigin-widgets-imagegrid-widget'
 		);
+
+		const imagesRepeater = widget.locator( '.siteorigin-widget-field-images > .siteorigin-widget-field-repeater' );
+		const addImageButton = imagesRepeater.locator( '> .siteorigin-widget-field-repeater-add' );
+		await ensureElementVisible( addImageButton, offset );
+		await addImageButton.click();
+
+		const imageItems = imagesRepeater.locator( '> .siteorigin-widget-field-repeater-items > .siteorigin-widget-field-repeater-item' );
+		await expect( imageItems ).toHaveCount( 1 );
+
+		const firstImageItem = imageItems.first();
+		const firstImageTop = firstImageItem.locator( '> .siteorigin-widget-field-repeater-item-top' );
+		await ensureElementVisible( firstImageTop, offset );
+		await firstImageTop.click( { force: true } );
+
+		const firstImageMediaField = firstImageItem.locator( '.siteorigin-widget-field-image' );
+		const firstImageMediaButton = firstImageMediaField.locator( '.media-upload-button' );
+		await ensureElementVisible( firstImageMediaButton, offset );
+		await firstImageMediaButton.click( { force: true } );
+
+		await uploadImageToMediaLibrary( admin );
+
+		await expect(
+			firstImageMediaField.locator( '.siteorigin-widget-input[type="hidden"]:not(.media-fallback-external)' )
+		).toHaveValue( /.+/ );
 
 		const imagePaddingSetting = widget.locator( '.siteorigin-widget-field-padding' );
 		await ensureElementVisible( imagePaddingSetting, offset );


### PR DESCRIPTION
## Summary
- Prevent direct SiteOrigin widget blocks from using the legacy widget preview modal/form submit handler.
- Rebind the form preview link after `sowSetupForm()` so direct blocks switch through the React preview path instead of navigating the editor canvas.
- Snapshot live direct widget forms before switching to preview and during `editor.preSavePost`, so iframe form values persist through preview, save, and reload.
- Harden the shared widget form snapshot path, including async field flushing, TinyMCE editor-content reads, and TinyMCE selection bookmark cleanup.
- Stabilize Site Editor iframe form setup by cloning required assets once per form, waiting for setup dependencies, restoring iframe editor APIs, and avoiding duplicate script/handler execution.
- Keep TinyMCE Visual/Code switching and change propagation idempotent in the iframe.
- Strip the temporary `[SOWB DEBUG]` instrumentation from the final PR changes.

## Root Cause
In the iframed block editor, `sowSetupForm()` still binds the legacy widget preview handler to the widget form preview link. That legacy path creates/submits a hidden preview form into an iframe. In the direct block flow this can navigate the editor canvas and produce a nested editor/sidebar view instead of simply switching the block into preview mode.

The reload failure was a separate missing piece: this stack was based on Alex's iframe asset branch and did not include the direct block save bridge from `feature/wb-direct-block-save-bridge`. Without that bridge, the form could show current values and previews could read current values, but the post save could still serialize stale `widgetData`.

Saving after preview exposed another gap. Once the direct block switches out of edit mode, the widget form is unmounted, so the save bridge has no live form to snapshot. The preview transition now snapshots the live form into block attributes before unmounting it.

The Site Editor iframe added timing and ownership issues: widget form scripts and TinyMCE dependencies can be present in the parent window before they are usable in the iframe, and cloned scripts can re-run if setup is retried. The form setup path now waits for the iframe-owned jQuery/plugins/editor APIs it needs and guards duplicate setup.

TinyMCE can also leave `mce_SELRES_*` bookmark spans in editor content while preserving selection. The direct widget block save path was reading editor/textarea content directly, so those internal bookmarks could be serialized into widget data. The cleanup now happens in the shared admin snapshot/value path.

## Validation
- Browser retest covered opening/editing a direct widget block in the Site Editor iframe, TinyMCE initialization, Visual/Code switching, preview generation, and save snapshot behavior.
- Confirmed the patched build no longer triggers the nested-editor/sidebar reload.
- Confirmed TinyMCE content is captured from the live editor during snapshot/save.
- Confirmed duplicate TinyMCE change events no longer cause repeated unchanged widget-data updates.
- Confirmed temporary `[SOWB DEBUG]` instrumentation is removed from the edited JS files.
- Remaining observed console noise is unrelated to this PR: the FitText jQuery Migrate load warning and WordPress iframe stylesheet enqueue warnings.
- `node --check compat/block-editor/widget-block.js`
- `node --check base/js/admin.js`
- `node --check base/inc/fields/js/tinymce-field.js`
- `git diff --check`
- Debug string scan across the three edited JS files returned no matches.

GitHub currently reports no checks for this branch.