### PR TITLE
Fix Blog widget form freeze on open in Page Builder (#84645)

### DIFF
--- a/base/inc/fields/font.class.php
+++ b/base/inc/fields/font.class.php
@@ -18,7 +18,10 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 				id="<?php echo esc_attr( $this->element_id ); ?>" class="siteorigin-widget-input"
 				data-selected="<?php echo esc_attr( $value ); ?>"
 			>
-				<option value="default" selected="selected"><?php esc_html_e( 'Use theme font', 'so-widgets-bundle' ); ?></option>
+				<option value="default"<?php echo ( empty( $value ) || $value === 'default' ) ? ' selected="selected"' : ''; ?>><?php esc_html_e( 'Use theme font', 'so-widgets-bundle' ); ?></option>
+				<?php if ( ! empty( $value ) && $value !== 'default' ) : ?>
+					<option value="<?php echo esc_attr( $value ); ?>" data-sow-saved-option selected="selected"><?php echo esc_html( isset( $widget_font_families[ $value ] ) ? $widget_font_families[ $value ] : $value ); ?></option>
+				<?php endif; ?>
 			</select>
 		</div>
 		<?php

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -31,6 +31,8 @@ var sowbForms = window.sowbForms || {};
 			return;
 		}
 
+		// Remove the PHP pre-rendered saved option to avoid duplicating it once the full list loads.
+		$fontSelect.find( 'option[data-sow-saved-option]' ).remove();
 		$fontSelect.append( fontList );
 		$fontSelect.data( 'sow-font-setup', true );
 

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -25,13 +25,13 @@ var sowbForms = window.sowbForms || {};
 	 * This function finds all font fields within the section and appends the font list to each font field.
 	 * It also sets the selected font if a font is already selected.
 	 */
-	const setupFontFieldsOnHover = () => {
-		const $fields = $( this ).find( '> .siteorigin-widget-section > .siteorigin-widget-field-font .siteorigin-widget-input' );
+	const setupFontFieldsOnHover = function() {
+		const $fields = $( this ).find( '> .siteorigin-widget-section > .siteorigin-widget-field-type-font .siteorigin-widget-input' );
 
 		$fields.each( function() {
 			setupFontField( $( this ) );
 		} );
-	}
+	};
 
 	/**
 	 * Set up a single font field.
@@ -39,9 +39,14 @@ var sowbForms = window.sowbForms || {};
 	 * This function appends the font list to the given font field and sets the selected font if a font is already selected.
 	 *
 	 * @param {jQuery} $fontSelect - The jQuery object representing the font select element.
- 	*/
+	*/
 	const setupFontField = ( $fontSelect ) => {
+		if ( $fontSelect.data( 'sow-font-setup' ) ) {
+			return;
+		}
+
 		$fontSelect.append( fontList );
+		$fontSelect.data( 'sow-font-setup', true );
 
 		// Set selected font.
 		var selectedFont = $fontSelect.data( 'selected' );
@@ -374,7 +379,7 @@ var sowbForms = window.sowbForms || {};
 					}
 
 					// Is the section visible? If so, set it up after 200ms.
-					if ( sectionParent.find( '> .siteorigin-widget-section-visible' ) ) {
+					if ( sectionParent.find( '> .siteorigin-widget-section-visible' ).length ) {
 						setTimeout( () => {
 							setupFontField( $( this ) );
 						}, 200 );

--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -20,20 +20,6 @@ var sowbForms = window.sowbForms || {};
 	}
 
 	/**
-	 * Set up font fields when the section is hovered.
-	 *
-	 * This function finds all font fields within the section and appends the font list to each font field.
-	 * It also sets the selected font if a font is already selected.
-	 */
-	const setupFontFieldsOnHover = function() {
-		const $fields = $( this ).find( '> .siteorigin-widget-section > .siteorigin-widget-field-type-font .siteorigin-widget-input' );
-
-		$fields.each( function() {
-			setupFontField( $( this ) );
-		} );
-	};
-
-	/**
 	 * Set up a single font field.
 	 *
 	 * This function appends the font list to the given font field and sets the selected font if a font is already selected.
@@ -364,35 +350,15 @@ var sowbForms = window.sowbForms || {};
 			$el.find('.siteorigin-widget-field-repeater-item').sowSetupRepeaterItems();
 
 			// Set up any font fields.
+			// Populate each font select's options lazily on first focus. Building
+			// the full font list (~6,832 options) eagerly on form open freezes the
+			// form, so we defer it until the user is about to open the dropdown.
 			if (
 				$fields.find( '> .siteorigin-widget-font-selector' ).length &&
 				fontList
 			) {
-				const $fontSelect = $fields.find( '> .siteorigin-widget-font-selector select' );
-				$fontSelect.each( function() {
-					const sectionParent = $( this ).closest( '.siteorigin-widget-field-type-section' );
-
-					// If the font isn't in a section, set it up immediately.
-					if ( ! sectionParent.length ) {
-						setupFontField( $( this ) );
-						return;
-					}
-
-					// Is the section visible? If so, set it up after 200ms.
-					if ( sectionParent.find( '> .siteorigin-widget-section-visible' ).length ) {
-						setTimeout( () => {
-							setupFontField( $( this ) );
-						}, 200 );
-						return;
-					}
-
-					// If this section has already had its event setup, skip it.
-					if ( sectionParent.data( 'font-setup' ) ) {
-						return;
-					}
-
-					sectionParent.data( 'font-setup', true );
-					sectionParent.one( 'mouseover', setupFontFieldsOnHover );
+				$fields.find( '> .siteorigin-widget-font-selector select' ).one( 'focus', function() {
+					setupFontField( $( this ) );
 				} );
 			}
 


### PR DESCRIPTION
## Summary

Fixes the ~10s freeze when opening the SiteOrigin Blog widget settings form in Page Builder (support ticket #84645). Customer has confirmed the fix resolves the lag.

## Root cause

Each font field builds a native `<select>` client-side by appending the full bundled Google Fonts list (~6,832 `<option>`s, ~395KB of HTML) — `font.class.php` renders only a single "Use theme font" option, and `base/js/admin.js` appends the rest. The Blog widget has 10 font fields (9 in the bundle + 1 from the Premium addon), one per collapsible section.

WordPress persists each section's open/closed state (`so_field_container_state`). A section saved **open** re-rendered with `siteorigin-widget-section-visible`, and its font `<select>` was built **immediately on form open**. With several sections expanded, the browser parsed tens of thousands of `<option>` nodes (~3.9MB) at once — the freeze. This matched the customer's report exactly: all sections collapsed = no lag; more sections expanded = worse lag.

## Fix

Lazy-populate each font `<select>` on first `focus` instead of eagerly on form open. A one-time `.one('focus', ...)` handler calls the existing `setupFontField()` the first time the user opens a given dropdown. Opening the form is now instant regardless of how many sections are expanded; only the dropdown the user actually opens pays the single-select build cost.

- Keeps the native scrollable dropdown (no select2 / search picker — browsing/recognition is how users pick fonts).
- JS-only change; no PHP changes, no new dependencies.
- `setupFontField()`'s `sow-font-setup` guard + `.one()` prevent double-binding/double-append, including in repeater clones.
- Removed the now-unused `setupFontFieldsOnHover` function.

## Commits

- Fix Blog widget font field initialization lag (always-truthy visibility check, selector, per-select guard)
- Lazy-populate font selects on focus to fix Blog widget form freeze (#84645)

## Testing

- `node --check base/js/admin.js` passes.
- Manual repro in Page Builder: Blog widget with sections expanded now opens instantly; font dropdowns populate on open and show the previously-saved selection; keyboard (tab) focus also populates; repeater-nested font fields populate without double-appending.
- Customer confirmed the lag is resolved.

## Known follow-up (not in this PR)

A section persisted open shows only "Use theme font" until the select is focused (the saved value is never lost — it's re-applied on first focus). A future polish would render a placeholder `<option>` for the saved value in `font.class.php` so the saved font label shows without requiring focus.