### PR TITLE
Widget Blocks: Stop Stripping Saved Rich-Text Content for Logged-Out Visitors

### DIFF
--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -561,7 +561,14 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 			$value = wpautop( $value );
 		}
 
-		if ( current_user_can( 'unfiltered_html' ) ) {
+		// Widget block content is sanitized at save under the user who saved it.
+		// When rendering the block we keep the stored value as is — checking the
+		// current user here would apply the viewer's capability to it, stripping
+		// admin-authored markup (e.g. iframes) for logged out visitors.
+		if (
+			! empty( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] ) ||
+			current_user_can( 'unfiltered_html' )
+		) {
 			$sanitized_value = $value;
 		} else {
 			$sanitized_value = wp_kses_post( $value );

--- a/base/inc/fields/tinymce.class.php
+++ b/base/inc/fields/tinymce.class.php
@@ -565,8 +565,14 @@ class SiteOrigin_Widget_Field_TinyMCE extends SiteOrigin_Widget_Field_Text_Input
 		// When rendering the block we keep the stored value as is — checking the
 		// current user here would apply the viewer's capability to it, stripping
 		// admin-authored markup (e.g. iframes) for logged out visitors.
+		// wp_pre_kses_block_attributes() is the core save-time sanitizer that
+		// guarantee rests on; where a very old core lacks it, keep the old
+		// render-time behaviour.
 		if (
-			! empty( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] ) ||
+			(
+				! empty( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] ) &&
+				function_exists( 'wp_pre_kses_block_attributes' )
+			) ||
 			current_user_can( 'unfiltered_html' )
 		) {
 			$sanitized_value = $value;

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -672,73 +672,78 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		$instance = $block_content['widgetData'];
 		add_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
 
-		ob_start();
+		// The render flag skips render time sanitization of stored values, so it
+		// must never outlive this render — clean it up even if a widget throws.
+		try {
+			ob_start();
 
-		$always_render_widget_list = array(
-			'SiteOrigin_Widget_PostCarousel_Widget',
-			'SiteOrigin_Widgets_ContactForm_Widget',
-			'SiteOrigin_Widget_Blog_Widget',
-		);
+			$always_render_widget_list = array(
+				'SiteOrigin_Widget_PostCarousel_Widget',
+				'SiteOrigin_Widgets_ContactForm_Widget',
+				'SiteOrigin_Widget_Blog_Widget',
+			);
 
-		/*
-		* Generate widget markup if:
-		* - No pre-generated widgetMarkup exists.
-		* - widgetMarkup contains "No widget preview available".
-		* - POST data exists (widget settings likely changed).
-		* - Widget is in always_render_widget_list.
-		* - Widget excluded via siteorigin_widgets_block_exclude_widget filter.
-		* - Active WPML translation exists.
-		*/
-		if (
-			(
-				empty( $block_content['widgetMarkup'] ) ||
-				// Does widgetMarkup contain the string No widget preview available?
-				strpos( $block_content['widgetMarkup'], __( 'No widget preview available.', 'so-widgets-bundle' ) ) !== false
-			) ||
-			! empty( $_POST ) ||
-			in_array( $block_content['widgetClass'], $always_render_widget_list ) ||
-			apply_filters( 'siteorigin_widgets_block_exclude_widget', false, $block_content['widgetClass'], $instance ) ||
-			$this->wpml_render_check()
-		) {
-			// Add anchor to widget wrapper.
-			if ( ! empty( $block_content['anchor'] ) ) {
-				$this->widgetAnchor = $block_content['anchor'];
-				add_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10, 3 );
-			}
+			/*
+			* Generate widget markup if:
+			* - No pre-generated widgetMarkup exists.
+			* - widgetMarkup contains "No widget preview available".
+			* - POST data exists (widget settings likely changed).
+			* - Widget is in always_render_widget_list.
+			* - Widget excluded via siteorigin_widgets_block_exclude_widget filter.
+			* - Active WPML translation exists.
+			*/
+			if (
+				(
+					empty( $block_content['widgetMarkup'] ) ||
+					// Does widgetMarkup contain the string No widget preview available?
+					strpos( $block_content['widgetMarkup'], __( 'No widget preview available.', 'so-widgets-bundle' ) ) !== false
+				) ||
+				! empty( $_POST ) ||
+				in_array( $block_content['widgetClass'], $always_render_widget_list ) ||
+				apply_filters( 'siteorigin_widgets_block_exclude_widget', false, $block_content['widgetClass'], $instance ) ||
+				$this->wpml_render_check()
+			) {
+				// Add anchor to widget wrapper.
+				if ( ! empty( $block_content['anchor'] ) ) {
+					$this->widgetAnchor = $block_content['anchor'];
+					add_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10, 3 );
+				}
 
-			/* @var $widget SiteOrigin_Widget */
-			$instance = $widget->update( $instance, $instance );
-			$widget->widget( array(
-				'before_widget' => '',
-				'after_widget' => '',
-				'before_title' => '<h3 class="widget-title">',
-				'after_title' => '</h3>',
-			), $instance );
+				/* @var $widget SiteOrigin_Widget */
+				$instance = $widget->update( $instance, $instance );
+				$widget->widget( array(
+					'before_widget' => '',
+					'after_widget' => '',
+					'before_title' => '<h3 class="widget-title">',
+					'after_title' => '</h3>',
+				), $instance );
 
-			if ( ! empty( $block_content['anchor'] ) ) {
-				remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
-			}
-		} else {
-			$widget->generate_and_enqueue_instance_styles( $instance );
-			$widget->enqueue_frontend_scripts( $instance );
+				if ( ! empty( $block_content['anchor'] ) ) {
+					remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
+				}
+			} else {
+				$widget->generate_and_enqueue_instance_styles( $instance );
+				$widget->enqueue_frontend_scripts( $instance );
 
-			// Check if this widget uses any icons that need to be enqueued.
-			if ( ! empty( $block_content['widgetIcons'] ) ) {
-				$widget_icon_families = apply_filters( 'siteorigin_widgets_icon_families', array() );
+				// Check if this widget uses any icons that need to be enqueued.
+				if ( ! empty( $block_content['widgetIcons'] ) ) {
+					$widget_icon_families = apply_filters( 'siteorigin_widgets_icon_families', array() );
 
-				foreach ( $block_content['widgetIcons'] as $icon_font ) {
-					if ( ! wp_style_is( $icon_font ) ) {
-						$font_family = explode( 'siteorigin-widget-icon-font-', $icon_font )[1];
-						wp_enqueue_style( $icon_font, $widget_icon_families[ $font_family ]['style_uri'] );
+					foreach ( $block_content['widgetIcons'] as $icon_font ) {
+						if ( ! wp_style_is( $icon_font ) ) {
+							$font_family = explode( 'siteorigin-widget-icon-font-', $icon_font )[1];
+							wp_enqueue_style( $icon_font, $widget_icon_families[ $font_family ]['style_uri'] );
+						}
 					}
 				}
+				echo $block_content['widgetMarkup'];
 			}
-			echo $block_content['widgetMarkup'];
-		}
 
-		$rendered_widget = ob_get_clean();
-		remove_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
-		unset( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
+			$rendered_widget = ob_get_clean();
+		} finally {
+			remove_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
+			unset( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
+		}
 
 		return $rendered_widget;
 	}

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -668,6 +668,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			return $class_names;
 		};
 
+		$had_render_flag = ! empty( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
 		$GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] = true;
 		$instance = $block_content['widgetData'];
 		add_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
@@ -739,9 +740,13 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 			$rendered_widget = ob_get_clean();
 		} finally {
-			// On the success path ob_get_clean() already popped the buffer.
+			// On the success path ob_get_clean() already popped the buffer. A
+			// non removable buffer opened by widget code cannot be discarded —
+			// stop rather than loop on it.
 			while ( ob_get_level() > $ob_level ) {
-				ob_end_clean();
+				if ( ! @ob_end_clean() ) {
+					break;
+				}
 			}
 
 			if ( ! empty( $block_content['anchor'] ) ) {
@@ -750,7 +755,12 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 			}
 
 			remove_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
-			unset( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
+
+			// Restore rather than unset, so a nested render cannot clear the
+			// flag for a still active outer render.
+			if ( ! $had_render_flag ) {
+				unset( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
+			}
 		}
 
 		return $rendered_widget;

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -673,7 +673,9 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 		add_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
 
 		// The render flag skips render time sanitization of stored values, so it
-		// must never outlive this render — clean it up even if a widget throws.
+		// must never outlive this render — clean it up even if a widget throws,
+		// along with every other resource this render acquires.
+		$ob_level = ob_get_level();
 		try {
 			ob_start();
 
@@ -717,10 +719,6 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 					'before_title' => '<h3 class="widget-title">',
 					'after_title' => '</h3>',
 				), $instance );
-
-				if ( ! empty( $block_content['anchor'] ) ) {
-					remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
-				}
 			} else {
 				$widget->generate_and_enqueue_instance_styles( $instance );
 				$widget->enqueue_frontend_scripts( $instance );
@@ -741,6 +739,16 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 			$rendered_widget = ob_get_clean();
 		} finally {
+			// On the success path ob_get_clean() already popped the buffer.
+			while ( ob_get_level() > $ob_level ) {
+				ob_end_clean();
+			}
+
+			if ( ! empty( $block_content['anchor'] ) ) {
+				remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
+				$this->widgetAnchor = null;
+			}
+
 			remove_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );
 			unset( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] );
 		}

--- a/compat/block-editor/widget-block.php
+++ b/compat/block-editor/widget-block.php
@@ -675,8 +675,12 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 
 		// The render flag skips render time sanitization of stored values, so it
 		// must never outlive this render — clean it up even if a widget throws,
-		// along with every other resource this render acquires.
-		$ob_level = ob_get_level();
+		// along with every other resource this render acquires. Track the anchor
+		// filter and prior anchor so a nested render of the same widget does not
+		// tear down an outer render's wrapper id.
+		$ob_level            = ob_get_level();
+		$anchor_filter_added = false;
+		$prev_widget_anchor  = $this->widgetAnchor;
 		try {
 			ob_start();
 
@@ -710,6 +714,7 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				if ( ! empty( $block_content['anchor'] ) ) {
 					$this->widgetAnchor = $block_content['anchor'];
 					add_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10, 3 );
+					$anchor_filter_added = true;
 				}
 
 				/* @var $widget SiteOrigin_Widget */
@@ -749,9 +754,12 @@ class SiteOrigin_Widgets_Bundle_Widget_Block {
 				}
 			}
 
-			if ( ! empty( $block_content['anchor'] ) ) {
+			// Only tear down the anchor filter this invocation added, and put the
+			// anchor back to what it was, so a nested render cannot strip an
+			// outer render's wrapper id.
+			if ( $anchor_filter_added ) {
 				remove_filter( 'siteorigin_widgets_wrapper_id_' . $widget->id_base, array( $this, 'add_widget_id' ), 10 );
-				$this->widgetAnchor = null;
+				$this->widgetAnchor = $prev_widget_anchor;
 			}
 
 			remove_filter( 'siteorigin_widgets_wrapper_classes_' . $widget->id_base, $add_custom_class_name );

--- a/tests/e2e/wb-widget-block-render-capability.test.js
+++ b/tests/e2e/wb-widget-block-render-capability.test.js
@@ -9,6 +9,17 @@ const {
 	setupRequestUtils,
 } = common;
 
+// Join a REST path to WP_BASE_URL for the raw fetch() calls that carry their
+// own auth. Normalizing the base to end in a slash keeps this correct for both
+// a root install (CI default, no trailing slash) and a subdirectory install.
+const restUrl = ( relativePath ) => {
+	const base = process.env.WP_BASE_URL.endsWith( '/' )
+		? process.env.WP_BASE_URL
+		: `${ process.env.WP_BASE_URL }/`;
+
+	return new URL( relativePath, base ).toString();
+};
+
 // Mirror serialize_block_attributes() so seeded content matches what the
 // block editor stores. Quotes stay as JSON escapes; none of these can
 // produce the comment terminator.
@@ -110,7 +121,7 @@ test(
 				params: { name: 'wbcap-e2e' },
 			} );
 
-			const response = await fetch( `${ process.env.WP_BASE_URL }/wp-json/wp/v2/posts`, {
+			const response = await fetch( restUrl( 'wp-json/wp/v2/posts' ), {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
@@ -191,7 +202,7 @@ test(
 			).toString( 'base64' );
 
 			const response = await fetch(
-				`${ process.env.WP_BASE_URL }wp-json/wp/v2/block-renderer/sowb/siteorigin-widget-editor-widget?context=edit`,
+				restUrl( 'wp-json/wp/v2/block-renderer/sowb/siteorigin-widget-editor-widget?context=edit' ),
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json', Authorization: auth },
@@ -209,8 +220,15 @@ test(
 			);
 
 			// Schema validation rejects the unsaved attributes; render never runs.
+			// Pin the actual boundary: the widgetData/widgetClass properties are
+			// refused because they are not registered server side.
 			expect( response.status ).toBe( 400 );
 			const body = await response.json();
+			expect( body.code ).toBe( 'rest_invalid_param' );
+			expect( body.data?.params?.attributes ).toMatch( /widgetClass/ );
+			expect( body.data?.details?.attributes?.code ).toBe(
+				'rest_additional_properties_forbidden'
+			);
 			expect( JSON.stringify( body ) ).not.toContain( '<script>alert(1)' );
 		} finally {
 			if ( author ) {

--- a/tests/e2e/wb-widget-block-render-capability.test.js
+++ b/tests/e2e/wb-widget-block-render-capability.test.js
@@ -62,12 +62,16 @@ test(
 
 			// The REST save pre-renders widgetMarkup, so the GET above serves the
 			// stored markup. A POST forces the live render path — the one that
-			// re-sanitized stored values with the viewer's capability.
+			// re-sanitized stored values with the viewer's capability. Assert an
+			// actual iframe element, not just the string, so escaped output such
+			// as &lt;iframe cannot pass.
 			const slowPath = await anonContext.request.post( post.link, {
 				form: { wb_render_capability_probe: '1' },
 			} );
 			const slowPathHtml = await slowPath.text();
-			expect( slowPathHtml ).toContain( 'iframe src="https://example.com/frame"' );
+			expect( slowPathHtml ).toMatch(
+				/<iframe[^>]*\ssrc="https:\/\/example\.com\/frame"/
+			);
 
 			await anonContext.close();
 		} finally {
@@ -142,6 +146,73 @@ test(
 				} ).catch( () => {} );
 			}
 
+			if ( author ) {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/users/${ author.id }`,
+					params: { force: true, reassign: 1 },
+				} ).catch( () => {} );
+			}
+		}
+	}
+);
+
+test(
+	'Block renderer preview cannot supply unsaved widgetData to the render path.',
+	async () => {
+		// render_widget_block() sets the render flag that skips sanitization, so
+		// any render caller that carries unsaved request attributes must not
+		// reach it. The block does not register widgetData/widgetClass server
+		// side, so the core block-renderer schema rejects them before render.
+		const requestUtils = await setupRequestUtils();
+		const suffix = Date.now();
+		let author = null;
+
+		try {
+			author = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/users',
+				params: {
+					username: `wbcap-prev-${ suffix }`,
+					email: `wbcap-prev-${ suffix }@example.com`,
+					password: `wbcap-prev-${ suffix }!A1`,
+					roles: [ 'author' ],
+				},
+			} );
+
+			const appPassword = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/users/${ author.id }/application-passwords`,
+				params: { name: 'wbcap-preview-e2e' },
+			} );
+
+			const auth = 'Basic ' + Buffer.from(
+				`${ author.username }:${ appPassword.password }`
+			).toString( 'base64' );
+
+			const response = await fetch(
+				`${ process.env.WP_BASE_URL }wp-json/wp/v2/block-renderer/sowb/siteorigin-widget-editor-widget?context=edit`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json', Authorization: auth },
+					body: JSON.stringify( {
+						attributes: {
+							widgetClass: 'SiteOrigin_Widget_Editor_Widget',
+							widgetData: {
+								text: '<script>alert(1)</script>',
+								text_selected_editor: 'tinymce',
+								autop: false,
+							},
+						},
+					} ),
+				}
+			);
+
+			// Schema validation rejects the unsaved attributes; render never runs.
+			expect( response.status ).toBe( 400 );
+			const body = await response.json();
+			expect( JSON.stringify( body ) ).not.toContain( '<script>alert(1)' );
+		} finally {
 			if ( author ) {
 				await requestUtils.rest( {
 					method: 'DELETE',

--- a/tests/e2e/wb-widget-block-render-capability.test.js
+++ b/tests/e2e/wb-widget-block-render-capability.test.js
@@ -1,0 +1,154 @@
+const {
+	expect,
+	test
+} = require( '@playwright/test' );
+
+const common = require( 'siteorigin-tests-common/playwright/common' );
+
+const {
+	setupRequestUtils,
+} = common;
+
+// Mirror serialize_block_attributes() so seeded content matches what the
+// block editor stores. Quotes stay as JSON escapes; none of these can
+// produce the comment terminator.
+const escapeBlockAttrs = ( attrs ) => JSON.stringify( attrs )
+	.replace( /--/g, '\\u002d\\u002d' )
+	.replace( /</g, '\\u003c' )
+	.replace( />/g, '\\u003e' )
+	.replace( /&/g, '\\u0026' );
+
+const editorWidgetBlock = ( text ) => `<!-- wp:sowb/siteorigin-widget-editor-widget ${ escapeBlockAttrs( {
+	widgetClass: 'SiteOrigin_Widget_Editor_Widget',
+	widgetData: {
+		title: '',
+		text,
+		autop: false,
+		text_selected_editor: 'tinymce',
+	},
+} ) } /-->`;
+
+test(
+	'Editor widget block keeps an admin authored iframe for logged out visitors.',
+	async ( { browser } ) => {
+		const requestUtils = await setupRequestUtils();
+		const post = await requestUtils.createPost( {
+			status: 'publish',
+			title: 'WB render capability - admin iframe',
+			content: editorWidgetBlock(
+				'<p>before</p><iframe src="https://example.com/frame" width="400" height="200"></iframe><p>after</p>'
+			),
+		} );
+
+		try {
+			// The saving admin has unfiltered_html, so the iframe must reach storage.
+			const saved = await requestUtils.rest( {
+				method: 'GET',
+				path: `/wp/v2/posts/${ post.id }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.content.raw ).toContain( 'example.com/frame' );
+
+			// A fresh context has no auth cookies — this is a logged out visitor.
+			const anonContext = await browser.newContext();
+			const anonPage = await anonContext.newPage();
+			await anonPage.goto( post.link );
+
+			const widget = anonPage.locator( '.siteorigin-widget-tinymce' );
+			await expect( widget ).toContainText( 'before' );
+			await expect(
+				widget.locator( 'iframe[src="https://example.com/frame"]' )
+			).toHaveCount( 1 );
+
+			// The REST save pre-renders widgetMarkup, so the GET above serves the
+			// stored markup. A POST forces the live render path — the one that
+			// re-sanitized stored values with the viewer's capability.
+			const slowPath = await anonContext.request.post( post.link, {
+				form: { wb_render_capability_probe: '1' },
+			} );
+			const slowPathHtml = await slowPath.text();
+			expect( slowPathHtml ).toContain( 'iframe src="https://example.com/frame"' );
+
+			await anonContext.close();
+		} finally {
+			await requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/posts/${ post.id }`,
+				params: { force: true },
+			} ).catch( () => {} );
+		}
+	}
+);
+
+test(
+	'Editor widget block content from a user without unfiltered_html is sanitized at save.',
+	async () => {
+		const requestUtils = await setupRequestUtils();
+		const suffix = Date.now();
+		let author = null;
+		let postId = null;
+
+		try {
+			author = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/users',
+				params: {
+					username: `wbcap-author-${ suffix }`,
+					email: `wbcap-author-${ suffix }@example.com`,
+					password: `wbcap-pass-${ suffix }!A1`,
+					roles: [ 'author' ],
+				},
+			} );
+
+			const appPassword = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/users/${ author.id }/application-passwords`,
+				params: { name: 'wbcap-e2e' },
+			} );
+
+			const response = await fetch( `${ process.env.WP_BASE_URL }/wp-json/wp/v2/posts`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: 'Basic ' + Buffer.from(
+						`${ author.username }:${ appPassword.password }`
+					).toString( 'base64' ),
+				},
+				body: JSON.stringify( {
+					status: 'draft',
+					title: 'WB render capability - author save',
+					content: editorWidgetBlock(
+						'<p>keep</p><script>alert(1)</script><iframe src="https://example.com/frame"></iframe>'
+					),
+				} ),
+			} );
+			expect( response.status ).toBe( 201 );
+
+			const saved = await response.json();
+			postId = saved.id;
+
+			// Core kses runs at save under the saving user: tags are stripped
+			// from the decoded attributes, inner text survives.
+			expect( saved.content.raw ).toContain( 'keep' );
+			expect( saved.content.raw ).toContain( 'alert(1)' );
+			expect( saved.content.raw ).not.toContain( 'example.com/frame' );
+			expect( saved.content.raw ).not.toMatch( /script/ );
+		} finally {
+			if ( postId ) {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/posts/${ postId }`,
+					params: { force: true },
+				} ).catch( () => {} );
+			}
+
+			if ( author ) {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/users/${ author.id }`,
+					params: { force: true, reassign: 1 },
+				} ).catch( () => {} );
+			}
+		}
+	}
+);


### PR DESCRIPTION
> ### 🧪 Ready-to-test build — install this
> **[so-widgets-bundle.1.75.0-pr2344-2345.zip](https://siteorigin.com/wp-content/uploads/2026/08/so-widgets-bundle.1.75.0-pr2344-2345.zip)**
>
> This is **this PR combined with #2344** (the Open Builder jQuery-gate fix), so the block-editor builder works while you test. Install this zip to check that admin-authored iframes/rich text render for logged-out visitors — no local build needed.

---

Fixes a SiteOrigin widget block rendering an admin-authored `<iframe>` (or any rich HTML) to a logged-in admin but stripping it for logged-out visitors.

## What was wrong

`render_widget_block()` re-runs `$widget->update( $instance, $instance )` on every slow-path render (`compat/block-editor/widget-block.php`). Inside it, the TinyMCE field sanitizer branches on the **viewer's** capability:

```php
// base/inc/fields/tinymce.class.php
if ( current_user_can( 'unfiltered_html' ) ) { /* keep */ }
else { $sanitized_value = wp_kses_post( $value ); } // strip
```

`current_user_can()` asks about whoever is *viewing* the page. A logged-out visitor never has `unfiltered_html`, so the iframe an admin saved is stripped on every public view — while the admin still sees it. Every styled widget takes this slow path (its preview `widgetMarkup` is blanked at save because it carries inline `<style>`), so the re-sanitize runs on essentially every front-end render.

This affects **every bundled widget with a rich-text (TinyMCE) field**, not just the Editor widget: Editor, Tabs, Accordion, Features, Testimonials, Anything Carousel, Hero, Contact Form, Google Map — and TinyMCE content nested inside a Layout Slider.

## Why it is safe to stop re-sanitizing at render

Widget block attributes are already sanitized **at save, under the saving user**. Since WordPress 5.3.1, `content_save_pre` → `wp_filter_post_kses` → `pre_kses` → `wp_pre_kses_block_attributes` → `filter_block_content()` recurses the decoded block attributes and `wp_kses()`-es every string for users without `unfiltered_html`. So a low-privileged author's `<script>`/`<iframe>` is stripped when they save; an admin's is intentionally kept. Re-sanitizing at render with the *viewer's* capability is a redundant second pass keyed to the wrong user — the bug.

## The change

The TinyMCE sanitizer keeps the stored value when we are rendering a widget block on a core that has the save-time sanitizer:

```php
if (
    ( ! empty( $GLOBALS['SITEORIGIN_WIDGET_BLOCK_RENDER'] ) && function_exists( 'wp_pre_kses_block_attributes' ) )
    || current_user_can( 'unfiltered_html' )
) {
    $sanitized_value = $value;
} else {
    $sanitized_value = wp_kses_post( $value );
}
```

`render_widget_block()` already sets `SITEORIGIN_WIDGET_BLOCK_RENDER` for the render; the `function_exists()` guard means a pre-5.3.1 core (which lacks the save-time block-attribute sanitizer) keeps the old render-time behaviour. Save paths and editor previews never set the flag, so their capability semantics are unchanged. All of `update()`'s non-security work (measurement combining, colour shaping, URL escaping, unknown-key stripping) still runs at render, so there is no styling or shape change.

Supporting hardening in `render_widget_block()`, since the flag now controls sanitization:

- The render flag, wrapper filters, widget anchor and output buffer are cleaned up in a `finally`, so a widget that throws mid-render cannot leave the flag set for the rest of the request.
- The flag is restored (not blindly unset) so a nested widget-block render cannot clear it for a still-active outer render.
- The anchor filter teardown is scoped to the render that added it.

## Scope notes

- **Nested Layout Slider content is covered**: a known widget nested in a slider is re-sanitized through its own `update()`, which now honours the flag. (A nested widget whose class does not resolve still hits Page Builder's own kses fallback — pre-existing, unrelated, out of scope here.)
- Independent of the Open Builder canvas fix (#2341 / PR for `widget-block.js`); they touch disjoint files and were tested together on a combined build.
- Existing content needs no migration or re-save — it was sanitized by core at its original save and renders as stored.

## Tests

Adds `tests/e2e/wb-widget-block-render-capability.test.js`:
- An admin-authored iframe in an Editor widget block renders for a logged-out visitor (asserted on a real `<iframe>` element on the live render path, forced via POST since REST saves pre-render markup).
- Content saved by a user without `unfiltered_html` is stripped at save.
- The block-renderer preview endpoint rejects unsaved `widgetData` (schema), so request-supplied attributes cannot reach the render path.

Mutation-tested: reverting the field change makes the render test fail; restored, it passes.

## Manual verification

On WordPress 7.0.3, before/after on the same pages: an Editor widget iframe and a Layout-Slider-nested Editor iframe are stripped for logged-out visitors before, present after; an author without `unfiltered_html` still has script/iframe stripped at save; button/measurement styling is byte-identical before and after.

