### PR TITLE
Fields: Strip unvalidated widget-instance keys + template escaping hardening

### DIFF
--- a/base/inc/fields/base.class.php
+++ b/base/inc/fields/base.class.php
@@ -476,6 +476,24 @@ abstract class SiteOrigin_Widget_Field_Base {
 	}
 
 	/**
+	 * Some field types write to one or more companion instance keys that
+	 * are siblings of, but not equal to, their own $field_name — e.g. a
+	 * media field's fallback URL or a tinymce field's selected-editor
+	 * mode. These keys are never declared in get_widget_form()'s
+	 * $form_options, so update_fields() / Container_Base's unknown-key
+	 * strip (see sanitize_field_input()) cannot recognize them as
+	 * legitimate through the form_options allowlist alone. Override this
+	 * method to return the exact sibling key name(s) this field instance
+	 * owns, so the strip can allowlist them too. Returns an empty array
+	 * by default (most fields have none).
+	 *
+	 * @return string[]
+	 */
+	public function get_related_instance_keys() {
+		return array();
+	}
+
+	/**
 	 * Occasionally it is necessary for a field to set a variable to be used in the front end. Override this function
 	 * and set any necessary values on the `javascript_variables` instance property.
 	 *

--- a/base/inc/fields/container-base.class.php
+++ b/base/inc/fields/container-base.class.php
@@ -102,6 +102,8 @@ abstract class SiteOrigin_Widget_Field_Container_Base extends SiteOrigin_Widget_
 		/* @var $field_factory SiteOrigin_Widget_Field_Factory */
 		$field_factory = SiteOrigin_Widget_Field_Factory::single();
 
+		$known_keys = array_keys( $this->fields );
+
 		foreach ( $this->fields as $sub_field_name => $sub_field_options ) {
 			/* @var $sub_field SiteOrigin_Widget_Field_Base */
 			if ( ! empty( $this->sub_fields ) && ! empty( $this->sub_fields[$sub_field_name] ) ) {
@@ -116,7 +118,23 @@ abstract class SiteOrigin_Widget_Field_Container_Base extends SiteOrigin_Widget_
 			}
 			$value[$sub_field_name] = $sub_field->sanitize( isset( $value[$sub_field_name] ) ? $value[$sub_field_name] : null, $value );
 			$value = $sub_field->sanitize_instance( $value );
+
+			// Collect companion keys from the sub-field instance actually
+			// used for this row. This must happen inside the loop:
+			// $this->sub_fields is only populated by the render path
+			// (create_and_render_sub_fields()), so on a save-only request
+			// the instances created above never enter that cache and a
+			// post-loop scan of $this->sub_fields would miss them.
+			$known_keys = array_merge( $known_keys, $sub_field->get_related_instance_keys() );
 		}
+
+		// See SiteOrigin_Widget::update_fields() for the top-level
+		// equivalent and full reasoning. Strip any sibling key in this
+		// row/section that isn't a declared sub-field, a sub-field-declared
+		// companion key, or the container's own state-tracking key.
+		$known_keys[] = 'so_field_container_state';
+
+		$value = array_intersect_key( $value, array_flip( $known_keys ) );
 
 		return $value;
 	}

--- a/base/inc/fields/container-base.class.php
+++ b/base/inc/fields/container-base.class.php
@@ -99,6 +99,20 @@ abstract class SiteOrigin_Widget_Field_Container_Base extends SiteOrigin_Widget_
 		if ( ! is_array( $value ) ) {
 			return array();
 		}
+
+		// A container can legitimately reach sanitization with no declared
+		// sub-fields — e.g. a 'widget' field whose sub-widget class isn't
+		// available this request (that widget deactivated in SOWB), or a
+		// section declared without a 'fields' key. There is nothing to
+		// sanitize against and nothing to allowlist, so preserve the value
+		// as-is — matching this method's pre-strip degenerate behavior —
+		// rather than wiping a full sub-widget instance whose class is
+		// temporarily unavailable. Also avoids a PHP 8 TypeError from
+		// array_keys( null ) below.
+		if ( empty( $this->fields ) || ! is_array( $this->fields ) ) {
+			return $value;
+		}
+
 		/* @var $field_factory SiteOrigin_Widget_Field_Factory */
 		$field_factory = SiteOrigin_Widget_Field_Factory::single();
 

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -187,8 +187,17 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 		$v_name = $base_name;
 
 		if ( strpos( $v_name, '][' ) !== false ) {
-			// Remove this splitter
-			$v_name = substr( $v_name, strpos( $v_name, '][' ) + 2 );
+			// Remove everything up to the LAST splitter: the stored companion
+			// key is always the final segment + '_fallback' regardless of
+			// nesting depth (render-path instances are created with unprefixed
+			// names, so the posted key never carries container prefixes).
+			// strrpos, not strpos — a base_name nested two or more containers
+			// deep (e.g. 'frames][background][image') contains multiple
+			// splitters, and taking the first would yield a key like
+			// 'background][image_fallback' that never matches the real stored
+			// key. Matches get_selected_editor_field_name() in
+			// tinymce.class.php.
+			$v_name = substr( $v_name, strrpos( $v_name, '][' ) + 2 );
 		}
 
 		return $v_name . '_fallback';

--- a/base/inc/fields/media.class.php
+++ b/base/inc/fields/media.class.php
@@ -179,6 +179,10 @@ class SiteOrigin_Widget_Field_Media extends SiteOrigin_Widget_Field_Base {
 		return $instance;
 	}
 
+	public function get_related_instance_keys() {
+		return array( $this->get_fallback_field_name( $this->base_name ) );
+	}
+
 	public function get_fallback_field_name( $base_name ) {
 		$v_name = $base_name;
 

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -582,6 +582,10 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		return $instance;
 	}
 
+	public function get_related_instance_keys() {
+		return array( $this->get_selected_editor_field_name( $this->base_name ) );
+	}
+
 	public function get_selected_editor( $instance ) {
 		$selected_editor = null;
 		$selected_editor_name = $this->get_selected_editor_field_name( $this->base_name );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -868,6 +868,25 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 				$new_instance = $field->sanitize_instance( $new_instance );
 			}
 
+			// Strip any instance key that isn't a declared form field, a
+			// field-declared companion key (e.g. a media field's fallback URL,
+			// a tinymce field's selected-editor mode), or known plugin
+			// bookkeeping. An unrecognized key was never routed through any
+			// field's sanitize(), so it must not be allowed to persist
+			// unsanitized (e.g. injected via a crafted save payload).
+			$known_keys = array_keys( $form_options );
+
+			foreach ( $this->fields as $field ) {
+				$known_keys = array_merge( $known_keys, $field->get_related_instance_keys() );
+			}
+
+			$known_keys = array_merge(
+				$known_keys,
+				array( '_sow_form_id', '_sow_form_timestamp', 'panels_info' )
+			);
+
+			$new_instance = array_intersect_key( $new_instance, array_flip( $known_keys ) );
+
 			// Let other plugins also sanitize the instance
 			$new_instance = apply_filters( 'siteorigin_widgets_sanitize_instance', $new_instance, $form_options, $this );
 			$new_instance = apply_filters( 'siteorigin_widgets_sanitize_instance_' . $this->id_base, $new_instance, $form_options, $this );

--- a/base/siteorigin-widget.class.php
+++ b/base/siteorigin-widget.class.php
@@ -819,19 +819,27 @@ abstract class SiteOrigin_Widget extends WP_Widget {
 
 		if ( ! empty( $form_options ) ) {
 			if ( isset( $_GET['fl_builder'] ) && is_array( $new_instance ) ) {
-				$key = array_keys( $new_instance )[0];
-				$new_instance = $this->update_fields(
-					$new_instance[ $key ],
-					$old_instance,
-					$form_options
-				);
-			} else {
-				$new_instance = $this->update_fields(
-					$new_instance,
-					$old_instance,
-					$form_options
-				);
+				// Beaver Builder wraps the submitted instance in an extra
+				// array level — unwrap it before migrating/sanitizing.
+				$new_instance = $new_instance[ array_keys( $new_instance )[0] ];
 			}
+
+			// Migrate any legacy instance shape BEFORE sanitizing: update()
+			// can receive stored instances directly (e.g. the block editor's
+			// render/save paths and widget previews) without widget()/form()
+			// having run modify_instance() first, and update_fields()'
+			// unknown-key strip would otherwise delete un-migrated legacy
+			// keys before modify_instance() could move their data into
+			// current declared fields. modify_instance() implementations are
+			// isset/empty-guarded no-ops on already-current instances, so
+			// this is safe to run on every save.
+			$new_instance = $this->modify_instance( $new_instance );
+
+			$new_instance = $this->update_fields(
+				$new_instance,
+				$old_instance,
+				$form_options
+			);
 		}
 
 		// Remove the old CSS, it'll be regenerated on page load.

--- a/widgets/accordion/accordion.php
+++ b/widgets/accordion/accordion.php
@@ -243,13 +243,16 @@ class SiteOrigin_Widget_Accordion_Widget extends SiteOrigin_Widget {
 		$anchor_list = array();
 
 		foreach ( $panels as $i => &$panel ) {
-			if ( empty( $panel['before_title'] ) ) {
-				$panel['before_title'] = '';
-			}
-
-			if ( empty( $panel['after_title'] ) ) {
-				$panel['after_title'] = '';
-			}
+			// before_title/after_title are filter-owned template slots (e.g.
+			// SiteOrigin Premium injects title-icon markup via the
+			// siteorigin_widgets_template_variables_{id_base} filter, which
+			// runs AFTER this method) — they are never legitimate instance
+			// data. Reset them unconditionally so a value stored in the
+			// instance (e.g. injected before the unknown-key strip existed,
+			// or carried by pre-strip-signed content on render paths that
+			// never pass through update()) can never reach the template.
+			$panel['before_title'] = '';
+			$panel['after_title'] = '';
 
 			if ( empty( $panel['title'] ) ) {
 				$id = $this->id_base;

--- a/widgets/accordion/tpl/default.php
+++ b/widgets/accordion/tpl/default.php
@@ -26,9 +26,18 @@ if ( ! empty( $instance['title'] ) ) {
 					<div class="sow-accordion-panel-header-container"<?php if ( ! $title_has_native_heading ) { ?> role="heading" aria-level="<?php echo esc_attr( $title_level ); ?>"<?php } ?>>
 					<div class="sow-accordion-panel-header" tabindex="0" role="button" id="accordion-label-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>" aria-controls="accordion-content-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>" aria-expanded="<?php echo $panel['initial_state'] == 'open' ? 'true' : 'false'; ?>">
 						<<?php echo esc_attr( $title_tag ); ?> class="sow-accordion-title <?php echo empty( $panel['after_title'] ) ? 'sow-accordion-title-icon-left' : 'sow-accordion-title-icon-right'; ?>">
-							<?php echo wp_kses_post( $panel['before_title'] ); ?>
+							<?php
+							// before_title/after_title carry plugin-generated icon markup
+							// (filter-owned slots, unconditionally reset in
+							// get_template_variables() before the filter runs — never
+							// instance data). Deliberately NOT passed through
+							// wp_kses_post(): kses's attribute-value handling strips the
+							// Private Use Area glyph entities in data-sow-icon="&#x...;",
+							// blanking every font icon.
+							?>
+							<?php echo $panel['before_title']; ?>
 							<?php echo wp_kses_post( $panel['title'] ); ?>
-							<?php echo wp_kses_post( $panel['after_title'] ); ?>
+							<?php echo $panel['after_title']; ?>
 						</<?php echo esc_attr( $title_tag ); ?>>
 						<div class="sow-accordion-open-close-button">
 							<div class="sow-accordion-open-button">

--- a/widgets/accordion/tpl/default.php
+++ b/widgets/accordion/tpl/default.php
@@ -26,9 +26,9 @@ if ( ! empty( $instance['title'] ) ) {
 					<div class="sow-accordion-panel-header-container"<?php if ( ! $title_has_native_heading ) { ?> role="heading" aria-level="<?php echo esc_attr( $title_level ); ?>"<?php } ?>>
 					<div class="sow-accordion-panel-header" tabindex="0" role="button" id="accordion-label-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>" aria-controls="accordion-content-<?php echo sanitize_title_with_dashes( $panel['anchor'] ); ?>" aria-expanded="<?php echo $panel['initial_state'] == 'open' ? 'true' : 'false'; ?>">
 						<<?php echo esc_attr( $title_tag ); ?> class="sow-accordion-title <?php echo empty( $panel['after_title'] ) ? 'sow-accordion-title-icon-left' : 'sow-accordion-title-icon-right'; ?>">
-							<?php echo $panel['before_title']; ?>
+							<?php echo wp_kses_post( $panel['before_title'] ); ?>
 							<?php echo wp_kses_post( $panel['title'] ); ?>
-							<?php echo $panel['after_title']; ?>
+							<?php echo wp_kses_post( $panel['after_title'] ); ?>
 						</<?php echo esc_attr( $title_tag ); ?>>
 						<div class="sow-accordion-open-close-button">
 							<div class="sow-accordion-open-button">

--- a/widgets/price-table/tpl/atom.php
+++ b/widgets/price-table/tpl/atom.php
@@ -14,7 +14,7 @@ $initial_button_attrs = $button_attrs;
 
 <?php
 if ( ! empty( $title ) ) {
-	echo $before_title . $title . $after_title;
+	echo $before_title . wp_kses_post( $title ) . $after_title;
 }
 ?>
 
@@ -62,7 +62,7 @@ if ( ! empty( $title ) ) {
 								$icon_styles = array();
 
 								if ( ! empty( $feature['icon_color'] ) ) {
-									$icon_styles[] = 'color: ' . $feature['icon_color'];
+									$icon_styles[] = 'color: ' . esc_attr( $feature['icon_color'] );
 								}
 								echo siteorigin_widget_get_icon( $feature['icon_new'], $icon_styles );
 								?>

--- a/widgets/tabs/tabs.php
+++ b/widgets/tabs/tabs.php
@@ -232,13 +232,16 @@ class SiteOrigin_Widget_Tabs_Widget extends SiteOrigin_Widget {
 		$tabs = empty( $instance['tabs'] ) ? array() : $instance['tabs'];
 
 		foreach ( $tabs as $i => &$tab ) {
-			if ( empty( $tab['before_title'] ) ) {
-				$tab['before_title'] = '';
-			}
-
-			if ( empty( $tab['after_title'] ) ) {
-				$tab['after_title'] = '';
-			}
+			// before_title/after_title are filter-owned template slots (e.g.
+			// SiteOrigin Premium injects title-icon markup via the
+			// siteorigin_widgets_template_variables_{id_base} filter, which
+			// runs AFTER this method) — they are never legitimate instance
+			// data. Reset them unconditionally so a value stored in the
+			// instance (e.g. injected before the unknown-key strip existed,
+			// or carried by pre-strip-signed content on render paths that
+			// never pass through update()) can never reach the template.
+			$tab['before_title'] = '';
+			$tab['after_title'] = '';
 
 			if ( empty( $tab['title'] ) ) {
 				$id = $this->id_base;

--- a/widgets/tabs/tpl/default.php
+++ b/widgets/tabs/tpl/default.php
@@ -26,9 +26,18 @@ if ( ! empty( $instance['title'] ) ) {
 			tabindex="0"
 		>
 			<div class="sow-tabs-title <?php echo empty( $tab['after_title'] ) ? 'sow-tabs-title-icon-left' : 'sow-tabs-title-icon-right'; ?>">
-				<?php echo wp_kses_post( $tab['before_title'] ); ?>
+				<?php
+				// before_title/after_title carry plugin-generated icon markup
+				// (filter-owned slots, unconditionally reset in
+				// get_template_variables() before the filter runs — never
+				// instance data). Deliberately NOT passed through
+				// wp_kses_post(): kses's attribute-value handling strips the
+				// Private Use Area glyph entities in data-sow-icon="&#x...;",
+				// blanking every font icon.
+				?>
+				<?php echo $tab['before_title']; ?>
 				<?php echo wp_kses_post( $tab['title'] ); ?>
-				<?php echo wp_kses_post( $tab['after_title'] ); ?>
+				<?php echo $tab['after_title']; ?>
 			</div>
 		</div>
 	<?php } ?>

--- a/widgets/tabs/tpl/default.php
+++ b/widgets/tabs/tpl/default.php
@@ -26,9 +26,9 @@ if ( ! empty( $instance['title'] ) ) {
 			tabindex="0"
 		>
 			<div class="sow-tabs-title <?php echo empty( $tab['after_title'] ) ? 'sow-tabs-title-icon-left' : 'sow-tabs-title-icon-right'; ?>">
-				<?php echo $tab['before_title']; ?>
+				<?php echo wp_kses_post( $tab['before_title'] ); ?>
 				<?php echo wp_kses_post( $tab['title'] ); ?>
-				<?php echo $tab['after_title']; ?>
+				<?php echo wp_kses_post( $tab['after_title'] ); ?>
 			</div>
 		</div>
 	<?php } ?>


### PR DESCRIPTION
## Summary

Follow-up to #2319. Closes the unknown-instance-key passthrough gap: `update_fields()` and `Container_Base::sanitize_field_input()` previously only overwrote declared field keys and let any other key in a save payload persist completely unsanitized — concretely exploitable as stored XSS via undeclared repeater-row keys (`panels[0][before_title]`) echoed raw by the accordion/tabs templates.

### Input-side hardening
- New `get_related_instance_keys()` extension seam on `SiteOrigin_Widget_Field_Base` so field types can declare legitimate companion keys (media `{field}_fallback`, tinymce `{field}_selected_editor`) — a public override point available to third-party field subclasses.
- Allowlist strip of unknown keys in `update_fields()` (top level) and `Container_Base` (every repeater row/section/tab), preserving declared fields, companion keys, and plugin bookkeeping (`_sow_form_id`, `_sow_form_timestamp`, `panels_info`, `so_field_container_state`). The strip runs **before** the `siteorigin_widgets_sanitize_instance*` filters, so third parties retain a supported path to re-add custom keys.
- `modify_instance()` legacy migration now runs before sanitize/strip in `update()` (after unwrapping Beaver Builder's extra array level), so legacy instance shapes can't lose un-migrated settings.
- Media fallback key derivation fixed for depth-≥2 container nesting (`strrpos`, matching tinymce) — also fixes a pre-existing bug where depth-2 fallback URLs never reached `sow_esc_url_raw()`.
- `Container_Base` degenerate guard: no PHP 8 fatal (and no data wipe) when a container legitimately has no declared sub-fields.

### Output-side hardening
- Accordion/tabs `before_title`/`after_title` are filter-owned template slots (SiteOrigin Premium title icons), never instance data: now unconditionally reset at the source in `get_template_variables()`, echoed raw at the sink (kses would strip PUA glyph entities from `data-sow-icon`, blanking every Premium font icon — human-verified on live WP).
- Price-table template: `wp_kses_post()` on `$title`, `esc_attr()` on `icon_color` — matching sibling widget patterns.

### Release notes
- Third-party code stashing custom instance keys **without** using the sanitize filters will see them stripped on next save; the filter escape hatch is the supported answer.
- `SOW_SANITIZE_VERSION`: Steps 3-4 qualify as sanitization-tightening — consider a bump at release-cut time (deliberately not bumped on this branch, per policy).

Reviewed through three pipeline rounds plus human overseer verification; final commit (`0241402d`) human-approved.