### PR TITLE
Fields: Neutral sanitization floor for registry-empty choice fields

### DIFF
--- a/base/inc/fields/base.class.php
+++ b/base/inc/fields/base.class.php
@@ -41,6 +41,23 @@ abstract class SiteOrigin_Widget_Field_Base {
 	 * @var array
 	 */
 	protected $javascript_variables;
+	/**
+	 * The value this field held in the previously-persisted widget
+	 * instance, for the CURRENT sanitize() call only. Set immediately
+	 * before sanitize_field_input() is invoked, so subclasses that need to
+	 * distinguish "value unchanged from what's already stored" from "value
+	 * changed" (e.g. when their own options/families registry is empty on
+	 * this request and they cannot validate against it) can read it
+	 * without widening the abstract sanitize_field_input( $value, $instance )
+	 * signature across all field subclasses. Null when unavailable (e.g.
+	 * this field is nested inside a repeater/tabs/section container, whose
+	 * SiteOrigin_Widget_Field_Container_Base::sanitize_field_input() does
+	 * not have a per-sub-field old value to pass through) — treat null as
+	 * "old value not reliably known", never as "old value is null".
+	 *
+	 * @var mixed
+	 */
+	protected $old_value;
 
 	/* ============================================================================================================== */
 	/* BASE FIELD CONFIGURATION PROPERTIES                                                                            */
@@ -352,6 +369,7 @@ abstract class SiteOrigin_Widget_Field_Base {
 			return '';
 		}
 
+		$this->old_value = $old_value;
 		$value = $this->sanitize_field_input( $value, $instance );
 
 		if ( isset( $this->sanitize ) && ! empty( $value ) ) {

--- a/base/inc/fields/checkboxes.class.php
+++ b/base/inc/fields/checkboxes.class.php
@@ -39,10 +39,21 @@ class SiteOrigin_Widget_Field_Checkboxes extends SiteOrigin_Widget_Field_Base {
 			$value = array();
 		}
 
-		// When the options registry didn't populate this request, return the
-		// stored value unchanged instead of resetting valid values to default.
+		// When the options registry didn't populate this request, don't reset
+		// valid stored values to default.
 		if ( empty( $this->options ) ) {
-			return is_array( $value ) ? $value : array( $value );
+			// See select.class.php::sanitize_field_input() for full reasoning
+			// (same registry-empty gap, same fix). Checkboxes values are
+			// always an array (checkbox group) — preserve the existing
+			// scalar-to-array coercion for the untouched-resave path, and
+			// sanitize each element for the changed-value path.
+			$normalized_value = is_array( $value ) ? $value : array( $value );
+
+			if ( $normalized_value === $this->old_value ) {
+				return $normalized_value;
+			}
+
+			return array_map( 'sanitize_text_field', $normalized_value );
 		}
 
 		$values = is_array( $value ) ? $value : array( $value );

--- a/base/inc/fields/image-radio.class.php
+++ b/base/inc/fields/image-radio.class.php
@@ -50,10 +50,17 @@ class SiteOrigin_Widget_Field_Image_Radio extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
-		// When the options registry didn't populate this request, return the
-		// stored value unchanged instead of resetting it to default.
+		// When the options registry didn't populate this request, don't reset
+		// the stored value to default.
 		if ( empty( $this->options ) ) {
-			return $value;
+			// See select.class.php::sanitize_field_input() for full reasoning
+			// (same registry-empty gap, same fix). Image-radio values are
+			// always scalar (single selection, matched against an option key).
+			if ( $value === $this->old_value ) {
+				return $value;
+			}
+
+			return sanitize_text_field( $value );
 		}
 
 		$sanitized_value = $value;

--- a/base/inc/fields/radio.class.php
+++ b/base/inc/fields/radio.class.php
@@ -36,10 +36,17 @@ class SiteOrigin_Widget_Field_Radio extends SiteOrigin_Widget_Field_Base {
 	}
 
 	protected function sanitize_field_input( $value, $instance ) {
-		// When the options registry didn't populate this request, return the
-		// stored value unchanged instead of resetting it to default.
+		// When the options registry didn't populate this request, don't reset
+		// the stored value to default.
 		if ( empty( $this->options ) ) {
-			return $value;
+			// See select.class.php::sanitize_field_input() for full reasoning
+			// (same registry-empty gap, same fix). Radio values are always
+			// scalar (single selection).
+			if ( $value === $this->old_value ) {
+				return $value;
+			}
+
+			return sanitize_text_field( $value );
 		}
 
 		$sanitized_value = $value;

--- a/base/inc/fields/select.class.php
+++ b/base/inc/fields/select.class.php
@@ -115,15 +115,20 @@ class SiteOrigin_Widget_Field_Select extends SiteOrigin_Widget_Field_Base {
 		// value would fail the in_array() check below and get reset to default,
 		// corrupting good stored data.
 		if ( empty( $this->options ) ) {
-			// Can't validate against the registry this request. If this is an
-			// untouched re-save (new value matches what's already stored, or
-			// old value isn't reliably known because this field is nested in a
-			// container), pass through unchanged to avoid re-running
-			// sanitizers on their own stored output. Otherwise the value has
-			// genuinely changed and must not bypass sanitization entirely —
-			// apply a neutral floor. sanitize_text_field() (not sanitize_key())
-			// is required here: real stored option keys in this codebase
-			// include dotted-decimal strings (e.g. '0.5', '1.33' in
+			// Can't validate against the registry this request. Only pass
+			// through unchanged when the new value is CONFIRMED equal to
+			// what's already stored ($this->old_value) — an untouched
+			// re-save, where skipping sanitization avoids re-running
+			// sanitizers on their own stored output. Any other case —
+			// including a genuinely changed value, or the old value not
+			// being reliably known at all (e.g. this field is nested inside
+			// a container, where $this->old_value is always null) — falls
+			// through to the neutral sanitize_text_field() floor below.
+			// Treating "unknown" the same as "unchanged" would reopen the
+			// unsanitized-pass-through bypass this branch exists to close.
+			// sanitize_text_field() (not sanitize_key()) is required here:
+			// real stored option keys in this codebase include
+			// dotted-decimal strings (e.g. '0.5', '1.33' in
 			// widgets/social-media-buttons/social-media-buttons.php) that
 			// sanitize_key() would corrupt by stripping the '.'.
 			if ( $value === $this->old_value ) {

--- a/base/inc/fields/select.class.php
+++ b/base/inc/fields/select.class.php
@@ -113,9 +113,26 @@ class SiteOrigin_Widget_Field_Select extends SiteOrigin_Widget_Field_Base {
 	protected function sanitize_field_input( $value, $instance ) {
 		// When the options registry didn't populate this request, every stored
 		// value would fail the in_array() check below and get reset to default,
-		// corrupting good stored data. Return the value unchanged instead.
+		// corrupting good stored data.
 		if ( empty( $this->options ) ) {
-			return $value;
+			// Can't validate against the registry this request. If this is an
+			// untouched re-save (new value matches what's already stored, or
+			// old value isn't reliably known because this field is nested in a
+			// container), pass through unchanged to avoid re-running
+			// sanitizers on their own stored output. Otherwise the value has
+			// genuinely changed and must not bypass sanitization entirely —
+			// apply a neutral floor. sanitize_text_field() (not sanitize_key())
+			// is required here: real stored option keys in this codebase
+			// include dotted-decimal strings (e.g. '0.5', '1.33' in
+			// widgets/social-media-buttons/social-media-buttons.php) that
+			// sanitize_key() would corrupt by stripping the '.'.
+			if ( $value === $this->old_value ) {
+				return $value;
+			}
+
+			return is_array( $value )
+				? array_map( 'sanitize_text_field', $value )
+				: sanitize_text_field( $value );
 		}
 
 		$values = is_array( $value ) ? $value : array( $value );


### PR DESCRIPTION
## Summary

Closes the gap (follow-up to #2316) where `select`, `radio`, `image-radio`, and `checkboxes` fields returned a **changed**, attacker-controllable value completely unsanitized whenever their options registry was empty on a given request (e.g. REST save contexts where the options-populating filter never ran).

### Approach
- New protected `$old_value` property on `SiteOrigin_Widget_Field_Base`, set by `sanitize()` from its existing 3rd parameter immediately before `sanitize_field_input()` runs — no change to the abstract method signature across the 27 field subclasses.
- In each of the 4 choice-type fields, the registry-empty guard now passes the value through unchanged **only** when it strictly matches the previously stored value (untouched re-save — preserving #2316's idempotency fix). Any changed value, or a value whose old state isn't reliably known (container-nested fields), gets a neutral `sanitize_text_field()` floor instead of a bare pass-through.
- `sanitize_text_field()` (not `sanitize_key()`) is used because real production option keys include dotted-decimal strings (e.g. `'0.5'` in the Social Media Buttons widget) that `sanitize_key()` would corrupt.
- `icon`/`font` fields need no change — they already apply an unconditional regex floor before their registry-empty check.

### Template escaping audit
All 40 `widgets/*/tpl/*.php` + `base/inc/widgets/tpl/*.php` files were audited for select/radio/icon/font/checkboxes values echoed without escaping: **zero in-scope findings** (two adjacent out-of-scope observations documented for a future pass).

### Verification
- `php -l` clean on all touched files.
- Functional trace (19 assertions): untouched re-save passes through with zero sanitizer calls; changed `<script>` payloads are stripped; container-nested fields always sanitize; the populated-registry allow-list path is byte-identical.

Reviewed and approved via the plan pipeline.