### PR TITLE
Compat: Inline sanitize-version literal, relocate bump-policy doc to its call site

### DIFF
--- a/compat/compat.php
+++ b/compat/compat.php
@@ -77,7 +77,30 @@ class SiteOrigin_Widgets_Bundle_Compatibility {
 	 * @return string
 	 */
 	public function add_sanitize_version_signal( $version ) {
-		return $version . ';sowb:' . SOW_SANITIZE_VERSION;
+		// The '1' below is the version identifier for this plugin's
+		// field-sanitization SEMANTICS — i.e. what content a sanitizer
+		// allows through, not its code/bugfix history. Consumed by
+		// siteorigin-panels' Layout Block trust-signature scheme so a stale
+		// save-time signature can be detected and invalidated when this
+		// plugin's sanitization rules materially tighten.
+		//
+		// Bump this value ONLY when a field/widget sanitizer becomes MORE
+		// RESTRICTIVE in a security-relevant way (e.g. a previously-unfiltered
+		// field starts running wp_kses_post(), or a bypass is closed).
+		//
+		// NEVER bump it for idempotency fixes, bugfixes, or any behavior
+		// change that does not affect what content is allowed through.
+		//
+		// Bumping this invalidates EVERY existing siteorigin-panels Layout
+		// Block trust signature site-wide, with NO bulk remediation path:
+		// each affected post must be individually re-saved by its own author
+		// to regain trusted-render status (capability-gated sanitization is
+		// only meaningful under the real author's session, so there is no
+		// safe way to batch/cron re-sign on their behalf). This is an
+		// accepted, intentionally expensive cost for genuine security
+		// tightening — do not bump casually, and do not bump for anything
+		// covered by the "never" list above.
+		return $version . ';sowb:1';
 	}
 
 	public function get_active_builder() {

--- a/so-widgets-bundle.php
+++ b/so-widgets-bundle.php
@@ -15,35 +15,6 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.txt
 define( 'SOW_BUNDLE_VERSION', 'dev' );
 define( 'SOW_BUNDLE_BASE_FILE', __FILE__ );
 
-/**
- * Version identifier for this plugin's field-sanitization SEMANTICS —
- * i.e. what content a sanitizer allows through, not its code/bugfix
- * history. Consumed by siteorigin-panels' Layout Block trust-signature
- * scheme (see so-widgets-bundle's contribution to the
- * `siteorigin_panels_sanitize_version` filter, in
- * compat/compat.php) so a stale save-time signature can be detected
- * and invalidated when this plugin's sanitization rules materially
- * tighten.
- *
- * Bump this value ONLY when a field/widget sanitizer becomes MORE
- * RESTRICTIVE in a security-relevant way (e.g. a previously-unfiltered
- * field starts running wp_kses_post(), or a bypass is closed).
- *
- * NEVER bump it for idempotency fixes, bugfixes, or any behavior change
- * that does not affect what content is allowed through.
- *
- * Bumping this invalidates EVERY existing siteorigin-panels Layout
- * Block trust signature site-wide, with NO bulk remediation path: each
- * affected post must be individually re-saved by its own author to
- * regain trusted-render status (capability-gated sanitization is only
- * meaningful under the real author's session, so there is no safe way
- * to batch/cron re-sign on their behalf). This is an accepted,
- * intentionally expensive cost for genuine security tightening — do
- * not bump casually, and do not bump for anything covered by the
- * "never" list above.
- */
-define( 'SOW_SANITIZE_VERSION', '1' );
-
 // Allow JS suffix to be pre-set.
 if ( ! defined( 'SOW_BUNDLE_JS_SUFFIX' ) ) {
 	define( 'SOW_BUNDLE_JS_SUFFIX', '' );


### PR DESCRIPTION
## Summary

Pure naming/organization refactor — no behavior change.

- `SOW_SANITIZE_VERSION` (a named constant with a single consumer) is replaced by an inline `'1'` literal in `compat/compat.php`'s `add_sanitize_version_signal()`, matching the precedent on the `siteorigin-panels` side where the equivalent `'panels:1'` value is a bare literal in the filter callback.
- The version-bump policy doc-comment moves from the plugin bootstrap to the call site (reformatted as inline comments), with all policy points preserved: bump only for security-relevant sanitizer tightening, never for idempotency fixes/bugfixes, and the site-wide re-save cost of a bump.

The composed `siteorigin_panels_sanitize_version` filter output is byte-for-byte unchanged (`panels:1;sowb:1`), verified by executable trace — **no signature-invalidation event occurs from this change**. The trace also ran without the constant defined, confirming nothing else depends on it (repo-wide grep: zero remaining references).

This is not a version bump; whether/when to bump the sanitize-version value remains a separate release-branch-time decision.

Reviewed and approved via the plan pipeline.