### PR TITLE
Beaver Builder: Fall Back to a Native Color Input for Color Fields

### DIFF
--- a/base/js/admin.js
+++ b/base/js/admin.js
@@ -368,6 +368,21 @@ var sowbForms = window.sowbForms || {};
 			// Set up any color fields.
 			$fields.find( '> .siteorigin-widget-input-color' ).each( function() {
 				var $colorField = $( this );
+
+				// Without the WP color picker (e.g. inside Beaver Builder), fall
+				// back to a native color input. Native color inputs only accept
+				// #rrggbb and coerce anything else — an empty value, shorthand
+				// #rgb, or an rgba() alpha value — to #000000, which Beaver
+				// Builder would then save over the stored value. So only upgrade
+				// fields already holding a full hex colour, and leave the rest as
+				// plain text inputs so their value is preserved.
+				if ( typeof $.fn.wpColorPicker !== 'function' ) {
+					if ( /^#[0-9a-f]{6}$/i.test( $colorField.val() ) ) {
+						$colorField.attr( 'type', 'color' );
+					}
+					return;
+				}
+
 				var colorResult = ''
 				var alphaImage = '';
 
@@ -400,11 +415,9 @@ var sowbForms = window.sowbForms || {};
 					$colorFieldOptions.palettes = $colorField.data( 'palettes' );
 				}
 
-				if ( typeof $.fn.wpColorPicker === 'function' ) {
-					$colorField.wpColorPicker( $colorFieldOptions );
-					if ( $colorField.data( 'alpha-enabled' ) ) {
-						$colorField.on( 'change', handleAlphaDefault ).trigger( 'change' );
-					}
+				$colorField.wpColorPicker( $colorFieldOptions );
+				if ( $colorField.data( 'alpha-enabled' ) ) {
+					$colorField.on( 'change', handleAlphaDefault ).trigger( 'change' );
 				}
 			} );
 

--- a/compat/beaver-builder/styles.less
+++ b/compat/beaver-builder/styles.less
@@ -42,6 +42,26 @@
 
 		input.siteorigin-widget-input-color {
 			height: inherit !important;
+
+			// Only the native color input becomes a swatch. Values the JS guard
+			// leaves as a plain text input (empty, shorthand #rgb, rgba()) keep
+			// the normal text-field styling so they stay readable and editable.
+			&[type="color"] {
+				border: none;
+				height: 20px !important;
+				padding: 0;
+				width: 40px;
+
+				&::-moz-color-swatch-wrapper,
+				&::-webkit-color-swatch-wrapper {
+					padding: 0;
+				}
+
+				&::-moz-color-swatch,
+				&::-webkit-color-swatch {
+					border: none;
+				}
+			}
 		}
 
 		input.siteorigin-widget-input-measurement {


### PR DESCRIPTION
## Problem

Inside the Beaver Builder editor, `wp.wpColorPicker` (WordPress' Iris color picker) is not loaded, so SiteOrigin widget color fields fell back to a plain text input showing a raw value like `#e2401c`. Poor UX.

This reimplements the idea from #1841 fresh on current `develop` (that PR had gone stale/conflicting since 2023).

## Fix

When the WP color picker is unavailable, upgrade the field to a native `<input type="color">` swatch — but **only when it already holds a full `#rrggbb` hex value**.

Native color inputs accept only `#rrggbb` and silently coerce anything else — an empty value, shorthand `#rgb`, or an `rgba(...)` alpha value — to `#000000`. Beaver Builder reads the live input value on save, so an unconditional conversion would overwrite those stored values just by saving the widget. The `/^#[0-9a-f]{6}$/i` guard leaves every non-hex value as a normal, editable text input, exactly as before.

`compat/beaver-builder/styles.less` styles the swatch, scoped to `[type="color"]` so the text-fallback fields keep their normal text-input appearance.

## Verification

Confirmed live in the Beaver Builder editor (where `jQuery.fn.wpColorPicker` is `undefined`):

| starting value | result |
|---|---|
| `#e2401c` | native color swatch, value preserved |
| `""` (empty) | text input, preserved |
| `#fff` (shorthand) | text input, preserved |
| `rgba(226,64,28,0.5)` (alpha) | text input, preserved — no alpha loss |

## Notes

Supersedes #1841.
