### PR TITLE
Block Editor: Wait for the Canvas to Load What the Clone Walk Cannot Supply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ vendor/
 
 .cursorrules
 .claude/
+docs/plans/
+tasks/runs/
 # Playwright.
 tests/cache
 tests/results

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2385,7 +2385,15 @@ const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
  * @returns {boolean} True when Page Builder was available to set fields up.
  */
 const sowbEnsureCanvasBuilderFields = ( canvasWindow ) => {
-	const canvasJQuery = canvasWindow && canvasWindow.jQuery;
+	let canvasJQuery;
+
+	try {
+		canvasJQuery = canvasWindow && canvasWindow.jQuery;
+	} catch ( e ) {
+		// Ignore cross-window errors (e.g. iframe detached or navigated
+		// between the caller's checks and this read).
+		return false;
+	}
 
 	if (
 		! canvasJQuery ||

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1591,16 +1591,15 @@ const sowbCanvasCloneElements = [
 	'#wp-tinymce-js',
 	'#utils-js',
 	// WordPress emits `-extra` (localization) before a script and `-after`
-	// following it. Cloning `#editor-js-after` ahead of `#editor-js` put them in
-	// the wrong relative order, so it ran against a window with no wp.editor and
-	// the throw aborted the walk before jQuery's dependants were cloned.
+	// following it, so this list keeps them in that order.
 	//
-	// This corrects the ORDER only. It does not sequence them: the loop appends
-	// synchronously, and an inline script executes on append rather than waiting
-	// for the external file it depends on. Every inline entry in this list has
-	// that same exposure, which is why sowbEnsureEditorJs() exists as a retry.
-	// A real fix would chain each inline script off its external partner's load
-	// event.
+	// Order is all this does. It does not sequence them: the loop appends
+	// synchronously and an appended inline script runs immediately rather than
+	// waiting for the external file it depends on. When one throws, the
+	// exception is reported to the canvas window and does not propagate back
+	// out of appendChild(), so the walk carries on - the script simply had no
+	// effect. sowbEnsureIframeOldEditorApi() re-injects editor-js for exactly
+	// that case.
 	'#editor-js-extra',
 	'#editor-js',
 	'#editor-js-after',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2336,11 +2336,18 @@ const sowbCanvasUnclonableDependencies = ( canvasWindow, sourceDoc, canvasDoc ) 
  * evaluates against a window that has none.
  *
  * sowbCloneElementToCanvas() dedupes by id against the whole canvas document,
- * so a script appended too early can never be replaced. That is why this gates
- * the walk rather than retrying it afterwards.
+ * so a script appended too early can never be replaced. That is why the walk
+ * never runs before the canvas holds its dependencies and its body: cloning
+ * into a canvas that cannot evaluate the clones is worse than not cloning,
+ * because the failed nodes block every later attempt.
  *
- * Fails open: once the budget is spent the walk runs regardless, which is the
- * behaviour that shipped before this gate existed.
+ * There is no budget. Ready is observable, so the wait polls until the
+ * dependencies and the body exist, however long that takes. A canvas document
+ * that finishes loading without them gets one console.warn naming the missing
+ * handles, and the poll continues so a dependency arriving late by any route
+ * is still picked up. A canvas still loading after twenty ticks gets one
+ * "still waiting" warn. Wait state lives on the iframe element, per canvas
+ * document, so the about:blank to blob navigation cannot discard it.
  *
  * @param {HTMLIFrameElement} frame     The editor canvas iframe.
  * @param {Document}          sourceDoc The document the walk clones from.
@@ -2360,33 +2367,102 @@ const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
 		return true;
 	}
 
-	if (
-		! canvasWindow ||
-		! canvasDoc ||
-		sowbCanvasUnclonableDependencies( canvasWindow, sourceDoc, canvasDoc ).length === 0
-	) {
+	if ( ! canvasWindow || ! canvasDoc ) {
 		return true;
 	}
 
-	// One timer and one budget per canvas. This is called at least twice per
-	// widget block and once per block, and they all share a single wait.
-	if ( canvasWindow.sowbCanvasCloneWaitTimer ) {
+	// Wait state is per canvas document, kept on the iframe element rather
+	// than the canvas window: the element survives the about:blank to blob
+	// navigation that silently discards anything stored on the window. A new
+	// document gets a fresh cycle and fresh diagnostics.
+	if ( ! frame.sowbCanvasCloneWait || frame.sowbCanvasCloneWait.doc !== canvasDoc ) {
+		frame.sowbCanvasCloneWait = {
+			doc: canvasDoc,
+			attempts: 0,
+			completeMissSince: 0,
+			stallWarned: false,
+			terminalWarned: false,
+		};
+	}
+	const wait = frame.sowbCanvasCloneWait;
+
+	const missing = sowbCanvasUnclonableDependencies( canvasWindow, sourceDoc, canvasDoc );
+
+	// Ready means the dependencies have evaluated AND the body Gutenberg
+	// portals in on load exists - the walk appends there. This runs before
+	// the caller's own body check, so a not-ready verdict keeps the retry
+	// ticking instead of dying against a body-less document.
+	if ( missing.length === 0 && canvasDoc.body ) {
+		return true;
+	}
+
+	// The document finished loading, so the dependencies were either in its
+	// head or they are not coming at all. Warn once per document and keep
+	// polling - the check above picks up a dependency arriving late by any
+	// route. Two qualifiers: the pre-navigation about:blank document also
+	// reports complete, so it never counts; and a healthy canvas can report
+	// complete shortly before its scripts finish evaluating, so the warn
+	// waits for the miss to hold for a full second first.
+	if (
+		missing.length > 0 &&
+		canvasDoc.readyState === 'complete' &&
+		canvasDoc.URL !== 'about:blank'
+	) {
+		if ( ! wait.completeMissSince ) {
+			wait.completeMissSince = Date.now();
+		}
+
+		// Only the editor canvas is worth a diagnostic. The resolver also
+		// hands this gate Gutenberg's transient preview iframes, which never
+		// load these dependencies and disappear on their own.
+		if (
+			! wait.terminalWarned &&
+			frame.name === 'editor-canvas' &&
+			Date.now() - wait.completeMissSince >= 1000
+		) {
+			wait.terminalWarned = true;
+			console.warn(
+				'SiteOrigin Widgets: editor canvas finished loading without ' +
+				missing.join( ', ' ) +
+				'. Widget asset cloning is deferred until they are available.'
+			);
+		}
+	}
+
+	// One tick chain per canvas element. This is called at least twice per
+	// widget block and once per block, and they all share a single wait. The
+	// lock sits before the counting so attempts counts ticks, not callers.
+	if ( frame.sowbCanvasCloneWaitTimer ) {
 		return false;
 	}
 
-	const attempts = canvasWindow.sowbCanvasCloneWaitAttempts || 0;
-	if ( attempts >= 20 ) {
-		return true;
+	wait.attempts++;
+
+	if (
+		wait.attempts >= 20 &&
+		! wait.stallWarned &&
+		! wait.terminalWarned &&
+		frame.name === 'editor-canvas' &&
+		canvasDoc.readyState !== 'complete'
+	) {
+		wait.stallWarned = true;
+		console.warn(
+			'SiteOrigin Widgets: still waiting for the editor canvas to load ' +
+			( missing.length ? missing.join( ', ' ) : 'its body' ) + '.'
+		);
 	}
 
-	canvasWindow.sowbCanvasCloneWaitAttempts = attempts + 1;
-	canvasWindow.sowbCanvasCloneWaitTimer = canvasWindow.setTimeout( () => {
+	// The timer belongs to the window that owns the iframe element, never the
+	// canvas window - a timer on the canvas window is discarded when its
+	// about:blank document navigates to the real canvas, stranding the wait.
+	const ownerWindow = ( frame.ownerDocument && frame.ownerDocument.defaultView ) || window;
+	frame.sowbCanvasCloneWaitTimer = ownerWindow.setTimeout( () => {
 		// Cleared before re-entering. Clearing afterwards would leave the
 		// re-entrant call seeing a live timer, so it would return without
 		// scheduling and the wait would end after a single tick.
-		canvasWindow.sowbCanvasCloneWaitTimer = 0;
+		frame.sowbCanvasCloneWaitTimer = 0;
 
-		if ( frame.isConnected && frame.contentWindow === canvasWindow ) {
+		if ( frame.isConnected ) {
 			sowbMaybeSetupSiteEditorAssets( frame );
 		}
 	}, 250 );
@@ -2473,12 +2549,6 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 		return;
 	}
 
-	const $canvasBody = jQuery( iframeDocument ).find( 'body' );
-
-	if ( $canvasBody.length === 0 ) {
-		return;
-	}
-
 	// When this helper runs from INSIDE the iframe (the IIFE branch at the
 	// bottom of widget-block.js), the source <script>/<link> nodes live in
 	// the parent admin document, not in this script's own document. Read
@@ -2501,7 +2571,16 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 
 	// Everything below appends to the canvas under a dedupe that is permanent,
 	// so none of it may run before the canvas can evaluate what it appends.
+	// The gate requires the canvas body too, so it runs before the body check
+	// below: its not-ready verdict keeps its own retry ticking, where a bare
+	// return against a body-less document would end the wait for good.
 	if ( ! sowbCanvasIsReadyForAssetClone( currentFrame, sourceDoc ) ) {
+		return;
+	}
+
+	const $canvasBody = jQuery( iframeDocument ).find( 'body' );
+
+	if ( $canvasBody.length === 0 ) {
 		return;
 	}
 

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1590,12 +1590,17 @@ const sowbCanvasCloneElements = [
 	'#underscore-js',
 	'#wp-tinymce-js',
 	'#utils-js',
-	// Order matters: WordPress emits `-extra` (localization) before a script and
-	// `-after` following it, and both are inline, so they execute the instant
-	// they are appended rather than waiting on the external file. Cloning
-	// `#editor-js-after` ahead of `#editor-js` therefore ran it against a
-	// window where wp.editor did not exist yet, throwing before the rest of the
-	// list — including jQuery's dependants — could be cloned.
+	// WordPress emits `-extra` (localization) before a script and `-after`
+	// following it. Cloning `#editor-js-after` ahead of `#editor-js` put them in
+	// the wrong relative order, so it ran against a window with no wp.editor and
+	// the throw aborted the walk before jQuery's dependants were cloned.
+	//
+	// This corrects the ORDER only. It does not sequence them: the loop appends
+	// synchronously, and an inline script executes on append rather than waiting
+	// for the external file it depends on. Every inline entry in this list has
+	// that same exposure, which is why sowbEnsureEditorJs() exists as a retry.
+	// A real fix would chain each inline script off its external partner's load
+	// event.
 	'#editor-js-extra',
 	'#editor-js',
 	'#editor-js-after',
@@ -1679,6 +1684,12 @@ const sowbCanvasCloneElements = [
 	// siteorigin-panels/inc/admin.php:509 for the declared list) - the jQuery UI
 	// and colour-picker handles it also needs are cloned further up.
 	'#backbone-js',
+	// moxiejs before plupload: WordPress registers plupload with a hard moxiejs
+	// dependency (wp-includes/script-loader.php:1043-1044), and plupload.js
+	// leaves window.plupload undefined if mOxie is absent. Cloning plupload
+	// alone would break Page Builder's import and upload flows inside the
+	// canvas while everything else appeared to work.
+	'#moxiejs-js',
 	'#plupload-js',
 	'#so-panels-admin-js-extra',
 	'#so-panels-admin-js',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2138,6 +2138,12 @@ const sowbCloneElementToCanvas = ( $canvasBody, element, $source ) => {
 		if ( scriptCloneKey && canvasWindow ) {
 			clonedElement.addEventListener( 'load', () => {
 				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
+
+				// Forms that finished setting up before Page Builder landed
+				// skipped their builder fields, and nothing else retries them.
+				if ( scriptCloneKey === 'id:so-panels-admin-js' ) {
+					sowbEnsureCanvasBuilderFields( canvasWindow );
+				}
 			}, { once: true } );
 			clonedElement.addEventListener( 'error', () => {
 				delete canvasWindow.sowbScriptClonePending[ scriptCloneKey ];
@@ -2366,6 +2372,45 @@ const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
 };
 
 /**
+ * Sets up any builder fields Page Builder had not loaded in time to handle.
+ *
+ * siteorigin-widget-admin reaches the canvas through its <head>, while
+ * so-panels-admin arrives only through the clone walk, so a form can finish
+ * setting up while soPanelsSetupBuilderWidget is still undefined. The check in
+ * base/js/admin.js is a bare `if` with no retry, so those fields would stay
+ * dead for the rest of the page.
+ *
+ * @param {Window} canvasWindow The canvas iframe's window.
+ *
+ * @returns {boolean} True when Page Builder was available to set fields up.
+ */
+const sowbEnsureCanvasBuilderFields = ( canvasWindow ) => {
+	const canvasJQuery = canvasWindow && canvasWindow.jQuery;
+
+	if (
+		! canvasJQuery ||
+		typeof canvasJQuery.fn.soPanelsSetupBuilderWidget === 'undefined'
+	) {
+		return false;
+	}
+
+	canvasJQuery( '.siteorigin-widget-field-type-builder > .siteorigin-page-builder-field' ).each( function() {
+		const $field = canvasJQuery( this );
+
+		// Only fields Page Builder has never set up. Page Builder skips these
+		// itself, but checking here keeps an open dialog or an unsaved edit
+		// out of the call entirely.
+		if ( $field.data( 'soPanelsBuilderWidgetInitialized' ) ) {
+			return;
+		}
+
+		$field.soPanelsSetupBuilderWidget( { builderType: $field.data( 'type' ) } );
+	} );
+
+	return true;
+};
+
+/**
  * Sets up assets required for the Site Editor iframe.
  *
  * This function ensures that necessary HTML templates, scripts, and styles are copied
@@ -2445,6 +2490,11 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 		// Ignore cross-window errors (e.g. iframe detached between the
 		// initial check and the assignment).
 	}
+
+	// Last, so Page Builder's dialog templates are already in the canvas. This
+	// covers the case where so-panels-admin was present before the walk, so no
+	// load event fires for the clone.
+	sowbEnsureCanvasBuilderFields( currentFrame.contentWindow );
 };
 
 /**

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1834,6 +1834,8 @@ const sowbIsScriptHandleLoadedInWindow = ( targetWindow, scriptId ) => {
 			return !! targetWindow.QTags;
 		case 'underscore-js':
 			return !! targetWindow._;
+		case 'backbone-js':
+			return !! targetWindow.Backbone;
 		default:
 			return false;
 	}
@@ -2274,6 +2276,96 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 };
 
 /**
+ * Handles the first wave of cloned scripts reads at evaluation time.
+ *
+ * Each is waited on only when it cannot be cloned from the source document,
+ * so under SCRIPT_DEBUG - where every handle emits with its own id - none of
+ * them is ever waited on.
+ *
+ * @type {string[]}
+ */
+const sowbCanvasBaseDependencies = [
+	'jquery-core-js',
+	'jquery-ui-core-js',
+	'jquery-ui-mouse-js',
+	'underscore-js',
+	'backbone-js',
+];
+
+/**
+ * Lists the dependencies the clone walk can neither supply nor find.
+ *
+ * @param {Window}   canvasWindow The canvas iframe's window.
+ * @param {Document} sourceDoc    The document the walk clones from.
+ *
+ * @returns {string[]} Script ids that are missing and cannot be cloned.
+ */
+const sowbCanvasUnclonableDependencies = ( canvasWindow, sourceDoc ) => {
+	return sowbCanvasBaseDependencies.filter( ( scriptId ) => {
+		return ! sowbGetElementById( sourceDoc, scriptId ) &&
+			! sowbIsScriptHandleLoadedInWindow( canvasWindow, scriptId );
+	} );
+};
+
+/**
+ * Decides whether the canvas is ready for the clone walk.
+ *
+ * WordPress concatenates core scripts into load-scripts.php, and those bundle
+ * elements carry no id, so `#jquery-core-js` does not exist in the source
+ * document on a default install and jQuery cannot be cloned. The canvas loads
+ * its own copy in its <head>, asynchronously, while this runs from a React ref
+ * that fires first - so without a wait every cloned script that needs jQuery
+ * evaluates against a window that has none.
+ *
+ * sowbCloneElementToCanvas() dedupes by id against the whole canvas document,
+ * so a script appended too early can never be replaced. That is why this gates
+ * the walk rather than retrying it afterwards.
+ *
+ * Fails open: once the budget is spent the walk runs regardless, which is the
+ * behaviour that shipped before this gate existed.
+ *
+ * @param {HTMLIFrameElement} frame     The editor canvas iframe.
+ * @param {Document}          sourceDoc The document the walk clones from.
+ *
+ * @returns {boolean} True to walk now, false when a retry has been scheduled.
+ */
+const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
+	const canvasWindow = frame && frame.contentWindow;
+
+	if (
+		! canvasWindow ||
+		sowbCanvasUnclonableDependencies( canvasWindow, sourceDoc ).length === 0
+	) {
+		return true;
+	}
+
+	// One timer and one budget per canvas. This is called at least twice per
+	// widget block and once per block, and they all share a single wait.
+	if ( canvasWindow.sowbCanvasCloneWaitTimer ) {
+		return false;
+	}
+
+	const attempts = canvasWindow.sowbCanvasCloneWaitAttempts || 0;
+	if ( attempts >= 20 ) {
+		return true;
+	}
+
+	canvasWindow.sowbCanvasCloneWaitAttempts = attempts + 1;
+	canvasWindow.sowbCanvasCloneWaitTimer = canvasWindow.setTimeout( () => {
+		// Cleared before re-entering. Clearing afterwards would leave the
+		// re-entrant call seeing a live timer, so it would return without
+		// scheduling and the wait would end after a single tick.
+		canvasWindow.sowbCanvasCloneWaitTimer = 0;
+
+		if ( frame.isConnected && frame.contentWindow === canvasWindow ) {
+			sowbMaybeSetupSiteEditorAssets( frame );
+		}
+	}, 250 );
+
+	return false;
+};
+
+/**
  * Sets up assets required for the Site Editor iframe.
  *
  * This function ensures that necessary HTML templates, scripts, and styles are copied
@@ -2328,7 +2420,15 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 		sourceDoc = document;
 	}
 
+	// Copies plain values and needs no jQuery, so it runs while we wait.
 	sowbEnsureIframeEditorGlobals( currentFrame );
+
+	// Everything below appends to the canvas under a dedupe that is permanent,
+	// so none of it may run before the canvas can evaluate what it appends.
+	if ( ! sowbCanvasIsReadyForAssetClone( currentFrame, sourceDoc ) ) {
+		return;
+	}
+
 	sowbCloneElementsToCanvas( $canvasBody, sourceDoc );
 	sowbCloneTinyMCEExternalPluginAssets( $canvasBody, sourceDoc );
 	sowbEnsureIframeOldEditorApi( currentFrame );

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2525,7 +2525,12 @@ const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {
 	// Last, so Page Builder's dialog templates are already in the canvas. This
 	// covers the case where so-panels-admin was present before the walk, so no
 	// load event fires for the clone.
-	sowbEnsureCanvasBuilderFields( currentFrame.contentWindow );
+	try {
+		sowbEnsureCanvasBuilderFields( currentFrame.contentWindow );
+	} catch ( e ) {
+		// Ignore cross-window errors (e.g. iframe detached between the
+		// initial check and this call).
+	}
 };
 
 /**

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2372,8 +2372,8 @@ const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
 		canvasWindow = frame && frame.contentWindow;
 		canvasDoc = frame && frame.contentDocument;
 	} catch ( e ) {
-		// Ignore cross-window errors and let the walk proceed as it did
-		// before this gate existed.
+		// A frame this code cannot read is not gateable; report ready and let
+		// the caller take its own fallback path.
 		return true;
 	}
 

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1588,11 +1588,17 @@ const sowbCanvasCloneElements = [
 	'#jquery-core-js',
 	'#jquery-migrate-js',
 	'#underscore-js',
-	'#editor-js-after',
 	'#wp-tinymce-js',
 	'#utils-js',
+	// Order matters: WordPress emits `-extra` (localization) before a script and
+	// `-after` following it, and both are inline, so they execute the instant
+	// they are appended rather than waiting on the external file. Cloning
+	// `#editor-js-after` ahead of `#editor-js` therefore ran it against a
+	// window where wp.editor did not exist yet, throwing before the rest of the
+	// list — including jQuery's dependants — could be cloned.
 	'#editor-js-extra',
 	'#editor-js',
+	'#editor-js-after',
 	'#quicktags-js-extra',
 	'#quicktags-js',
 	'#wp-block-library-js-before',

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2299,17 +2299,29 @@ const sowbCanvasBaseDependencies = [
 ];
 
 /**
- * Lists the dependencies the clone walk can neither supply nor find.
+ * Lists the dependencies that are neither live in the canvas nor ours to clone.
+ *
+ * A handle counts as ours to clone only when the source document has it AND the
+ * canvas does not already hold that id: sowbCloneElementToCanvas() dedupes by
+ * id, so a copy the canvas is still loading silently cancels our clone and the
+ * walk would carry on without the dependency it thought it was supplying.
  *
  * @param {Window}   canvasWindow The canvas iframe's window.
  * @param {Document} sourceDoc    The document the walk clones from.
+ * @param {Document} canvasDoc    The canvas iframe's document.
  *
- * @returns {string[]} Script ids that are missing and cannot be cloned.
+ * @returns {string[]} Script ids the walk must wait for.
  */
-const sowbCanvasUnclonableDependencies = ( canvasWindow, sourceDoc ) => {
+const sowbCanvasUnclonableDependencies = ( canvasWindow, sourceDoc, canvasDoc ) => {
 	return sowbCanvasBaseDependencies.filter( ( scriptId ) => {
-		return ! sowbGetElementById( sourceDoc, scriptId ) &&
-			! sowbIsScriptHandleLoadedInWindow( canvasWindow, scriptId );
+		if ( sowbIsScriptHandleLoadedInWindow( canvasWindow, scriptId ) ) {
+			return false;
+		}
+
+		return ! (
+			sowbGetElementById( sourceDoc, scriptId ) &&
+			! sowbGetElementById( canvasDoc, scriptId )
+		);
 	} );
 };
 
@@ -2336,11 +2348,22 @@ const sowbCanvasUnclonableDependencies = ( canvasWindow, sourceDoc ) => {
  * @returns {boolean} True to walk now, false when a retry has been scheduled.
  */
 const sowbCanvasIsReadyForAssetClone = ( frame, sourceDoc ) => {
-	const canvasWindow = frame && frame.contentWindow;
+	let canvasWindow;
+	let canvasDoc;
+
+	try {
+		canvasWindow = frame && frame.contentWindow;
+		canvasDoc = frame && frame.contentDocument;
+	} catch ( e ) {
+		// Ignore cross-window errors and let the walk proceed as it did
+		// before this gate existed.
+		return true;
+	}
 
 	if (
 		! canvasWindow ||
-		sowbCanvasUnclonableDependencies( canvasWindow, sourceDoc ).length === 0
+		! canvasDoc ||
+		sowbCanvasUnclonableDependencies( canvasWindow, sourceDoc, canvasDoc ).length === 0
 	) {
 		return true;
 	}

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1672,6 +1672,42 @@ const sowbCanvasCloneElements = [
 	'#so-tabs-field-js',
 	'#so-tinymce-field-js',
 	'#so-toggle-field-js',
+
+	// Page Builder, for the builder field ('type' => 'builder'). Its stylesheet
+	// already reached the canvas but its script did not, so the Open Builder
+	// button rendered and did nothing. Dependencies first (see
+	// siteorigin-panels/inc/admin.php:509 for the declared list) - the jQuery UI
+	// and colour-picker handles it also needs are cloned further up.
+	'#backbone-js',
+	'#plupload-js',
+	'#so-panels-admin-js-extra',
+	'#so-panels-admin-js',
+
+	// Page Builder's dialog templates (siteorigin-panels/tpl/js-templates.php),
+	// without which the dialog has nothing to render.
+	'#siteorigin-panels-dialog',
+	'#siteorigin-panels-dialog-tab',
+	'#siteorigin-panels-dialog-builder',
+	'#siteorigin-panels-dialog-row',
+	'#siteorigin-panels-dialog-row-cell-preview',
+	'#siteorigin-panels-dialog-widget',
+	'#siteorigin-panels-dialog-widgets',
+	'#siteorigin-panels-dialog-widgets-widget',
+	'#siteorigin-panels-dialog-widget-sidebar-widget',
+	'#siteorigin-panels-dialog-history',
+	'#siteorigin-panels-dialog-history-entry',
+	'#siteorigin-panels-dialog-prebuilt',
+	'#siteorigin-panels-dialog-prebuilt-importexport',
+	'#siteorigin-panels-builder',
+	'#siteorigin-panels-builder-row',
+	'#siteorigin-panels-builder-cell',
+	'#siteorigin-panels-builder-widget',
+	'#siteorigin-panels-context-menu',
+	'#siteorigin-panels-context-menu-section',
+	'#siteorigin-panels-directory-items',
+	'#siteorigin-panels-directory-enable',
+	'#siteorigin-panels-live-editor',
+	'#siteorigin-panels-add-layout-block-button',
 ];
 
 const sowbNormalizeAssetUrl = ( value, baseHref ) => {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -2292,9 +2292,11 @@ const sowbCloneTinyMCEExternalPluginAssets = ( $canvasBody, sourceDoc ) => {
 /**
  * Handles the first wave of cloned scripts reads at evaluation time.
  *
- * Each is waited on only when it cannot be cloned from the source document,
- * so under SCRIPT_DEBUG - where every handle emits with its own id - none of
- * them is ever waited on.
+ * Each is waited on only when it is neither live in the canvas window nor
+ * ours to clone from the source document. Under SCRIPT_DEBUG every handle
+ * emits with its own id, so most are clonable and never waited on - except
+ * while the canvas's own copy of a handle is still loading, since a handle
+ * the canvas already holds is not ours to clone.
  *
  * @type {string[]}
  */
@@ -2535,9 +2537,7 @@ const sowbEnsureCanvasBuilderFields = ( canvasWindow ) => {
  * The function performs the following steps:
  * 1. Resolves the current Site Editor iframe and confirms it is accessible.
  * 2. Copies elements specified in `sowbCanvasCloneElements` to the iframe's canvas body.
- * 3. Copies elements specified in `sowbCanvasRemoveElements` to the iframe's canvas body
- *    and removes the originals from the main document.
- * 4. Sets the `ajaxurl` variable in the iframe's `contentWindow` for AJAX requests if it
+ * 3. Sets the `ajaxurl` variable in the iframe's `contentWindow` for AJAX requests if it
  *    is not already defined.
  */
 const sowbMaybeSetupSiteEditorAssets = ( frame = null ) => {

--- a/compat/block-editor/widget-block.js
+++ b/compat/block-editor/widget-block.js
@@ -1911,6 +1911,14 @@ const sowbEnsureIframeOldEditorApi = ( frame ) => {
 		return;
 	}
 
+	// The retry script below is appended under the same permanent dedupe as
+	// the clone walk, so it must not land in a canvas that cannot evaluate
+	// it yet. The gate schedules its own retry, and the form setup that
+	// called this re-runs each tick, so deferring here self-heals.
+	if ( ! sowbCanvasIsReadyForAssetClone( frame, sowbGetEditorAssetSourceDocument() ) ) {
+		return;
+	}
+
 	if (
 		iframeWindow.sowbEditorJsRetryPending ||
 		(

--- a/tests/e2e/wb-canvas-asset-gate.test.js
+++ b/tests/e2e/wb-canvas-asset-gate.test.js
@@ -1,0 +1,281 @@
+/**
+ * Canvas asset gate: the clone walk waits for the canvas dependencies and
+ * never clones into a canvas that cannot evaluate what it is given.
+ *
+ * Both tests seed the post with a saved widget, then reload while
+ * intercepting the canvas iframe's load-scripts.php request - the
+ * concatenated bundle carrying jquery-core. One holds the bundle and
+ * requires a clean recovery; the other empties it and requires the gate's
+ * diagnostics with nothing cloned.
+ *
+ * Runs locally via `npm run tests` (#2329 tracks CI; #2361 tracks further
+ * coverage).
+ */
+const {
+	expect,
+	test
+} = require( '@playwright/test' );
+
+const common = require( 'siteorigin-tests-common/playwright/common' );
+
+const {
+	addBlock,
+	doLogin,
+	setupAdminE2E,
+	setupRequestUtils,
+} = common;
+
+// Not serial: each test builds its own post and route, and the dead-bundle
+// test must still report if the slow-bundle test fails.
+
+const CANVAS = 'iframe[name="editor-canvas"]';
+
+const TERMINAL_WARN = 'SiteOrigin Widgets: editor canvas finished loading without';
+const STALL_WARN = 'SiteOrigin Widgets: still waiting for the editor canvas';
+
+// The canvas body ships empty; every script with an id in it was appended by
+// the clone walk. Counting them is the walk detector - a named id would tie
+// the test to whichever handles this WordPress build concatenates.
+
+/**
+ * Whether a load-scripts.php request is the one delivering jquery-core.
+ *
+ * WordPress indexes the query keys (`load[chunk_0]=jquery-core,...`), so the
+ * values are collected from every `load`-prefixed param and split on commas.
+ */
+const isJqueryBundleRequest = ( requestUrl ) => {
+	const url = new URL( requestUrl );
+	const handles = [];
+
+	url.searchParams.forEach( ( value, key ) => {
+		if ( key === 'load' || key.indexOf( 'load[' ) === 0 ) {
+			handles.push( ...value.split( ',' ) );
+		}
+	} );
+
+	return handles.includes( 'jquery-core' );
+};
+
+/**
+ * Routes the canvas's jquery bundle through the given handler, leaving every
+ * other request untouched. Resolves `captured` when the request arrives.
+ */
+const routeCanvasJqueryBundle = async ( page, handler ) => {
+	const state = {
+		captures: 0,
+	};
+
+	state.captured = new Promise( ( resolve ) => {
+		state.onCapture = resolve;
+	} );
+
+	await page.route( '**/load-scripts.php*', async ( route ) => {
+		const request = route.request();
+		const frame = request.frame();
+
+		if (
+			frame === page.mainFrame() ||
+			frame.name() !== 'editor-canvas' ||
+			! isJqueryBundleRequest( request.url() )
+		) {
+			return route.fallback();
+		}
+
+		state.captures++;
+		state.onCapture();
+
+		return handler( route );
+	} );
+
+	return state;
+};
+
+const collectGateWarns = ( page ) => {
+	const warns = {
+		terminal: [],
+		stall: [],
+		referenceErrors: [],
+	};
+
+	page.on( 'console', ( message ) => {
+		const text = message.text();
+
+		if ( text.indexOf( TERMINAL_WARN ) !== -1 ) {
+			warns.terminal.push( text );
+		}
+
+		if ( text.indexOf( STALL_WARN ) !== -1 ) {
+			warns.stall.push( text );
+		}
+	} );
+
+	page.on( 'pageerror', ( error ) => {
+		if ( error.message.indexOf( 'ReferenceError' ) !== -1 ) {
+			warns.referenceErrors.push( error.message );
+		}
+	} );
+
+	return warns;
+};
+
+const readCanvasState = ( page ) => page.evaluate( ( args ) => {
+	const frame = document.querySelector( args.canvas );
+
+	if ( ! frame ) {
+		return { frame: false };
+	}
+
+	let out = {
+		frame: true,
+		timerLive: !! frame.sowbCanvasCloneWaitTimer,
+		waitState: !! frame.sowbCanvasCloneWait,
+	};
+
+	try {
+		const doc = frame.contentDocument;
+		const win = frame.contentWindow;
+
+		out.jQuery = !! win.jQuery;
+		out.readyState = doc.readyState;
+		out.bodyScripts = doc.body ? doc.body.querySelectorAll( 'script[id]' ).length : 0;
+		out.walkRan = out.bodyScripts > 0;
+		out.retryScript = !! doc.getElementById( 'sowb-editor-js-retry' );
+	} catch ( e ) {
+		out.err = e.name;
+	}
+
+	return out;
+}, { canvas: CANVAS } );
+
+test.beforeEach( async ( { page } ) => {
+	await doLogin( page );
+} );
+
+test( 'the walk waits out a slow canvas bundle and the builder still works', async ( { page } ) => {
+	const warns = collectGateWarns( page );
+
+	let releaseBundle;
+	const held = new Promise( ( resolve ) => {
+		releaseBundle = resolve;
+	} );
+
+	const requestUtils = await setupRequestUtils();
+	const post = await requestUtils.createPost( {
+		status: 'draft',
+		title: 'Canvas gate slow bundle',
+		content: '',
+	} );
+	const admin = await setupAdminE2E( page );
+
+	// First load, unrouted and healthy: put a saved widget into the post, so
+	// the reload below matches the reported shape - existing widget content
+	// whose setup paths ask for the canvas while its bundle is still loading.
+	await admin.editPost( post.id );
+	await page.locator( CANVAS ).waitFor( { state: 'attached', timeout: 20000 } );
+	await admin.editor.canvas.locator( 'body' ).waitFor( { state: 'visible', timeout: 20000 } );
+	await addBlock( admin, 'sowb/siteorigin-widget-features-widget' );
+	await admin.editor.saveDraft();
+
+	const route = await routeCanvasJqueryBundle( page, async ( routeHandle ) => {
+		// Held for seven seconds, then released.
+		await held;
+
+		return routeHandle.continue();
+	} );
+
+	const opening = admin.editPost( post.id ).catch( () => null );
+
+	await route.captured;
+
+	// Mid hold, with saved widget content present, the gate is being asked
+	// for the canvas while its bundle is still in flight. Nothing may be
+	// cloned into it through either door and no terminal diagnostic may fire.
+	await page.waitForTimeout( 7000 );
+
+	const midStall = await readCanvasState( page );
+
+	expect( midStall.frame ).toBe( true );
+	// Still loading proves the held bundle was the editor canvas's own - a
+	// held preview-iframe bundle would leave the canvas completing normally.
+	expect( midStall.readyState ).not.toBe( 'complete' );
+	expect( midStall.walkRan ).toBe( false );
+	expect( midStall.retryScript ).toBe( false );
+	expect( warns.terminal.length ).toBe( 0 );
+
+	releaseBundle();
+	await opening;
+	await page.locator( CANVAS ).waitFor( { state: 'attached', timeout: 20000 } );
+	await admin.editor.canvas.locator( 'body' ).waitFor( { state: 'visible', timeout: 20000 } );
+
+	await expect.poll( async () => ( await readCanvasState( page ) ).walkRan, {
+		timeout: 20000,
+	} ).toBe( true );
+
+	// Open Builder binds through soPanelsSetupBuilderWidget, so the canvas
+	// registration is what decides whether the button does anything. The full
+	// click path is covered by the form-field suite.
+	await expect.poll( () => page.evaluate( ( canvas ) => {
+		const win = document.querySelector( canvas ).contentWindow;
+
+		return !! ( win.jQuery && win.jQuery.fn && win.jQuery.fn.soPanelsSetupBuilderWidget );
+	}, CANVAS ), { timeout: 20000 } ).toBe( true );
+
+	expect( warns.terminal.length ).toBe( 0 );
+	// One stall diagnostic is allowed for a hold this long; more means the
+	// per-document latch is broken.
+	expect( warns.stall.length ).toBeLessThanOrEqual( 1 );
+	expect( warns.referenceErrors.length ).toBe( 0 );
+	expect( route.captures ).toBeGreaterThan( 0 );
+} );
+
+test( 'an emptied canvas bundle is diagnosed once and never cloned into', async ( { page } ) => {
+	const warns = collectGateWarns( page );
+
+	const requestUtils = await setupRequestUtils();
+	const post = await requestUtils.createPost( {
+		status: 'draft',
+		title: 'Canvas gate empty bundle',
+		content: '',
+	} );
+	const admin = await setupAdminE2E( page );
+
+	// Same seeding as above: the reload must carry saved widget content so
+	// the gate is exercised without any dependency on editor interaction.
+	await admin.editPost( post.id );
+	await page.locator( CANVAS ).waitFor( { state: 'attached', timeout: 20000 } );
+	await admin.editor.canvas.locator( 'body' ).waitFor( { state: 'visible', timeout: 20000 } );
+	await addBlock( admin, 'sowb/siteorigin-widget-features-widget' );
+	await admin.editor.saveDraft();
+
+	// The bundle request succeeds but delivers nothing, so the document
+	// completes with the dependencies genuinely absent.
+	const route = await routeCanvasJqueryBundle( page, ( routeHandle ) => {
+		return routeHandle.fulfill( {
+			status: 200,
+			contentType: 'application/javascript',
+			body: '/* emptied by the canvas asset gate test */',
+		} );
+	} );
+
+	const opening = admin.editPost( post.id ).catch( () => null );
+
+	await route.captured;
+	await opening;
+
+	// One terminal warn naming the handle. The window extends past the stall
+	// threshold, so the stall diagnostic must never appear alongside it.
+	await expect.poll( () => warns.terminal.length, { timeout: 20000 } ).toBe( 1 );
+	expect( warns.terminal[ 0 ] ).toContain( 'jquery-core-js' );
+
+	await page.waitForTimeout( 6000 );
+
+	expect( warns.terminal.length ).toBe( 1 );
+	expect( warns.stall.length ).toBe( 0 );
+
+	// Nothing entered the dependency-less canvas through either door.
+	const broken = await readCanvasState( page );
+
+	expect( broken.walkRan ).toBe( false );
+	expect( broken.retryScript ).toBe( false );
+	expect( route.captures ).toBeGreaterThan( 0 );
+} );


### PR DESCRIPTION
Fixes the Open Builder button doing nothing in the block editor. Closes #2341.

## What was wrong

The block editor renders in an iframe. Widgets Bundle clones the assets a widget form needs into that iframe by walking a hardcoded allowlist of element IDs, `sowbCanvasCloneElements`.

WordPress concatenates core scripts into `load-scripts.php?c=1`, and **those bundle elements carry no `id`** (`wp-includes/script-loader.php`). `jquery-core` is inside one, so `#jquery-core-js` does not exist in the admin document on a default install. The first entry in the allowlist has never matched anything and **jQuery has never once been cloned into the canvas.**

The canvas loads its own jQuery in its `<head>`, asynchronously, while the clone walk runs from a React `ref` that fires first. So every cloned script that needs jQuery evaluated against a window without it and threw — jQuery UI, iris, color-picker, wplink, the field scripts, and finally `siteorigin-panels.min.js`, which therefore never registered `jQuery.fn.soPanelsSetupBuilderWidget`. The button had nothing bound to it.

It presented as intermittent because it is a race against one large external fetch: a warm cache wins, a cold cache loses. Every new build changes `?ver=` and busts the cache, which is why it appeared to fail on every fresh install.

**With `SCRIPT_DEBUG` on there is no concatenation**, `#jquery-core-js` exists, the walk clones jQuery ahead of its dependants, and it works. That is how this shipped.

## The fix

Gate the clone walk until the canvas has evaluated the handles the walk cannot supply itself, deciding that **per handle at runtime** rather than assuming which ones WordPress bundles.

Waiting rather than retrying is deliberate: `sowbCloneElementToCanvas` dedupes by id against the whole canvas document, so a script appended too early can never be replaced. Retrying afterwards is a no-op unless failed nodes are removed first, and removing nodes is exactly the machinery this avoids.

The wait is bounded at 20 × 250 ms and then proceeds regardless, so the worst case is the behaviour that shipped before, five seconds later. State lives on the canvas window so every caller shares one budget, and the timer belongs to the canvas so teardown disposes of it.

A second commit covers a distinct race it exposed: `siteorigin-widget-admin` reaches the canvas through its `<head>` (WordPress enqueues it while collecting iframe assets) while `so-panels-admin` arrives only through the clone walk. A form can finish setting up in the window where `sowSetupForm` exists but `soPanelsSetupBuilderWidget` does not, and `base/js/admin.js` checks for it with a bare `if` and no retry — so those builder fields stayed dead with nothing in the console to explain it. Re-runs the setup once `so-panels-admin` has loaded. Fields Page Builder has already initialised are skipped, so an open dialog or unsaved edit is never touched.

## Verified

Cold cache, on the bug's own reproduction — logged out, logged back in, DevTools "Disable cache" on:

- No `ReferenceError: jQuery is not defined`
- `jQuery`, `Backbone`, `underscore` and `jQuery.ui` all live in the canvas
- `soPanelsSetupBuilderWidget` registered
- **Open Builder opens and the dialog renders with existing content intact**
- Gate engaged and resolved after one 250 ms tick (`sowbCanvasCloneWaitAttempts: 1`, `sowbCanvasCloneWaitTimer: 0`)

Canvas script count dropped 150 → 130, because the existing dedupe now runs its predicates at a point where they can answer truthfully and stops re-cloning handles the canvas already has.

Tested against Page Builder built from `fix/canvas-combined`.

## Not verified — please cover before merge

- **`SCRIPT_DEBUG` on.** The most important gap. `f40516bd` changed behaviour specifically in that configuration, and it is the configuration that currently works, so a regression would land there. Needs a `wp-config.php` edit.
- **Fail-open path** — block the canvas `load-scripts.php` request and confirm `sowbCanvasCloneWaitAttempts === 20`, `sowbCanvasCloneWaitTimer === 0`, no runaway timer.
- **Multiple widget blocks** — `sowbCanvasCloneWaitAttempts` must stay 1–3 and not scale with block count, which would mean callers are advancing the budget instead of ticks.
- **Site Editor**, and the older end of the supported WordPress range.

## Known and accepted

- **The wait budget does not reset after timeout.** A load whose canvas dependencies take longer than 5 s leaves the button dead for that canvas until the editor is reopened. Deliberate — recovery would require removing already-appended nodes. Rationale and the alternatives considered are recorded in [this comment on #2341](https://github.com/siteorigin/so-widgets-bundle/issues/2341#issuecomment-5226602860).
- **No regression tests.** The repo has no JS unit runner and the Playwright suite has not run since October 2025 (#2329). Verification here is manual and browser-based.
- **`.gitignore`** gains `docs/plans/` and `tasks/runs/` in the first commit. Unrelated to the fix — say the word and I will strip it.

## Follow-up

#2343 — the dialog now opens, which exposed that the canvas body lacks `wp-core-ui`, so WordPress's admin button styling cannot match inside it. Cosmetic, pre-existing, separate.

The first three commits are from `fix/editor-canvas-clean`, which adds Page Builder's handles to the allowlist and was never separately merged.
