### PR TITLE
Contribute sowb sanitize version to siteorigin_panels_sanitize_version filter

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -54,6 +54,30 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 		if ( function_exists( 'WC' ) ) {
 			add_filter( 'woocommerce_format_content', array( $this, 'woocommerce_shop_page_content' ), 10, 2 );
 		}
+
+		// Contribute this plugin's field-sanitization semantics version to
+		// Page Builder's Layout Block trust-signature scheme, so a signature
+		// computed before a security-relevant tightening of our own field
+		// sanitizers is correctly treated as stale. Registered unconditionally:
+		// apply_filters() on a filter tag that Page Builder never triggers
+		// (e.g. Page Builder inactive) is a harmless no-op, matching this
+		// plugin's existing pattern for other 'siteorigin_panels_*' filters
+		// (see so-widgets-bundle.php and base/inc/shortcode.php).
+		add_filter( 'siteorigin_panels_sanitize_version', array( $this, 'add_sanitize_version_signal' ) );
+	}
+
+	/**
+	 * Append this plugin's own field-sanitization semantics version to
+	 * Page Builder's composed 'siteorigin_panels_sanitize_version' filter
+	 * value, so its Layout Block trust-signature scheme can detect when
+	 * this plugin's sanitization rules have materially tightened.
+	 *
+	 * @param string $version
+	 *
+	 * @return string
+	 */
+	public function add_sanitize_version_signal( $version ) {
+		return $version . ';sowb:' . SOW_SANITIZE_VERSION;
 	}
 
 	public function get_active_builder() {

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -15,6 +15,35 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.txt
 define( 'SOW_BUNDLE_VERSION', 'dev' );
 define( 'SOW_BUNDLE_BASE_FILE', __FILE__ );
 
+/**
+ * Version identifier for this plugin's field-sanitization SEMANTICS —
+ * i.e. what content a sanitizer allows through, not its code/bugfix
+ * history. Consumed by siteorigin-panels' Layout Block trust-signature
+ * scheme (see so-widgets-bundle's contribution to the
+ * `siteorigin_panels_sanitize_version` filter, in
+ * compat/compat.php) so a stale save-time signature can be detected
+ * and invalidated when this plugin's sanitization rules materially
+ * tighten.
+ *
+ * Bump this value ONLY when a field/widget sanitizer becomes MORE
+ * RESTRICTIVE in a security-relevant way (e.g. a previously-unfiltered
+ * field starts running wp_kses_post(), or a bypass is closed).
+ *
+ * NEVER bump it for idempotency fixes, bugfixes, or any behavior change
+ * that does not affect what content is allowed through.
+ *
+ * Bumping this invalidates EVERY existing siteorigin-panels Layout
+ * Block trust signature site-wide, with NO bulk remediation path: each
+ * affected post must be individually re-saved by its own author to
+ * regain trusted-render status (capability-gated sanitization is only
+ * meaningful under the real author's session, so there is no safe way
+ * to batch/cron re-sign on their behalf). This is an accepted,
+ * intentionally expensive cost for genuine security tightening — do
+ * not bump casually, and do not bump for anything covered by the
+ * "never" list above.
+ */
+define( 'SOW_SANITIZE_VERSION', '1' );
+
 // Allow JS suffix to be pre-set.
 if ( ! defined( 'SOW_BUNDLE_JS_SUFFIX' ) ) {
 	define( 'SOW_BUNDLE_JS_SUFFIX', '' );


### PR DESCRIPTION
## Summary
* Defines `SOW_SANITIZE_VERSION` ('1'), bumped only for security-tightening sanitization changes, never for bugfixes/idempotency work.
* Contributes `;sowb:<version>` to the `siteorigin_panels_sanitize_version` filter (`compat/compat.php`), unconditionally — matches this codebase's existing pattern for `siteorigin_panels_*` filters (no `class_exists` guard needed; `apply_filters` on an unused tag is a no-op when panels isn't active).

## Why (context from the companion panels PR)
`siteorigin-panels` is introducing an HMAC "trust-on-write" signature scheme for its Block Editor Layout Block (see companion PR: siteorigin/siteorigin-panels#TBD, branch `feature/layout-block-render-trust-signature`). Layouts routinely contain widgets from this plugin, so the signature's version component needs a channel for sowb to signal when ITS sanitization rules materially tighten — otherwise a stale signature could keep trusting content sanitized under old sowb rules forever.

## ⚠️ Release-order dependency — please read before merging
This PR should merge and release **before or together with** the panels release that starts signing (i.e. panels PR siteorigin/siteorigin-panels#TBD). If panels starts signing under `panels:1` first and sites pick up this sowb filter later, every existing signature on that site is invalidated the moment sowb updates (fail-closed — no vulnerability — but the blank-embed symptom the panels fix exists to solve will resurface until each affected post is individually re-saved by its author). Same effect if Widgets Bundle is ever deactivated/reactivated on a site that has this filter active — expected, not a bug, but worth knowing if it comes up in support.

## Human QA checklist (please run through before merging)
- [ ] Confirm `SOW_SANITIZE_VERSION` is defined once, not overridable via `wp-config.php` (intentional — matches this file's existing constant convention)
- [ ] In the Block Editor, add a Layout Block containing at least one sowb widget (e.g. Button or Post Carousel) to a test post, save, confirm no PHP notices/warnings in debug log
- [ ] Confirm `add_filter( 'siteorigin_panels_sanitize_version', ... )` fires only when relevant (spot-check with panels active vs. deactivated — no fatal either way)
- [ ] Confirm this repo's `docs/plans/current.md` is NOT part of this diff (plan files are a workspace artifact, never committed)

## Test plan
- [x] `php -l` clean on both changed files
- [x] Pipeline reviewer: APPROVE
- [ ] Merge coordination: hold until ready to release with or ahead of the panels PR (see dependency note above)