### PR TITLE
Editor: Honour Page Builder's Keep-Shortcodes Opt-Out During the Post Content Render

### DIFF
--- a/tests/EditorWidgetShortcodeTest.php
+++ b/tests/EditorWidgetShortcodeTest.php
@@ -106,4 +106,45 @@ class EditorWidgetShortcodeTest extends SiteOriginTests {
 
 		$this->assertSame( 'Intro text [ninja_forms id=1]', $variables['text'] );
 	}
+
+	// Page Builder's opt-out filter returns false for a site that wants baked
+	// shortcode output in its post content copy; every other tag passes through.
+	private function opt_out_of_keeping_shortcodes(): void {
+		Functions\when( 'apply_filters' )->alias(
+			fn( $tag, $value ) => $tag === 'siteorigin_panels_post_content_keep_shortcodes' ? false : $value
+		);
+	}
+
+	public function test_keep_shortcodes_opt_out_executes_shortcodes_in_post_content_render() {
+		$GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] = true;
+		$this->opt_out_of_keeping_shortcodes();
+
+		Functions\when( 'shortcode_unautop' )->alias(
+			fn( $text ) => 'unautop(' . $text . ')'
+		);
+		Functions\expect( 'do_shortcode' )
+			->once()
+			->with( 'unautop(Intro text [ninja_forms id=1])' )
+			->andReturn( 'Intro text <div class="rendered-form"></div>' );
+		// The opt-out re-enables shortcodes only; the rest of the front-end
+		// pipeline still stays off during the post content render.
+		Functions\expect( 'wpautop' )->never();
+
+		$instance = array_merge( $this->instance(), array( 'autop' => true ) );
+		$variables = $this->widget()->get_template_variables( $instance, array() );
+
+		$this->assertSame( 'Intro text <div class="rendered-form"></div>', $variables['text'] );
+	}
+
+	public function test_keep_shortcodes_opt_out_does_not_affect_legacy_cache_render() {
+		$GLOBALS['SITEORIGIN_PANELS_CACHE_RENDER'] = true;
+		$this->opt_out_of_keeping_shortcodes();
+
+		Functions\expect( 'do_shortcode' )->never();
+		Functions\expect( 'shortcode_unautop' )->never();
+
+		$variables = $this->widget()->get_template_variables( $this->instance(), array() );
+
+		$this->assertSame( 'Intro text [ninja_forms id=1]', $variables['text'] );
+	}
 }

--- a/widgets/editor/editor.php
+++ b/widgets/editor/editor.php
@@ -124,7 +124,18 @@ class SiteOrigin_Widget_Editor_Widget extends SiteOrigin_Widget {
 			// shown, and plugins that check post_content with has_shortcode() to
 			// decide whether to enqueue their assets no longer find their shortcode.
 			// Keeping the shortcode intact lets it render normally, through
-			// the_content, when the copied content is displayed.
+			// the_content, when the copied content is displayed. A site can opt
+			// back into baked output through Page Builder's
+			// `siteorigin_panels_post_content_keep_shortcodes` filter, handled below.
+			$instance['text'] = do_shortcode( shortcode_unautop( $instance['text'] ) );
+		} elseif (
+			// Page Builder consults this filter before its post content render and
+			// executes shortcodes itself when it returns false. Follow the same
+			// decision so both plugins agree on what the mirror contains. The
+			// legacy cache render has no such switch and always keeps shortcodes.
+			empty( $GLOBALS[ 'SITEORIGIN_PANELS_CACHE_RENDER' ] ) &&
+			! (bool) apply_filters( 'siteorigin_panels_post_content_keep_shortcodes', true )
+		) {
 			$instance['text'] = do_shortcode( shortcode_unautop( $instance['text'] ) );
 		}
 


### PR DESCRIPTION
Fixes #2365.

The Editor widget now consults Page Builder's `siteorigin_panels_post_content_keep_shortcodes` filter during the post content render. When a site returns false to opt back into baked output, the widget runs `do_shortcode()` on the raw text, matching what it produced before #2364 and matching the core Text widget under Page Builder's own opt-out. The legacy cache render keeps shortcodes unconditionally, as before.

**Held as a draft.** The filter is introduced by siteorigin/siteorigin-panels#1373, open for review (the original #1372 was reverted on develop). Without it the tag is unfiltered and this branch changes nothing. Merge only if #1373 lands.

Tests: two cases in `EditorWidgetShortcodeTest`, red against develop, full suite green. Verified live through a classic editor save with the opt-out on (baked) and off (raw), and a logged-out front end render.

