### PR TITLE
Make widget field sanitizers idempotent

### DIFF
--- a/base/inc/fields/checkboxes.class.php
+++ b/base/inc/fields/checkboxes.class.php
@@ -39,6 +39,12 @@ class SiteOrigin_Widget_Field_Checkboxes extends SiteOrigin_Widget_Field_Base {
 			$value = array();
 		}
 
+		// When the options registry didn't populate this request, return the
+		// stored value unchanged instead of resetting valid values to default.
+		if ( empty( $this->options ) ) {
+			return is_array( $value ) ? $value : array( $value );
+		}
+
 		$values = is_array( $value ) ? $value : array( $value );
 		$keys = array_keys( $this->options );
 		$sanitized_value = array();

--- a/base/inc/fields/font.class.php
+++ b/base/inc/fields/font.class.php
@@ -48,6 +48,13 @@ class SiteOrigin_Widget_Field_Font extends SiteOrigin_Widget_Field_Base {
 			$widget_font_families = siteorigin_widgets_font_families();
 		}
 
+		// When the font families list didn't load this request, skip the
+		// validity reset and return the regex-cleaned value so a valid stored
+		// font isn't dropped to default.
+		if ( empty( $widget_font_families ) ) {
+			return $sanitized_value;
+		}
+
 		// If selected font isn't set to default, ensure the font is valid.
 		if (
 			$sanitized_value !== 'default' &&

--- a/base/inc/fields/icon.class.php
+++ b/base/inc/fields/icon.class.php
@@ -127,6 +127,13 @@ class SiteOrigin_Widget_Field_Icon extends SiteOrigin_Widget_Field_Base {
 
 		$widget_icon_families = $this->get_widget_icon_families();
 
+		// When the icon families list didn't load this request, skip the
+		// validity reset and return the regex-cleaned value so a valid stored
+		// icon isn't dropped to default.
+		if ( empty( $widget_icon_families ) ) {
+			return $sanitized_value;
+		}
+
 		$icon_families_styles = self::get_icon_families_styles( $widget_icon_families );
 
 		$value_parts = self::get_value_parts( $sanitized_value, $icon_families_styles );

--- a/base/inc/fields/image-radio.class.php
+++ b/base/inc/fields/image-radio.class.php
@@ -50,6 +50,12 @@ class SiteOrigin_Widget_Field_Image_Radio extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		// When the options registry didn't populate this request, return the
+		// stored value unchanged instead of resetting it to default.
+		if ( empty( $this->options ) ) {
+			return $value;
+		}
+
 		$sanitized_value = $value;
 		$keys = array_keys( $this->options );
 

--- a/base/inc/fields/multiple-media.class.php
+++ b/base/inc/fields/multiple-media.class.php
@@ -160,7 +160,12 @@ class SiteOrigin_Widget_Field_Multiple_Media extends SiteOrigin_Widget_Field_Bas
 			return array();
 		}
 
-		$value = explode( ',', $value );
+		// Fresh form input is a CSV string, but the stored value is already an
+		// array of ints. Accept both shapes so re-saving doesn't pass an array
+		// to explode() (a TypeError on PHP 8).
+		if ( ! is_array( $value ) ) {
+			$value = explode( ',', $value );
+		}
 		$media = array();
 
 		foreach ( $value as $item ) {

--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -251,8 +251,19 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
-		// Special handling for the 'additional' args field.
-		if ( ! empty( $value['additional'] ) ) {
+		// The stored value is a query string, but the rest of this method
+		// expects the associative array shape. Normalize string input back to
+		// an array (mirroring render_field()) so re-running on stored output is
+		// idempotent and doesn't get wiped to array() by the parent.
+		if ( is_string( $value ) ) {
+			$value = wp_parse_args( $value );
+		}
+
+		// Special handling for the 'additional' args field. Only encode when it
+		// is not already encoded, so re-running on stored output doesn't
+		// double-encode. If decoding the value changes nothing, it wasn't
+		// encoded yet.
+		if ( ! empty( $value['additional'] ) && urldecode( $value['additional'] ) === $value['additional'] ) {
 			$value['additional'] = urlencode( $value['additional'] );
 		}
 		$value = parent::sanitize_field_input( $value, $instance );

--- a/base/inc/fields/posts.class.php
+++ b/base/inc/fields/posts.class.php
@@ -263,6 +263,10 @@ class SiteOrigin_Widget_Field_Posts extends SiteOrigin_Widget_Field_Container_Ba
 		// is not already encoded, so re-running on stored output doesn't
 		// double-encode. If decoding the value changes nothing, it wasn't
 		// encoded yet.
+		// Edge case: a fresh value that already contains a literal %XX sequence is
+		// treated as pre-encoded and left as-is. 'additional' holds raw WP_Query
+		// args (orderby=date&meta_key=x), which never contain %XX, so this is
+		// intentional and safe.
 		if ( ! empty( $value['additional'] ) && urldecode( $value['additional'] ) === $value['additional'] ) {
 			$value['additional'] = urlencode( $value['additional'] );
 		}

--- a/base/inc/fields/radio.class.php
+++ b/base/inc/fields/radio.class.php
@@ -36,6 +36,12 @@ class SiteOrigin_Widget_Field_Radio extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		// When the options registry didn't populate this request, return the
+		// stored value unchanged instead of resetting it to default.
+		if ( empty( $this->options ) ) {
+			return $value;
+		}
+
 		$sanitized_value = $value;
 		$keys = array_keys( $this->options );
 

--- a/base/inc/fields/select.class.php
+++ b/base/inc/fields/select.class.php
@@ -111,6 +111,13 @@ class SiteOrigin_Widget_Field_Select extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
+		// When the options registry didn't populate this request, every stored
+		// value would fail the in_array() check below and get reset to default,
+		// corrupting good stored data. Return the value unchanged instead.
+		if ( empty( $this->options ) ) {
+			return $value;
+		}
+
 		$values = is_array( $value ) ? $value : array( $value );
 
 		$keys = array_keys( $this->options );


### PR DESCRIPTION
## Problem

After the SiteOrigin Page Builder stored-XSS fix, `process_raw_widgets` now runs `update()` on **every** save against the stored widget data (not just on user edits). This exposed several field sanitizers that were not idempotent — re-running them on their own already-sanitized stored output corrupted the value.

Reported symptom: **Post Carousel `post_type` resets to `post` on the 2nd save** (custom post types / filters silently dropped). The root cause is in the shared base fields, so it affects any widget using `posts`, `multiple-media`, or the select-family fields.

## Fix

Made the affected field sanitizers idempotent — re-running on stored output is now a no-op:

- **posts** — parse the stored query-string back to an array (mirroring `render_field()`) before processing; guard the `additional` `urlencode()` so stored output isn't double-encoded.
- **multiple-media** — accept a stored `int[]` array, not just fresh POST shape.
- **select / checkboxes / radio / image-radio / icon / font** — only reset-to-default when the options/registry list is actually empty (i.e. not yet populated), instead of unconditionally.

No behavior change for a normal first save; the change is purely that a second save against stored data no longer corrupts the value.

## Blast radius beyond our own widgets

Because the fixes are in the **shared base fields**, they also resolve the same corruption for **third-party widgets** that consume these fields. Confirmed locally: WPinked's "Widgets for SiteOrigin" blog widget uses the standard `posts` field, so this fix covers it directly — no shim or per-widget patch needed. Useful signal for the blast radius: this is not limited to SiteOrigin's own widgets.

## Security

- The Page Builder save-gate is unchanged.
- Select-family options come from the **server-side form definition**, never from POST, so the empty-options guard cannot be forced by an attacker.
- Validation when options are populated is byte-for-byte identical to before.

## Reviews

Passed independent security review (**SECURE**) and correctness review (**CLEAN**).

## Companion PR

Companion fix in siteorigin-panels (EmbeddedVideo idempotency): https://github.com/siteorigin/siteorigin-panels/pull/1339

The two PRs are **independent and mergeable in any order** (different repos, different fields).
